### PR TITLE
Use inih as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/inih"]
+	path = external/inih
+	url = https://github.com/benhoyt/inih.git

--- a/cmake/external/inih.cmake
+++ b/cmake/external/inih.cmake
@@ -1,22 +1,11 @@
 ###### External Project: inih
 include(ExternalProject)
 
-SET(INIH_REPOSITORY https://github.com/benhoyt/inih.git)
-SET(INIH_PREFIX_DIR ${EXTERNAL_PREFIX}/inih)
-
-ExternalProject_Add(inih-repository
-	PREFIX ${INIH_PREFIX_DIR}
-	# Do nothing, we just need the files.
-	CONFIGURE_COMMAND ""
-	BUILD_COMMAND ""
-	INSTALL_COMMAND ""
-	GIT_REPOSITORY ${INIH_REPOSITORY})
+SET(INIH_PREFIX_DIR ${PROJECT_SOURCE_DIR}/external/inih)
 
 SET(INIH_SOURCES
-	${INIH_PREFIX_DIR}/src/inih-repository/ini.c)
-set_source_files_properties(${INIH_SOURCES} PROPERTIES GENERATED TRUE)
+	${INIH_PREFIX_DIR}/ini.c)
 add_library(inih
 	${INIH_SOURCES})
 
-add_dependencies(inih inih-repository)
-target_include_directories(inih INTERFACE SYSTEM ${INIH_PREFIX_DIR}/src/inih-repository/)
+target_include_directories(inih INTERFACE SYSTEM ${INIH_PREFIX_DIR})


### PR DESCRIPTION
ExternalProject use is discouraged.
- Most package build systems do not allow any fetching on
  configure/build stage
- It's insecure the way it's used now, as it does not specify commit
  hash, so it may fetch whatever malicous code and it'll come
  unoticed