### PR TITLE
Debug features: "Jump to Debug Camera" and "Flip Vehicle"

### DIFF
--- a/rwgame/debugstate.cpp
+++ b/rwgame/debugstate.cpp
@@ -130,6 +130,15 @@ DebugState::DebugState(RWGame* game, const glm::vec3& vp, const glm::quat& vd)
 		game->getRenderer()->setCullOverride(true, _debugCam);
 	}, entryHeight));
 
+	// Optional block if the player is in a vehicle
+	auto player = game->getPlayer()->getCharacter();
+	auto cv = player->getCurrentVehicle();
+	if(cv) {
+		m->addEntry(Menu::lambda("Flip vehicle", [=] {
+			cv->setRotation(cv->getRotation() * glm::quat(glm::vec3(0.f, glm::pi<float>(), 0.f)));
+		}, entryHeight));
+	}
+
 	this->enterMenu(m);
 
 	_debugCam.position = vp;

--- a/rwgame/debugstate.cpp
+++ b/rwgame/debugstate.cpp
@@ -8,18 +8,21 @@
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtx/string_cast.hpp>
 
-void jumpCharacter(RWGame* game, CharacterObject* player, const glm::vec3& target)
+static void jumpCharacter(RWGame* game, CharacterObject* player, const glm::vec3& target, bool ground = true)
 {
-	glm::vec3 ground = game->getWorld()->getGroundAtPosition(target);
+	glm::vec3 newPosition = target;
+	if (ground) {
+		newPosition = game->getWorld()->getGroundAtPosition(newPosition) + glm::vec3(0.f, 0.f, 1.f);
+	}
 	if( player )
 	{
 		if( player->getCurrentVehicle() )
 		{
-			player->getCurrentVehicle()->setPosition(ground + glm::vec3(0.f, 0.f, 1.f));
+			player->getCurrentVehicle()->setPosition(newPosition);
 		}
 		else
 		{
-			player->setPosition(ground + glm::vec3(0.f, 0.f, 1.f));
+			player->setPosition(newPosition);
 		}
 	}
 }
@@ -84,6 +87,9 @@ DebugState::DebugState(RWGame* game, const glm::vec3& vp, const glm::quat& vd)
 	}, entryHeight));
 	m->addEntry(Menu::lambda("Quickload", [=] {
 		game->loadGame("quicksave");
+	}, entryHeight));
+	m->addEntry(Menu::lambda("Jump to Debug Camera", [=] {
+		jumpCharacter(game, game->getPlayer()->getCharacter(), _debugCam.position + _debugCam.rotation * glm::vec3(3.f, 0.f, 0.f), false);
 	}, entryHeight));
 	m->addEntry(Menu::lambda("Jump to Garage", [=] {
 		jumpCharacter(game, game->getPlayer()->getCharacter(), glm::vec3(270.f, -605.f, 40.f));


### PR DESCRIPTION
This makes testing easier (hopefully).

- "Jump to Debug Camera" places the player in front of the debug camera. Useful if you want to get somewhere fast.
I had to rework some of the JumpCharacter function to make this possible.
- "Flip Vehicle" (only shown while in a vehicle) will flip the vehicle upside down, however, it currently keeps its spin and velocity. It's still good enough to avoid mission failure.