### PR TITLE
Add FreeBSD support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,11 @@ option(ENABLE_PROFILING "Enable detailed profiling metrics")
 #
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-	add_definitions(-DRW_LINUX=1)
+	add_definitions(-DRW_LINUX)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-	add_definitions(-DRW_OSX=1)
+	add_definitions(-DRW_OSX)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+	add_definitions(-DRW_FREEBSD)
 else ()
 	message(FATAL_ERROR "Unknown platform \"${CMAKE_SYSTEM_NAME}\". please update CMakeLists.txt.")
 endif ()

--- a/rwgame/GameConfig.cpp
+++ b/rwgame/GameConfig.cpp
@@ -43,7 +43,7 @@ bool GameConfig::isValid()
 
 std::string GameConfig::getDefaultConfigPath()
 {
-#if RW_LINUX
+#if defined(RW_LINUX) || defined(RW_FREEBSD)
 	char* config_home = getenv("XDG_CONFIG_HOME");
 	if (config_home != nullptr) {
 		return std::string(config_home) + "/" + kConfigDirectoryName;
@@ -53,7 +53,7 @@ std::string GameConfig::getDefaultConfigPath()
 		return std::string(home) + "/.config/" + kConfigDirectoryName;
 	}
 
-#elif RW_OSX
+#elif defined(RW_OSX)
 	char* home = getenv("HOME");
 	if (home)
 		return std::string(home) + "/Library/Preferences/" + kConfigDirectoryName;


### PR DESCRIPTION
For now, there's only single OS-dependent bit of code, it it should be handled on FreeBSD just like on Linux. While here, change macro testing from #if XXX to #if defined(XXX), this is clener and not prone to
"undefined macro" errors