### PR TITLE
Enable / Disable depth writing

### DIFF
--- a/rwengine/include/data/ObjectData.hpp
+++ b/rwengine/include/data/ObjectData.hpp
@@ -52,23 +52,15 @@ struct ObjectData : public ObjectInformation
 	
 	short timeOn;
 	short timeOff;
-	
+
 	enum {
-		WET          = 1,       /// Render with a wet effect
-		NIGHTONLY    = 1 << 1,  /// Render only during the night
-		ALPHA1       = 1 << 2,  /// Alpha 
-		ALPHA2       = 1 << 3,  /// Alpha
-		DAYONLY      = 1 << 4,  /// Render only during the day
-		INTERIOR     = 1 << 5,  /// Is part of an interior
-		NOSHADOWMESH = 1 << 6,  /// Disable shadow mesh
-		DONTCULL     = 1 << 7,  /// Disable culling
-		NODRAWDIST   = 1 << 8,  /// Object won't be affected by draw distance
-		BREAKABLE    = 1 << 9,  /// Object can be broken
-		SMASHABLE    = 1 << 10, /// Object can be smashed and broken
-		GRGEDOOR     = 1 << 11, /// Is a garage door (SA and IV only)
-		MULTICLUMP   = 1 << 12, /// Multiclump
-		WBRIGHTNESS  = 1 << 13, /// Weather PoleShd value effects brightness.
-		EXPLODEONHIT = 1 << 14, /// Object explodes after being hit
+		NORMAL_CULL = 1,           /// Cull model if player doesn't look at it. Ignored in GTA 3.
+		DO_NOT_FADE = 1 << 1,      /// Do not fade the object when it is being loaded into or out of view.
+		DRAW_LAST = 1 << 2,        /// Model is transparent. Render this object after all opaque objects, allowing transparencies of other objects to be visible through this object.
+		ADDITIVE = 1 << 3,         /// Render with additive blending. Previous flag must be enabled too.
+		IS_SUBWAY = 1 << 4,        /// Model is a tunnel, i.e. set the object as invisible unless the player enters cull zone flag 128. This flag works only with static models.
+		IGNORE_LIGHTING = 1 << 5,  /// Don't use static lighting, we want dynamic if it's possible.
+		NO_ZBUFFER_WRITE = 1 << 6, /// Model is a shadow. Disable writing to z-buffer when rendering it, allowing transparencies of other objects, shadows, and lights to be visible through this object. (Not implemented in the PS2 version)
 	};
 
 	// Information loaded from PATH sections

--- a/rwengine/include/render/OpenGLRenderer.hpp
+++ b/rwengine/include/render/OpenGLRenderer.hpp
@@ -313,14 +313,18 @@ private:
 	// Set state
 	void setBlend(bool enable)
 	{
-		if (enable && !blendEnabled)
-		{
+		/// @todo set blendEnabled, currently not possible because other functions keep trashing the state
+#if 0
+		if (enable && !blendEnabled) {
 			glEnable(GL_BLEND);
-		}
-		else if(!enable && blendEnabled)
-		{
+			blendEnabled = enable;
+		} else if(!enable && blendEnabled) {
 			glDisable(GL_BLEND);
+			blendEnabled = enable;
 		}
+#else
+		glEnable(GL_BLEND);
+#endif
 	}
 
 	void setDepthWrite(bool enable)

--- a/rwengine/include/render/OpenGLRenderer.hpp
+++ b/rwengine/include/render/OpenGLRenderer.hpp
@@ -60,6 +60,8 @@ public:
 		Textures textures;
 		/// Alpha blending state
 		bool blend;
+		// Depth writing state
+		bool depthWrite;
 		/// Material
 		glm::u8vec4 colour;
 		/// Material
@@ -72,6 +74,7 @@ public:
 		// Default state -- should be moved to materials
 		DrawParameters()
 			: blend(false)
+			, depthWrite(true)
 			, ambient(1.f)
 			, diffuse(1.f)
 			, visibility(1.f)
@@ -305,6 +308,7 @@ private:
 
 	// State Cache
 	bool blendEnabled;
+	bool depthWriteEnabled;
 
 	// Set state
 	void setBlend(bool enable)
@@ -316,6 +320,14 @@ private:
 		else if(!enable && blendEnabled)
 		{
 			glDisable(GL_BLEND);
+		}
+	}
+
+	void setDepthWrite(bool enable)
+	{
+		if (enable != depthWriteEnabled) {
+			glDepthMask(enable ? GL_TRUE : GL_FALSE);
+			depthWriteEnabled = enable;
 		}
 	}
 

--- a/rwengine/src/objects/InstanceObject.cpp
+++ b/rwengine/src/objects/InstanceObject.cpp
@@ -160,24 +160,15 @@ void InstanceObject::setRotation(const glm::quat &r)
 
 bool InstanceObject::takeDamage(const GameObject::DamageInfo& dmg)
 {
-	bool explodeOnHit = (object->flags&ObjectData::EXPLODEONHIT) == ObjectData::EXPLODEONHIT;
-	bool smash = (object->flags&ObjectData::SMASHABLE) == ObjectData::SMASHABLE;
+	bool smash = false;
 	if( dynamics ) {
 		smash = dynamics->collDamageFlags == 80;
-
 		if( dmg.impulse >= dynamics->uprootForce && (body->body->getCollisionFlags() & btRigidBody::CF_STATIC_OBJECT) != 0 ) {
 			_enablePhysics = true;
 		}
 	}
-	if(explodeOnHit || smash)
-	{
-		if(explodeOnHit) {
-			// explode
-			health = -1.f;
-		}
-		else {
-			health -= dmg.hitpoints;
-		}
+	if(smash) {
+		health -= dmg.hitpoints;
 		return true;
 	}
 	return false;

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -50,6 +50,11 @@ void ObjectRenderer::renderGeometry(Model* model,
 		dp.textures = {0};
 		dp.visibility = 1.f;
 
+		if(object && object->type() == GameObject::Instance) {
+			auto instance = static_cast<InstanceObject*>(object);
+			dp.depthWrite = !(instance->object->flags & ObjectData::NO_ZBUFFER_WRITE);
+		}
+
 		if (model->geometries[g]->materials.size() > subgeom.material) {
 			Model::Material& mat = model->geometries[g]->materials[subgeom.material];
 

--- a/rwengine/src/render/OpenGLRenderer.cpp
+++ b/rwengine/src/render/OpenGLRenderer.cpp
@@ -190,6 +190,7 @@ OpenGLRenderer::OpenGLRenderer()
 	, currentObjectEntry(0)
 	, entryAlignment(0)
 	, blendEnabled(false)
+	, depthWriteEnabled(true)
 	, currentDebugDepth(0)
 {
 	// We need to query for some profiling exts.
@@ -294,11 +295,17 @@ void OpenGLRenderer::clear(const glm::vec4& colour, bool clearColour, bool clear
 		flags |= GL_COLOR_BUFFER_BIT;
 		glClearColor(colour.r, colour.g, colour.b, colour.a);
 	}
+	bool depthWriteWasEnabled = depthWriteEnabled;
 	if( clearDepth ) {
 		flags |= GL_DEPTH_BUFFER_BIT;
+		setDepthWrite(true);
 	}
 
 	glClear(flags);
+
+	if(depthWriteWasEnabled != depthWriteEnabled) {
+		setDepthWrite(depthWriteWasEnabled);
+	}
 }
 
 void OpenGLRenderer::setSceneParameters(const Renderer::SceneUniformData& data)
@@ -317,6 +324,7 @@ void OpenGLRenderer::setDrawState(const glm::mat4& model, DrawBuffer* draw, cons
 	}
 
 	setBlend(p.blend);
+	setDepthWrite(p.depthWrite);
 
 	ObjectUniformData oudata {
 		model,

--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -323,6 +323,7 @@ void TextRenderer::renderText(const TextRenderer::TextInfo& ti)
 	dp.count = gb.getCount();
 	auto ftexture = renderer->getData()->findTexture(fonts[ti.font]);
 	dp.textures = {ftexture->getName()};
+	dp.depthWrite = false;
 	
 	renderer->getRenderer()->drawArrays(glm::mat4(), &db, dp);
 


### PR DESCRIPTION
4 commits, 4 comments:

* First this replaces the ObjectData flags for SA with those from GTA3.
We can still re-add the code later when working on SA. I think this was added for SA by accident anyway?
This also made it necessary to change some damage handler.
(No idea what the 80 means btw, I think there should be an enum for these values..)

* Then add a depth write function to the OpenGL Renderer
(Unused at this point)

* During the previous change I noticed that the `blendEnabled` bool is never actually set (which always forces enabled `GL_BLEND`). However, setting it breaks the renderer because the blend state is not recovered on Renderer invalidation and even when adding that it's still broken because not everything invalidates the renderer..
I didn't want to fix it as part of this commit so I only added a note and made the current operation more obvious (which also should cause a warning during compilation).

* The real change in this one is that objects which have flag value 64 (NO_ZBUFFER_WRITE) don't do depth writes anymore now.
This avoids the shadow-z-fighting which is commonly seen under the train tracks.
I've also disabled depth writing for the text renderer but did not test if the actual game does that too.
I might have a look at text rendering soon anyway and it's easy enough to change it back if it's wrong.
