### PR TITLE
Vehicle Physics Improvements [do not merge]

### DIFF
--- a/rwengine/include/dynamics/CollisionInstance.hpp
+++ b/rwengine/include/dynamics/CollisionInstance.hpp
@@ -11,16 +11,17 @@ struct DynamicObjectData;
 struct VehicleHandlingInfo;
 
 /**
- * @brief Utility object for managing bullet objects.
- *
- * Stores handles to a btRigidBody and a set of collision shapes
+ * @brief CollisionInstance stores bullet body information
  */
 class CollisionInstance
 {
 public:
 
 	CollisionInstance()
-		: body(nullptr), vertArray(nullptr), motionState(nullptr), collisionHeight(0.f)
+		: m_body(nullptr)
+		, m_vertArray(nullptr)
+		, m_motionState(nullptr)
+		, m_collisionHeight(0.f)
 	{ }
 
 	~CollisionInstance();
@@ -30,12 +31,19 @@ public:
 						   DynamicObjectData* dynamics = nullptr,
 						   VehicleHandlingInfo* handling = nullptr);
 
-	btRigidBody* body;
-	std::vector<btCollisionShape*> shapes;
-	btTriangleIndexVertexArray* vertArray;
-	btMotionState* motionState;
+	btRigidBody *getBulletBody() const { return m_body; }
 
-	float collisionHeight;
+	float getBoundingHeight() const { return m_collisionHeight; }
+
+	void changeMass(float newMass);
+
+private:
+	btRigidBody* m_body;
+	std::vector<btCollisionShape*> m_shapes;
+	btTriangleIndexVertexArray* m_vertArray;
+	btMotionState* m_motionState;
+
+	float m_collisionHeight;
 
 };
 

--- a/rwengine/include/dynamics/VehicleDynamics.hpp
+++ b/rwengine/include/dynamics/VehicleDynamics.hpp
@@ -16,10 +16,8 @@ class btRigidBody;
  */
 class VehicleDynamics
 {
-public:
-
-	struct WheelInfo
-	{
+   public:
+	struct WheelInfo {
 		/// Position of the wheel relative to the chassis
 		glm::vec3 position;
 		/// Axle direction
@@ -47,28 +45,34 @@ public:
 		// Applied traction force
 		glm::vec3 tractionForceWS;
 
-		WheelInfo(const glm::vec3& pos, const glm::vec3& axle, float radius, float powerFrac)
-			: position(pos)
-			, axle(axle)
-			, radius(radius)
-			, maxPowerFrac(powerFrac)
-			, displacement(0.f)
-			, steerAngle(0.f)
-			, rotation(0.f)
-			, rotationVelocity(0.f)
-			, rayLength(0.f)
-			, isOnGround(false)
-			, suspensionForce(0.f)
-		{}
+		WheelInfo(const glm::vec3& pos,
+		          const glm::vec3& axle,
+		          float radius,
+		          float powerFrac)
+		    : position(pos)
+		    , axle(axle)
+		    , radius(radius)
+		    , maxPowerFrac(powerFrac)
+		    , displacement(0.f)
+		    , steerAngle(0.f)
+		    , rotation(0.f)
+		    , rotationVelocity(0.f)
+		    , rayLength(0.f)
+		    , isOnGround(false)
+		    , suspensionForce(0.f)
+		{
+		}
 	};
 
-	VehicleDynamics(VehicleObject *vehicle)
-		: m_vehicle(vehicle)
-		, m_engineForce(0.f)
-		, m_breakForce(0.f)
-	{ }
+	VehicleDynamics(VehicleObject* vehicle)
+	    : m_vehicle(vehicle), m_engineForce(0.f), m_breakForce(0.f)
+	{
+	}
 
-	void addWheel(const glm::vec3& position, const glm::vec3& axle, float radius, float power)
+	void addWheel(const glm::vec3& position,
+	              const glm::vec3& axle,
+	              float radius,
+	              float power)
 	{
 		m_wheels.emplace_back(position, axle, radius, power);
 	}
@@ -79,33 +83,28 @@ public:
 	 */
 	void tickPhysics(float dt);
 
-	const std::vector<WheelInfo>& getWheels() const
-	{
-		return m_wheels;
-	}
+	const std::vector<WheelInfo>& getWheels() const { return m_wheels; }
 
-	void setEngineForce(float force)
-	{
-		m_engineForce = force;
-	}
+	void setEngineForce(float force) { m_engineForce = force; }
 
-	void setBreakForce(float force)
-	{
-		m_breakForce = force;
-	}
+	void setBreakForce(float force) { m_breakForce = force; }
 
 	void setWheelAngle(int wheel, float angle)
 	{
 		m_wheels[wheel].steerAngle = angle;
 	}
 
-private:
-	VehicleObject *m_vehicle;
+   private:
+	VehicleObject* m_vehicle;
 	std::vector<WheelInfo> m_wheels;
 	float m_engineForce;
 	float m_breakForce;
 
-	bool raycastWheel(const WheelInfo& wheel, float& distFrac, glm::vec3& worldHit, const btRigidBody*& body);
+	bool raycastWheel(const WheelInfo& wheel,
+	                  float& distFrac,
+	                  glm::vec3& worldHit,
+	                  glm::vec3& worldNormal,
+	                  const btRigidBody*& body);
 };
 
 #endif

--- a/rwengine/include/dynamics/VehicleDynamics.hpp
+++ b/rwengine/include/dynamics/VehicleDynamics.hpp
@@ -1,0 +1,76 @@
+#ifndef RWENGINE_VEHICLEDYNAMICS_HPP
+#define RWENGINE_VEHICLEDYNAMICS_HPP
+
+#include <glm/glm.hpp>
+
+#include <vector>
+
+class VehicleObject;
+class btRigidBody;
+
+/**
+ * @brief The VehicleDynamics class
+ *
+ * implements vehicle physics, using raycasts.
+ *
+ */
+class VehicleDynamics
+{
+public:
+
+	struct WheelInfo
+	{
+		/// Position of the wheel relative to the chassis
+		glm::vec3 position;
+		/// Axle direction
+		glm::vec3 axle;
+		/// Wheel radius
+		float radius;
+		/// Vertical displacement
+		float displacement;
+		/// Rotation around the axle axis
+		float rotation;
+		/// Angular velocity
+		float rotationVelocity;
+		/// Ray length
+		float rayLength;
+
+		WheelInfo(const glm::vec3& pos, const glm::vec3& axle, float radius)
+			: position(pos)
+			, axle(axle)
+			, radius(radius)
+			, displacement(0.f)
+			, rotation(0.f)
+			, rotationVelocity(0.f)
+			, rayLength(0.f)
+		{}
+	};
+
+	VehicleDynamics(VehicleObject *vehicle)
+		: m_vehicle(vehicle)
+	{ }
+
+	void addWheel(const glm::vec3& position, const glm::vec3& axle, float radius)
+	{
+		m_wheels.emplace_back(position, axle, radius);
+	}
+
+	/**
+	 * @brief tickPhysics apply physics.
+	 * @param dt
+	 */
+	void tickPhysics(float dt);
+
+	const std::vector<WheelInfo>& getWheels() const
+	{
+		return m_wheels;
+	}
+
+private:
+	VehicleObject *m_vehicle;
+	std::vector<WheelInfo> m_wheels;
+
+	bool raycastWheel(const WheelInfo& wheel, float& distFrac, glm::vec3& worldHit, const btRigidBody*& body);
+};
+
+#endif

--- a/rwengine/include/dynamics/VehicleDynamics.hpp
+++ b/rwengine/include/dynamics/VehicleDynamics.hpp
@@ -26,33 +26,51 @@ public:
 		glm::vec3 axle;
 		/// Wheel radius
 		float radius;
+		/// How much engine power this wheel can consume [0-1]
+		float maxPowerFrac;
 		/// Vertical displacement
 		float displacement;
+		/// Current steering angle
+		float steerAngle;
 		/// Rotation around the axle axis
 		float rotation;
 		/// Angular velocity
 		float rotationVelocity;
 		/// Ray length
 		float rayLength;
+		/// Is wheel touching the ground
+		bool isOnGround;
+		/// Force that was applied to the vehicle
+		float suspensionForce;
+		// Applied suspension force
+		glm::vec3 suspensionForceWS;
+		// Applied traction force
+		glm::vec3 tractionForceWS;
 
-		WheelInfo(const glm::vec3& pos, const glm::vec3& axle, float radius)
+		WheelInfo(const glm::vec3& pos, const glm::vec3& axle, float radius, float powerFrac)
 			: position(pos)
 			, axle(axle)
 			, radius(radius)
+			, maxPowerFrac(powerFrac)
 			, displacement(0.f)
+			, steerAngle(0.f)
 			, rotation(0.f)
 			, rotationVelocity(0.f)
 			, rayLength(0.f)
+			, isOnGround(false)
+			, suspensionForce(0.f)
 		{}
 	};
 
 	VehicleDynamics(VehicleObject *vehicle)
 		: m_vehicle(vehicle)
+		, m_engineForce(0.f)
+		, m_breakForce(0.f)
 	{ }
 
-	void addWheel(const glm::vec3& position, const glm::vec3& axle, float radius)
+	void addWheel(const glm::vec3& position, const glm::vec3& axle, float radius, float power)
 	{
-		m_wheels.emplace_back(position, axle, radius);
+		m_wheels.emplace_back(position, axle, radius, power);
 	}
 
 	/**
@@ -66,9 +84,26 @@ public:
 		return m_wheels;
 	}
 
+	void setEngineForce(float force)
+	{
+		m_engineForce = force;
+	}
+
+	void setBreakForce(float force)
+	{
+		m_breakForce = force;
+	}
+
+	void setWheelAngle(int wheel, float angle)
+	{
+		m_wheels[wheel].steerAngle = angle;
+	}
+
 private:
 	VehicleObject *m_vehicle;
 	std::vector<WheelInfo> m_wheels;
+	float m_engineForce;
+	float m_breakForce;
 
 	bool raycastWheel(const WheelInfo& wheel, float& distFrac, glm::vec3& worldHit, const btRigidBody*& body);
 };

--- a/rwengine/include/engine/GameWorld.hpp
+++ b/rwengine/include/engine/GameWorld.hpp
@@ -224,32 +224,6 @@ public:
 	GameObject *getBlipTarget(const BlipData &blip) const;
 
 	/**
-	 * Stores objects within a grid cell, and their maximum
-	 * bounding radius
-	 */
-	struct GridCell
-	{
-		/**
-		 * Static instances within this grid cell
-		 */
-		std::set<GameObject*> instances;
-		float boundingRadius = 0.f;
-	};
-	std::array<GridCell, WORLD_GRID_CELLS> worldGrid;
-
-	/**
-	 * returns true if the given object should be stored
-	 * within the grid
-	 */
-	bool shouldBeOnGrid(GameObject* object);
-	void addToGrid(GameObject* object);
-
-	/**
-	 * Returns the grid coordinates for a world coordinates
-	 */
-	glm::ivec2 worldToGrid(const glm::vec2& world);
-
-	/**
 	 * Map of Model Names to Instances
 	 */
 	std::map<std::string, InstanceObject*> modelInstances;

--- a/rwengine/include/objects/CharacterObject.hpp
+++ b/rwengine/include/objects/CharacterObject.hpp
@@ -158,14 +158,12 @@ public:
 
 	virtual void setPosition(const glm::vec3& pos);
 
-	virtual glm::vec3 getPosition() const;
-
-	virtual glm::quat getRotation() const;
-
 	bool isAlive() const;
 	bool takeDamage(const DamageInfo& damage) override;
 
 	bool enterVehicle(VehicleObject* vehicle, size_t seat);
+
+	bool isEnteringOrExitingVehicle() const;
 
 	/**
 	 * @brief isStopped

--- a/rwengine/include/objects/GameObject.hpp
+++ b/rwengine/include/objects/GameObject.hpp
@@ -98,10 +98,10 @@ public:
 	
 	virtual void setPosition(const glm::vec3& pos);
 
-	virtual glm::vec3 getPosition() const { return position; }
+	const glm::vec3& getPosition() const { return position; }
 	const glm::vec3& getLastPosition() const { return _lastPosition; }
 
-	virtual glm::quat getRotation() const;
+	const glm::quat& getRotation() const { return rotation; }
 	virtual void setRotation(const glm::quat &orientation);
 
 	float getHeading() const;
@@ -185,9 +185,18 @@ public:
 	
 	void setLifetime(ObjectLifetime ol) { lifetime = ol; }
 	ObjectLifetime getLifetime() const { return lifetime; }
-	
+
+	void updateTransform(const glm::vec3& pos, const glm::quat& rot)
+	{
+		_lastPosition = position;
+		_lastRotation = rotation;
+		position = pos;
+		rotation = rot;
+	}
+
 private:
 	ObjectLifetime lifetime;
+
 };
 
 #endif // __GAMEOBJECTS_HPP__

--- a/rwengine/include/objects/InstanceObject.hpp
+++ b/rwengine/include/objects/InstanceObject.hpp
@@ -31,9 +31,6 @@ public:
 
 	void changeModel(std::shared_ptr<ObjectData> incoming);
 
-	glm::vec3 getPosition() const override;
-	glm::quat getRotation() const override;
-
 	virtual void setRotation(const glm::quat& r);
 	
 	virtual bool takeDamage(const DamageInfo& damage);

--- a/rwengine/include/objects/VehicleObject.hpp
+++ b/rwengine/include/objects/VehicleObject.hpp
@@ -7,8 +7,6 @@
 #include <dynamics/VehicleDynamics.hpp>
 
 class CollisionInstance;
-class btVehicleRaycaster;
-class btRaycastVehicle;
 class btRigidBody;
 class btHingeConstraint;
 class btTransform;
@@ -34,8 +32,6 @@ public:
 	std::map<size_t, GameObject*> seatOccupants;
 
 	CollisionInstance* collision;
-	btVehicleRaycaster* physRaycaster;
-	btRaycastVehicle* physVehicle;
 	VehicleDynamics dynamics;
 	
 	struct Part

--- a/rwengine/include/objects/VehicleObject.hpp
+++ b/rwengine/include/objects/VehicleObject.hpp
@@ -4,7 +4,13 @@
 #include <objects/GameObject.hpp>
 #include <map>
 #include <objects/VehicleInfo.hpp>
-#include <dynamics/CollisionInstance.hpp>
+
+class CollisionInstance;
+class btVehicleRaycaster;
+class btRaycastVehicle;
+class btRigidBody;
+class btHingeConstraint;
+class btTransform;
 
 /**
  * @class VehicleObject
@@ -27,8 +33,7 @@ public:
 	std::map<size_t, GameObject*> seatOccupants;
 
 	CollisionInstance* collision;
-	btRigidBody* physBody;
-	btVehicleRaycaster* physRaycaster = nullptr;
+	btVehicleRaycaster* physRaycaster;
 	btRaycastVehicle* physVehicle;
 	
 	struct Part
@@ -137,21 +142,6 @@ private:
 	void registerPart(ModelFrame* mf);
 	void createObjectHinge(btTransform &local, Part* part);
 	void destroyObjectHinge(Part* part);
-};
-
-/**
- * Implements vehicle ray casting behaviour.
- * i.e. ignore the god damn vehicle body when casting rays.
- */
-class VehicleRaycaster : public btVehicleRaycaster
-{
-	btDynamicsWorld* _world;
-	VehicleObject* _vehicle;
-public:
-	VehicleRaycaster(VehicleObject* vehicle, btDynamicsWorld* world)
-		: _world(world), _vehicle(vehicle) {}
-
-	void* castRay(const btVector3 &from, const btVector3 &to, btVehicleRaycasterResult &result);
 };
 
 #endif

--- a/rwengine/include/objects/VehicleObject.hpp
+++ b/rwengine/include/objects/VehicleObject.hpp
@@ -4,6 +4,7 @@
 #include <objects/GameObject.hpp>
 #include <map>
 #include <objects/VehicleInfo.hpp>
+#include <dynamics/VehicleDynamics.hpp>
 
 class CollisionInstance;
 class btVehicleRaycaster;
@@ -35,6 +36,7 @@ public:
 	CollisionInstance* collision;
 	btVehicleRaycaster* physRaycaster;
 	btRaycastVehicle* physVehicle;
+	VehicleDynamics dynamics;
 	
 	struct Part
 	{

--- a/rwengine/include/objects/VehicleObject.hpp
+++ b/rwengine/include/objects/VehicleObject.hpp
@@ -57,11 +57,7 @@ public:
 	
 	void setPosition(const glm::vec3& pos);
 
-	glm::vec3 getPosition() const;
-
 	void setRotation(const glm::quat &orientation);
-
-	glm::quat getRotation() const;
 
 	Type type() { return Vehicle; }
 
@@ -111,7 +107,10 @@ public:
 	glm::vec3 getSeatEntryPosition(size_t seat) const {
 		auto pos = info->seats[seat].offset;
 		pos -= glm::vec3(glm::sign(pos.x) * -0.81756252f, 0.34800607f, -0.486281008f);
-		return getPosition() + getRotation() * pos;
+		return pos;
+	}
+	glm::vec3 getSeatEntryPositionWorld(size_t seat) const {
+		return getPosition() + getRotation() * getSeatEntryPosition(seat);
 	}
 	
 	Part* getSeatEntryDoor(size_t seat);

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -207,7 +207,7 @@ bool Activities::EnterVehicle::update(CharacterObject *character, CharacterContr
 		float nearest = std::numeric_limits<float>::max();
 		for(unsigned int s = 1; s < vehicle->info->seats.size(); ++s)
 		{
-			auto entry = vehicle->getSeatEntryPosition(s);
+			auto entry = vehicle->getSeatEntryPositionWorld(s);
 			float dist = glm::distance(entry, character->getPosition());
 			if( dist < nearest )
 			{
@@ -218,6 +218,7 @@ bool Activities::EnterVehicle::update(CharacterObject *character, CharacterContr
 	}
 	
 	auto entryDoor = vehicle->getSeatEntryDoor(seat);
+	auto entryPos = vehicle->getSeatEntryPositionWorld(seat);
 
 	auto anm_open = character->animations.car_open_lhs;
 	auto anm_enter = character->animations.car_getin_lhs;
@@ -262,8 +263,7 @@ bool Activities::EnterVehicle::update(CharacterObject *character, CharacterContr
 		}
 	}
 	else {
-		glm::vec3 target = vehicle->getSeatEntryPosition(seat);
-		glm::vec3 targetDirection = target - character->getPosition();
+		glm::vec3 targetDirection = entryPos - character->getPosition();
 		targetDirection.z = 0.f;
 
 		float targetDistance = glm::length(targetDirection);
@@ -387,7 +387,7 @@ bool Activities::ExitVehicle::update(CharacterObject *character, CharacterContro
 
 	if( character->animator->getAnimation(AnimIndexAction) == anm_exit ) {
 		if( character->animator->isCompleted(AnimIndexAction) ) {
-			auto exitpos = vehicle->getSeatEntryPosition(seat);
+			auto exitpos = vehicle->getSeatEntryPositionWorld(seat);
 
 			character->enterVehicle(nullptr, seat);
 			character->setPosition(exitpos);

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -1,6 +1,7 @@
 #include <ai/CharacterController.hpp>
 #include <objects/CharacterObject.hpp>
 #include <objects/VehicleObject.hpp>
+#include <BulletDynamics/btBulletDynamicsCommon.h>
 
 #include <data/Model.hpp>
 #include <engine/Animator.hpp>

--- a/rwengine/src/dynamics/CollisionInstance.cpp
+++ b/rwengine/src/dynamics/CollisionInstance.cpp
@@ -6,23 +6,23 @@
 
 CollisionInstance::~CollisionInstance()
 {
-	if( body ) {
-		GameObject* object = static_cast<GameObject*>(body->getUserPointer());
+	if( m_body ) {
+		GameObject* object = static_cast<GameObject*>(m_body->getUserPointer());
 
 		// Remove body from existance.
-		object->engine->dynamicsWorld->removeRigidBody(body);
+		object->engine->dynamicsWorld->removeRigidBody(m_body);
 		
-		for(btCollisionShape* shape : shapes) {
+		for(btCollisionShape* shape : m_shapes) {
 			delete shape;
 		}
 		
-		delete body;
+		delete m_body;
 	}
-	if( vertArray ) {
-		delete vertArray;
+	if( m_vertArray ) {
+		delete m_vertArray;
 	}
-	if( motionState ) {
-		delete motionState;
+	if( m_motionState ) {
+		delete m_motionState;
 	}
 }
 
@@ -35,14 +35,14 @@ bool CollisionInstance::createPhysicsBody(GameObject *object, const std::string&
 		auto p = object->getPosition();
 		auto r = object->getRotation();
 
-		motionState = new btDefaultMotionState;
-		motionState->setWorldTransform(btTransform(
+		m_motionState = new btDefaultMotionState;
+		m_motionState->setWorldTransform(btTransform(
 									btQuaternion(r.x, r.y, r.z, -r.w).inverse(),
 									btVector3(p.x, p.y, p.z)
 									));
-		shapes.push_back(cmpShape);
+		m_shapes.push_back(cmpShape);
 
-		btRigidBody::btRigidBodyConstructionInfo info(0.f, motionState, cmpShape);
+		btRigidBody::btRigidBodyConstructionInfo info(0.f, m_motionState, cmpShape);
 
 		CollisionModel& physInst = *phyit->second.get();
 
@@ -62,7 +62,7 @@ bool CollisionInstance::createPhysicsBody(GameObject *object, const std::string&
 			colMin = std::min(colMin, mid.z - size.z);
 			colMax = std::max(colMax, mid.z + size.z);
 
-			shapes.push_back(bshape);
+			m_shapes.push_back(bshape);
 		}
 
 		// Spheres
@@ -76,26 +76,26 @@ bool CollisionInstance::createPhysicsBody(GameObject *object, const std::string&
 			colMin = std::min(colMin, sphere.center.z - sphere.radius);
 			colMax = std::max(colMax, sphere.center.z + sphere.radius);
 
-			shapes.push_back(sshape);
+			m_shapes.push_back(sshape);
 		}
 
 		if( physInst.vertices.size() > 0 && physInst.indices.size() >= 3 ) {
-			vertArray = new btTriangleIndexVertexArray(
+			m_vertArray = new btTriangleIndexVertexArray(
 						physInst.indices.size()/3,
 						(int*) physInst.indices.data(),
 						sizeof(uint32_t)*3,
 						physInst.vertices.size(),
 						&(physInst.vertices[0].x),
 					sizeof(glm::vec3));
-			btBvhTriangleMeshShape* trishape = new btBvhTriangleMeshShape(vertArray, false);
+			btBvhTriangleMeshShape* trishape = new btBvhTriangleMeshShape(m_vertArray, false);
 			trishape->setMargin(0.05f);
 			btTransform t; t.setIdentity();
 			cmpShape->addChildShape(t, trishape);
 
-			shapes.push_back(trishape);
+			m_shapes.push_back(trishape);
 		}
 
-		collisionHeight = colMax - colMin;
+		m_collisionHeight = colMax - colMin;
 
 		if( dynamics ) {
 			if( dynamics->uprootForce > 0.f ) {
@@ -115,12 +115,12 @@ bool CollisionInstance::createPhysicsBody(GameObject *object, const std::string&
 			info.m_localInertia = inert;
 		}
 
-		body = new btRigidBody(info);
-		body->setUserPointer(object);
-		object->engine->dynamicsWorld->addRigidBody(body);
+		m_body = new btRigidBody(info);
+		m_body->setUserPointer(object);
+		object->engine->dynamicsWorld->addRigidBody(m_body);
 
 		if( dynamics && dynamics->uprootForce > 0.f ) {
-			body->setCollisionFlags(body->getCollisionFlags()
+			m_body->setCollisionFlags(m_body->getCollisionFlags()
 									| btCollisionObject::CF_CUSTOM_MATERIAL_CALLBACK);
 		}
 	}
@@ -130,4 +130,15 @@ bool CollisionInstance::createPhysicsBody(GameObject *object, const std::string&
 	}
 
 	return true;
+}
+
+void CollisionInstance::changeMass(float newMass)
+{
+	GameObject* object = static_cast<GameObject*>(m_body->getUserPointer());
+	auto dynamicsWorld = object->engine->dynamicsWorld;
+	dynamicsWorld->removeRigidBody(m_body);
+	btVector3 inert;
+	m_body->getCollisionShape()->calculateLocalInertia(newMass, inert);
+	m_body->setMassProps(newMass, inert);
+	dynamicsWorld->addRigidBody(m_body);
 }

--- a/rwengine/src/dynamics/VehicleDynamics.cpp
+++ b/rwengine/src/dynamics/VehicleDynamics.cpp
@@ -1,0 +1,98 @@
+#include <dynamics/VehicleDynamics.hpp>
+#include <dynamics/CollisionInstance.hpp>
+#include <dynamics/RaycastCallbacks.hpp>
+#include <objects/VehicleObject.hpp>
+#include <engine/GameWorld.hpp>
+
+void VehicleDynamics::tickPhysics(float dt)
+{
+	float distFrac;
+	glm::vec3 worldHit;
+	const btRigidBody* body;
+	const float upperLimit = m_vehicle->info->handling.suspensionUpperLimit;
+	const float restLength = upperLimit -
+			m_vehicle->info->handling.suspensionLowerLimit;
+	// ??
+	const float springForce = (m_vehicle->info->handling.suspensionForce / restLength) * 1000.f;
+	const float springDamp = (m_vehicle->info->handling.suspensionDamping / restLength) * 10000.f;
+	auto bulletBody = m_vehicle->collision->getBulletBody();
+
+	// Downforce = 16677
+	// Force per wheel ~= 4169.25
+
+	for(auto& wheel : m_wheels)
+	{
+		// Calculate the ray length to ensure this ray can't fall through the ground.
+		wheel.rayLength = restLength + wheel.radius;
+		if (raycastWheel(wheel, distFrac, worldHit, body))
+		{
+			float distance = std::min((distFrac * wheel.rayLength) - wheel.radius,
+									  restLength);
+			// The center of the wheel must be radius above the end point.
+			wheel.displacement = glm::min(0.f, -distance);
+			float force = std::max(0.f, springForce * (restLength - distance)/restLength);
+			printf("force: %f displacement: %f distFrac %f\n", force, wheel.displacement, (restLength - distance)/restLength);
+			// Move force location into local space.
+			auto ws = m_vehicle->getRotation() * wheel.position;
+			auto btws = btVector3(ws.x, ws.y, ws.z);
+			auto pointVel = bulletBody->getLinearVelocity();
+			force += -pointVel.z() * springDamp;
+#if 1
+			bulletBody->applyImpulse(
+						btVector3(0.f, 0.f, force * dt),
+						btws);
+#else
+			bulletBody->applyForce(
+						btVector3(0.f, 0.f, force),
+						btws);
+#endif
+		}
+		else
+		{
+			wheel.displacement = -restLength;
+		}
+	}
+
+}
+
+bool VehicleDynamics::raycastWheel(const VehicleDynamics::WheelInfo& wheel, float& distFrac, glm::vec3& worldHit, const btRigidBody* &body)
+{
+	const float& handling_upperlimit = m_vehicle->info->handling.suspensionUpperLimit;
+
+	auto bulletbody = m_vehicle->collision->getBulletBody();
+	glm::vec3 wheelStartWorldSpace = m_vehicle->getPosition()
+			+ m_vehicle->getRotation()
+			* (wheel.position + glm::vec3(0.f, 0.f, handling_upperlimit));
+	glm::vec3 wheelEndWorldSpace = m_vehicle->getPosition()
+			+ m_vehicle->getRotation()
+			* (wheel.position + glm::vec3(0.f, 0.f, handling_upperlimit - wheel.rayLength));
+	btVector3 from(wheelStartWorldSpace.x, wheelStartWorldSpace.y, wheelStartWorldSpace.z);
+	btVector3 to(wheelEndWorldSpace.x, wheelEndWorldSpace.y, wheelEndWorldSpace.z);
+
+	ClosestNotMeRayResultCallback rayCallback( bulletbody, from, to );
+
+	auto world = m_vehicle->engine;
+	world->dynamicsWorld->rayTest(from, to, rayCallback);
+
+	if (rayCallback.hasHit()) {
+		const btRigidBody* raybody = btRigidBody::upcast( rayCallback.m_collisionObject );
+
+		if( raybody && raybody->hasContactResponse() ) {
+			worldHit.x = rayCallback.m_hitPointWorld.x();
+			worldHit.y = rayCallback.m_hitPointWorld.y();
+			worldHit.z = rayCallback.m_hitPointWorld.z();
+
+			//result.m_hitNormalInWorld = rayCallback.m_hitNormalWorld; //??
+			//result.m_hitNormalInWorld.normalize();
+
+			distFrac = rayCallback.m_closestHitFraction;
+			body = raybody;
+			return true;
+		}
+	}
+	else {
+		distFrac = 1.f;
+		body = nullptr;
+	}
+	return false;
+}

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -91,7 +91,7 @@ GameWorld::GameWorld(Logger* log, WorkContext* work, GameData* dat)
 	dynamicsWorld->setGravity(btVector3(0.f, 0.f, -9.81f));
 	broadphase->getOverlappingPairCache()->setInternalGhostPairCallback(new btGhostPairCallback());
 	gContactProcessedCallback = ContactProcessedCallback;
-	dynamicsWorld->setInternalTickCallback(PhysicsTickCallback, this);
+	dynamicsWorld->setInternalTickCallback(PhysicsTickCallback, this, true);
 
 	// Populate inventory items
 	for( auto& w : data->weaponData ) {

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -202,11 +202,6 @@ InstanceObject *GameWorld::createInstance(const uint16_t id, const glm::vec3& po
 		instancePool.insert(instance);
         allObjects.push_back(instance);
 
-		if( shouldBeOnGrid(instance) )
-		{
-			addToGrid( instance );
-		}
-
 		modelInstances.insert({
 			oi->modelName,
 			instance
@@ -530,14 +525,6 @@ GameObject*GameWorld::getBlipTarget(const BlipData& blip) const
 
 void GameWorld::destroyObject(GameObject* object)
 {
-	auto coord = worldToGrid(glm::vec2(object->getPosition()));
-	if( coord.x < 0 || coord.y < 0 || coord.x >= WORLD_GRID_WIDTH || coord.y >= WORLD_GRID_WIDTH )
-	{
-		return;
-	}
-	auto index = (coord.x * WORLD_GRID_WIDTH) + coord.y;
-	worldGrid[index].instances.erase(object);
-	
 	auto& pool = getTypeObjectPool(object);
 	pool.remove(object);
 
@@ -563,42 +550,6 @@ void GameWorld::destroyQueuedObjects()
 		destroyObject( *deletionQueue.begin() );
 		deletionQueue.erase( deletionQueue.begin() );
 	}
-}
-
-bool GameWorld::shouldBeOnGrid(GameObject* object)
-{
-	if( object->type() != GameObject::Instance )
-	{
-		// Only static instances currently.
-		return false;
-	}
-	auto instance = static_cast<InstanceObject*>(object);
-	return instance->body == nullptr || instance->body->body->isStaticObject();
-}
-
-void GameWorld::addToGrid(GameObject* object)
-{
-	auto coord = worldToGrid(glm::vec2(object->getPosition()));
-	if( coord.x < 0 || coord.y < 0 || coord.x >= WORLD_GRID_WIDTH || coord.y >= WORLD_GRID_WIDTH )
-	{
-		return;
-	}
-	auto index = (coord.x * WORLD_GRID_WIDTH) + coord.y;
-	worldGrid[index].instances.insert(object);
-	if( object->model->resource )
-	{
-		float cellhalf = WORLD_CELL_SIZE/2.f;
-		auto world = glm::vec3(glm::vec2(coord) * glm::vec2(WORLD_CELL_SIZE) - glm::vec2(WORLD_GRID_SIZE/2.f) + glm::vec2(cellhalf), 0.f);
-		auto offset = world - object->getPosition();
-		float maxRadius = glm::length(offset) + object->model->resource->getBoundingRadius();
-		worldGrid[index].boundingRadius = std::max(worldGrid[index].boundingRadius, maxRadius);
-	}
-}
-
-glm::ivec2 GameWorld::worldToGrid(const glm::vec2& world)
-{
-	static const float lowerCoord = -(WORLD_GRID_SIZE)/2.f;
-	return glm::ivec2((world - glm::vec2(lowerCoord)) / glm::vec2(WORLD_CELL_SIZE));
 }
 
 VisualFX* GameWorld::createEffect(VisualFX::EffectType type)

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -316,8 +316,6 @@ void CharacterObject::updateCharacter(float dt)
 	if(physCharacter) {
 		glm::vec3 walkDir = updateMovementAnimation(dt);
 
-		position = getPosition();
-
 		if (canTurn()) {
 			rotation = glm::angleAxis(m_look.x, glm::vec3{0.f, 0.f, 1.f});
 		}
@@ -399,39 +397,6 @@ void CharacterObject::setPosition(const glm::vec3& pos)
 	position = pos;
 }
 
-glm::vec3 CharacterObject::getPosition() const
-{
-	if(physCharacter) {
-		btVector3 Pos = physCharacter->getGhostObject()->getWorldTransform().getOrigin();
-		return glm::vec3(Pos.x(), Pos.y(), Pos.z());
-	}
-	if(currentVehicle) {
-		/// @todo this is hacky.
-		if( animator->getAnimation(AnimIndexAction) == animations.car_getout_lhs ) {
-			return currentVehicle->getSeatEntryPosition(currentSeat);
-		}
-
-		auto v = getCurrentVehicle();
-		auto R = glm::mat3_cast(v->getRotation());
-		glm::vec3 offset;
-		auto o = (animator->getAnimation(AnimIndexAction) == animations.car_getin_lhs) ? enter_offset : glm::vec3();
-		if(getCurrentSeat() < v->info->seats.size()) {
-			offset = R * (v->info->seats[getCurrentSeat()].offset -
-					o);
-		}
-		return currentVehicle->getPosition() + offset;
-	}
-	return position;
-}
-
-glm::quat CharacterObject::getRotation() const
-{
-	if(currentVehicle) {
-		return currentVehicle->getRotation();
-	}
-	return GameObject::getRotation();
-}
-
 bool CharacterObject::isAlive() const
 {
 	return currentState.health > 0.f;
@@ -463,6 +428,12 @@ bool CharacterObject::enterVehicle(VehicleObject* vehicle, size_t seat)
 		}
 	}
 	return false;
+}
+
+bool CharacterObject::isEnteringOrExitingVehicle() const
+{
+	return animator->getAnimation(AnimIndexAction) == animations.car_getout_lhs ||
+			animator->getAnimation(AnimIndexAction) == animations.car_getin_lhs;
 }
 
 bool CharacterObject::isStopped() const

--- a/rwengine/src/objects/GameObject.cpp
+++ b/rwengine/src/objects/GameObject.cpp
@@ -23,11 +23,6 @@ void GameObject::setPosition(const glm::vec3& pos)
 	_lastPosition = position = pos;
 }
 
-glm::quat GameObject::getRotation() const
-{
-	return rotation;
-}
-
 void GameObject::setRotation(const glm::quat& orientation)
 {
 	rotation = orientation;

--- a/rwengine/src/objects/InstanceObject.cpp
+++ b/rwengine/src/objects/InstanceObject.cpp
@@ -43,20 +43,17 @@ InstanceObject::~InstanceObject()
 void InstanceObject::tick(float dt)
 {
 	if( dynamics && body ) {
-		if( body->body->isStaticObject() ) {
-			if( _enablePhysics ) {
+		if( _enablePhysics ) {
+			if( body->getBulletBody()->isStaticObject() ) {
 				// Apparently bodies must be removed and re-added if their mass changes.
-				engine->dynamicsWorld->removeRigidBody(body->body);
-				btVector3 inert;
-				body->body->getCollisionShape()->calculateLocalInertia(dynamics->mass, inert);
-				body->body->setMassProps(dynamics->mass, inert);
-				engine->dynamicsWorld->addRigidBody(body->body);
+				body->changeMass(dynamics->mass);
 			}
 		}
 		
 		_updateLastTransform();
 
-		auto _bws = body->body->getWorldTransform().getOrigin();
+#warning replace with position from motionstate
+		auto _bws = body->getBulletBody()->getWorldTransform().getOrigin();
 		glm::vec3 ws(_bws.x(), _bws.y(), _bws.z());
 		auto wX = (int) ((ws.x + WATER_WORLD_SIZE/2.f) / (WATER_WORLD_SIZE/WATER_HQ_DATA_SIZE));
 		auto wY = (int) ((ws.y + WATER_WORLD_SIZE/2.f) / (WATER_WORLD_SIZE/WATER_HQ_DATA_SIZE));
@@ -83,10 +80,10 @@ void InstanceObject::tick(float dt)
 		_lastHeight = ws.z;
 
 		if( inWater ) {
-			float oZ = -(body->collisionHeight * (dynamics->bouancy/100.f));
-			body->body->activate(true);
+			float oZ = -(body->getBoundingHeight() * (dynamics->bouancy/100.f));
+			body->getBulletBody()->activate(true);
 			// Damper motion
-			body->body->setDamping(0.95f, 0.9f);
+			body->getBulletBody()->setDamping(0.95f, 0.9f);
 
 			auto wi = engine->data->getWaterIndexAt(ws);
 			if(wi != NO_WATER_INDEX) {
@@ -106,10 +103,10 @@ void InstanceObject::tick(float dt)
 					}*/
 
 					float x = (h - ws.z);
-					float F = WATER_BUOYANCY_K * x + -WATER_BUOYANCY_C * body->body->getLinearVelocity().z();
+					float F = WATER_BUOYANCY_K * x + -WATER_BUOYANCY_C * body->getBulletBody()->getLinearVelocity().z();
 					btVector3 forcePos = btVector3(0.f, 0.f, 2.f).rotate(
-								body->body->getOrientation().getAxis(), body->body->getOrientation().getAngle());
-					body->body->applyForce(btVector3(0.f, 0.f, F),
+								body->getBulletBody()->getOrientation().getAxis(), body->getBulletBody()->getOrientation().getAngle());
+					body->getBulletBody()->applyForce(btVector3(0.f, 0.f, F),
 										 forcePos);
 				}
 			}
@@ -133,7 +130,7 @@ void InstanceObject::changeModel(std::shared_ptr<ObjectData> incoming)
 
 		if( bod->createPhysicsBody(this, object->modelName, dynamics.get()) )
 		{
-			bod->body->setActivationState(ISLAND_SLEEPING);
+			bod->getBulletBody()->setActivationState(ISLAND_SLEEPING);
 			body = bod;
 		}
 	}
@@ -152,7 +149,7 @@ glm::quat InstanceObject::getRotation() const
 void InstanceObject::setRotation(const glm::quat &r)
 {
 	if( body ) {
-		auto& wtr = body->body->getWorldTransform();
+		auto& wtr = body->getBulletBody()->getWorldTransform();
 		wtr.setRotation(btQuaternion(r.x, r.y, r.z, r.w));
 	}
 	GameObject::setRotation(r);
@@ -163,7 +160,8 @@ bool InstanceObject::takeDamage(const GameObject::DamageInfo& dmg)
 	bool smash = false;
 	if( dynamics ) {
 		smash = dynamics->collDamageFlags == 80;
-		if( dmg.impulse >= dynamics->uprootForce && (body->body->getCollisionFlags() & btRigidBody::CF_STATIC_OBJECT) != 0 ) {
+
+		if( dmg.impulse >= dynamics->uprootForce && (body->getBulletBody()->getCollisionFlags() & btRigidBody::CF_STATIC_OBJECT) != 0 ) {
 			_enablePhysics = true;
 		}
 	}
@@ -177,17 +175,17 @@ bool InstanceObject::takeDamage(const GameObject::DamageInfo& dmg)
 void InstanceObject::setSolid(bool solid)
 {
 	// Early out in case we don't have a collision body
-	if (body == nullptr || body->body == nullptr) {
+	if (body == nullptr || body->getBulletBody() == nullptr) {
 		return;
 	}
 
-	int flags = body->body->getCollisionFlags();
+	int flags = body->getBulletBody()->getCollisionFlags();
 	if (solid) {
 		flags &= ~btCollisionObject::CF_NO_CONTACT_RESPONSE;
 	} else {
 		flags |= btCollisionObject::CF_NO_CONTACT_RESPONSE;
 	}
-	body->body->setCollisionFlags(flags);
+	body->getBulletBody()->setCollisionFlags(flags);
 }
 
 

--- a/rwengine/src/objects/InstanceObject.cpp
+++ b/rwengine/src/objects/InstanceObject.cpp
@@ -49,12 +49,8 @@ void InstanceObject::tick(float dt)
 				body->changeMass(dynamics->mass);
 			}
 		}
-		
-		_updateLastTransform();
 
-#warning replace with position from motionstate
-		auto _bws = body->getBulletBody()->getWorldTransform().getOrigin();
-		glm::vec3 ws(_bws.x(), _bws.y(), _bws.z());
+		const glm::vec3& ws = getPosition();
 		auto wX = (int) ((ws.x + WATER_WORLD_SIZE/2.f) / (WATER_WORLD_SIZE/WATER_HQ_DATA_SIZE));
 		auto wY = (int) ((ws.y + WATER_WORLD_SIZE/2.f) / (WATER_WORLD_SIZE/WATER_HQ_DATA_SIZE));
 		float vH = ws.z;// - _collisionHeight/2.f;
@@ -134,16 +130,6 @@ void InstanceObject::changeModel(std::shared_ptr<ObjectData> incoming)
 			body = bod;
 		}
 	}
-}
-
-glm::vec3 InstanceObject::getPosition() const
-{
-	return position;
-}
-
-glm::quat InstanceObject::getRotation() const
-{
-	return rotation;
 }
 
 void InstanceObject::setRotation(const glm::quat &r)

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -128,6 +128,13 @@ void VehicleObject::tickPhysics(float dt)
 		{
 			velFac = 0.f;
 		}
+
+		/// @todo make this be correct
+		// There's some resources here:
+		// http://projectcerbera.com/gta/3-vc/tutorials/acceleration
+		//  and here:
+		// http://projectcerbera.com/gta/3-vc/tutorials/dimensions
+		// But I haven't gotten this matching that yet.
 		float engineForce = glm::sqrt(info->handling.acceleration) * throttle * info->handling.mass * velFac;
 		if( fabs(engineForce) >= 0.001f )
 		{

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -29,6 +29,17 @@ VehicleObject::VehicleObject(GameWorld* engine, const glm::vec3& pos, const glm:
 {
 	collision = new CollisionInstance;
 	if( collision->createPhysicsBody(this, data->modelName, nullptr, &info->handling) ) {
+
+		// calculate the intertia from the handling information
+		auto& dim = info->handling.dimensions;
+		auto mass = info->handling.mass;
+		// see: https://en.wikipedia.org/wiki/List_of_moments_of_inertia
+		btVector3 handlingInertia(
+		    1.f / ((mass / 12) * (dim.y * dim.y + dim.z * dim.z)),
+		    1.f / ((mass / 12) * (dim.x * dim.x + dim.z * dim.z)),
+		    1.f / ((mass / 12) * (dim.x * dim.x + dim.y * dim.y)));
+		collision->getBulletBody()->setInvInertiaDiagLocal(handlingInertia);
+
 		for(size_t w = 0; w < info->wheels.size(); ++w) {
 			bool front = info->wheels[w].position.y > 0;
 			float maxPower = 0.f;

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -60,6 +60,7 @@ VehicleObject::VehicleObject(GameWorld* engine, const glm::vec3& pos, const glm:
 	, collision(nullptr)
 	, physRaycaster(nullptr)
 	, physVehicle(nullptr)
+	, dynamics(this)
 {
 	collision = new CollisionInstance;
 	if( collision->createPhysicsBody(this, data->modelName, nullptr, &info->handling) ) {
@@ -80,6 +81,8 @@ VehicleObject::VehicleObject(GameWorld* engine, const glm::vec3& pos, const glm:
 		float kR = 0.6f;
 
 		for(size_t w = 0; w < info->wheels.size(); ++w) {
+			dynamics.addWheel(info->wheels[w].position, glm::vec3(1.f, 0.f, 0.f), data->wheelScale/2.f);
+#if 0
 			auto restLength = travel;
 			auto heightOffset = info->handling.suspensionUpperLimit;
 			btVector3 connection(
@@ -102,6 +105,7 @@ VehicleObject::VehicleObject(GameWorld* engine, const glm::vec3& pos, const glm:
 			wi.m_rollInfluence = 0.30f;
 			float halfFriction = tuning.m_frictionSlip * 0.5f;
 			wi.m_frictionSlip = halfFriction + halfFriction * (front ? info->handling.tractionBias : 1.f - info->handling.tractionBias);
+#endif
 		}
 
 		// Hide all LOD and damage frames.
@@ -184,6 +188,8 @@ void VehicleObject::tick(float dt)
 void VehicleObject::tickPhysics(float dt)
 {
 	RW_UNUSED(dt);
+
+	dynamics.tickPhysics(dt);
 
 	if( physVehicle )
 	{

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -187,9 +187,13 @@ void VehicleObject::tickPhysics(float dt)
 
 	if( physVehicle )
 	{
-		// todo: a real engine function
-		float velFac = info->handling.maxVelocity;
-		float engineForce = info->handling.acceleration * throttle * velFac;
+		float currentVelocity = physVehicle->getCurrentSpeedKmHour();
+		float velFac = 1.f;
+		if (currentVelocity >= info->handling.maxVelocity) // (info->handling.maxVelocity - currentVelocity) / info->handling.maxVelocity;
+		{
+			velFac = 0.f;
+		}
+		float engineForce = glm::sqrt(info->handling.acceleration) * throttle * info->handling.mass * velFac;
 		if( fabs(engineForce) >= 0.001f )
 		{
 			collision->getBulletBody()->activate(true);

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -404,6 +404,8 @@ void ObjectRenderer::renderVehicle(VehicleObject *vehicle,
 				auto wheelPosition = wi.position + glm::vec3(0.f, 0.f, vehicle->info->handling.suspensionUpperLimit + wi.displacement);
 				glm::mat4 wheelMatrix = matrixModel;
 				wheelMatrix = glm::translate(wheelMatrix, wheelPosition);
+				wheelMatrix = glm::rotate(wheelMatrix, wi.steerAngle, glm::vec3(0.f, 0.f, 1.f));
+				wheelMatrix = glm::rotate(wheelMatrix, wi.rotation, glm::vec3(1.f, 0.f, 0.f));
 
 				wheelMatrix = glm::scale(wheelMatrix, glm::vec3(vehicle->vehicle->wheelScale));
 				if(wi.position.x < 0.f) {

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -298,7 +298,28 @@ void ObjectRenderer::renderInstance(InstanceObject *instance,
 void ObjectRenderer::renderCharacter(CharacterObject *pedestrian,
 									 RenderList& outList)
 {
-	glm::mat4 matrixModel = pedestrian->getTimeAdjustedTransform( m_renderAlpha );
+	glm::mat4 matrixModel;
+
+	if (pedestrian->getCurrentVehicle())
+	{
+		auto vehicle = pedestrian->getCurrentVehicle();
+		auto seat = pedestrian->getCurrentSeat();
+		matrixModel = vehicle->getTimeAdjustedTransform( m_renderAlpha );
+		if (pedestrian->isEnteringOrExitingVehicle())
+		{
+			matrixModel = glm::translate(matrixModel, vehicle->getSeatEntryPosition(seat));
+		}
+		else
+		{
+			if (seat < vehicle->info->seats.size()) {
+				matrixModel = glm::translate(matrixModel, vehicle->info->seats[seat].offset);
+			}
+		}
+	}
+	else
+	{
+		matrixModel = pedestrian->getTimeAdjustedTransform( m_renderAlpha );
+	}
 
 	if(!pedestrian->model->resource) return;
 

--- a/rwengine/src/script/modules/ObjectModule.cpp
+++ b/rwengine/src/script/modules/ObjectModule.cpp
@@ -29,6 +29,8 @@
 
 glm::vec3 spawnMagic( 0.f, 0.f, 1.f );
 
+constexpr float kVehicleStoppedSpeed = 0.1f;
+
 void game_create_player(const ScriptArguments& args)
 {
 	auto id = args[0].integer;
@@ -596,7 +598,7 @@ bool game_vehicle_stopped(const ScriptArguments& args)
 	
 	if( vehicle )
 	{
-		return std::abs( vehicle->physVehicle->getCurrentSpeedKmHour() ) <= 0.01f;
+		return std::fabs(vehicle->getVelocity()) < kVehicleStoppedSpeed;
 	}
 	return false;
 }
@@ -660,7 +662,7 @@ bool game_character_stoped_in_volume_in_vehicle(const ScriptArguments& args)
 		if( pp.x >= min.x && pp.y >= min.y && pp.z >= min.z &&
 			pp.x <= max.x && pp.y <= max.y && pp.z <= max.z )
 		{
-			return character->getCurrentVehicle()->physVehicle->getCurrentSpeedKmHour() < 0.75f;
+			return std::fabs(character->getCurrentVehicle()->getVelocity()) < kVehicleStoppedSpeed;
 		}
 		
 		// Request the renderer draw a cylinder here.
@@ -692,7 +694,7 @@ bool game_character_stoped_in_volume(const ScriptArguments& args)
 	{
 		if( character->getCurrentVehicle() != nullptr )
 		{
-			return character->getCurrentVehicle()->physVehicle->getCurrentSpeedKmHour() < 0.75f;
+			return std::fabs(character->getCurrentVehicle()->getVelocity()) < kVehicleStoppedSpeed;
 		}
 		else
 		{
@@ -737,7 +739,7 @@ bool game_is_character_stopped(const ScriptArguments& args)
 	
 	if( character && character->getCurrentVehicle() != nullptr )
 	{
-		return character->getCurrentVehicle()->physVehicle->getCurrentSpeedKmHour() < 0.75f;
+		return std::fabs(character->getCurrentVehicle()->getVelocity()) < kVehicleStoppedSpeed;
 	}
 	
 	return true;
@@ -817,7 +819,7 @@ void game_get_speed(const ScriptArguments& args)
 	auto vehicle = static_cast<VehicleObject*>(args.getObject<VehicleObject>(0));
 	if( vehicle )
 	{
-		*args[1].globalReal = vehicle->physVehicle->getCurrentSpeedKmHour();
+		*args[1].globalReal = vehicle->getVelocity()*60.f*60.f*(1.f/1000.f);
 	}
 }
 

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -647,6 +647,10 @@ void RWGame::renderDebugStats(float time, Renderer::ProfileInfo& worldRenderTime
 			ss << "Idle";
 		}
 		ss << std::endl;
+		auto vehicle = player->getCharacter()->getCurrentVehicle();
+		if (vehicle) {
+			ss << "Velocity: " << (vehicle->getVelocity()/1000.f)*60*60 << " km/h\n";
+		}
 	}
 	
 	TextRenderer::TextInfo ti;

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -41,6 +41,7 @@ class RWGame
 	bool showDebugStats;
 	bool showDebugPaths;
 	bool showDebugPhysics;
+	bool showDebugSuspension;
 	int lastDraws; /// Number of draws issued for the last frame.
 
 	float accum;
@@ -139,6 +140,7 @@ private:
 	void renderDebugStats(float time, Renderer::ProfileInfo& worldRenderTime);
 	void renderDebugPaths(float time);
 	void renderProfile();
+	void renderSuspension();
 
 	void globalKeyEvent(const SDL_Event& event);
 };

--- a/rwgame/ingamestate.cpp
+++ b/rwgame/ingamestate.cpp
@@ -8,6 +8,7 @@
 #include <objects/CharacterObject.hpp>
 #include <objects/VehicleObject.hpp>
 #include <objects/ItemPickup.hpp>
+#include <dynamics/CollisionInstance.hpp>
 #include <data/Model.hpp>
 #include <items/WeaponItem.hpp>
 #include <engine/GameWorld.hpp>
@@ -166,7 +167,7 @@ void IngameState::tick(float dt)
 			lookTargetPosition = targetPosition;
 			lookTargetPosition.z += (vehicle->info->handling.dimensions.z * 0.5f);
 			targetPosition.z += (vehicle->info->handling.dimensions.z * 0.5f);
-			physTarget = vehicle->physBody;
+			physTarget = vehicle->collision->getBulletBody();
 
 			if (!m_vehicleFreeLook)
 			{

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ set(TEST_SOURCES
 	"test_weapon.cpp"
 	"test_worker.cpp"
 	"test_world.cpp"
+	"test_VehicleDynamics.cpp"
 
 	# Hack in rwgame sources until there's a per-target test suite
 	"${CMAKE_SOURCE_DIR}/rwgame/GameConfig.cpp"

--- a/tests/test_VehicleDynamics.cpp
+++ b/tests/test_VehicleDynamics.cpp
@@ -1,0 +1,45 @@
+#include <boost/test/unit_test.hpp>
+#include "test_globals.hpp"
+#include <dynamics/VehicleDynamics.hpp>
+#include <objects/VehicleObject.hpp>
+
+BOOST_AUTO_TEST_SUITE(VehicleDynamicsTests)
+
+BOOST_AUTO_TEST_CASE(test_wheels)
+{
+	VehicleDynamics dynamics(nullptr);
+	const glm::vec3 axle = glm::vec3(1.f, 0.f, 0.f);
+	const float radius = 0.25f;
+
+	dynamics.addWheel(glm::vec3( 1.f, 1.f, 0.f), axle, radius);
+	dynamics.addWheel(glm::vec3(-1.f, 1.f, 0.f), axle, radius);
+	dynamics.addWheel(glm::vec3( 1.f,-1.f, 0.f), axle, radius);
+	dynamics.addWheel(glm::vec3(-1.f,-1.f, 0.f), axle, radius);
+
+	BOOST_CHECK_EQUAL(4, dynamics.getWheels().size());
+
+	auto& wheels = dynamics.getWheels();
+	BOOST_CHECK_EQUAL(1.f, wheels[0].position.x);
+	BOOST_CHECK_EQUAL(1.f, wheels[0].position.y);
+
+	BOOST_CHECK_EQUAL(-1.f, wheels[3].position.x);
+	BOOST_CHECK_EQUAL(-1.f, wheels[3].position.y);
+}
+
+BOOST_AUTO_TEST_CASE(test_dynamics)
+{
+	VehicleObject* vehicle = Global::get().e->createVehicle(90u, glm::vec3(), glm::quat());
+
+	BOOST_REQUIRE(vehicle != nullptr);
+
+	BOOST_REQUIRE(vehicle->info != nullptr);
+	BOOST_REQUIRE(vehicle->vehicle != nullptr);
+
+	// We should have the vehicle rest on a surface
+	// but I can't be bothered to write that now.
+	// gg me rip
+
+	Global::get().e->destroyObject(vehicle);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_VehicleDynamics.cpp
+++ b/tests/test_VehicleDynamics.cpp
@@ -26,6 +26,7 @@ BOOST_AUTO_TEST_CASE(test_wheels)
 	BOOST_CHECK_EQUAL(-1.f, wheels[3].position.y);
 }
 
+#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_dynamics)
 {
 	VehicleObject* vehicle = Global::get().e->createVehicle(90u, glm::vec3(), glm::quat());
@@ -40,5 +41,6 @@ BOOST_AUTO_TEST_CASE(test_dynamics)
 
 	Global::get().e->destroyObject(vehicle);
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_VehicleDynamics.cpp
+++ b/tests/test_VehicleDynamics.cpp
@@ -11,10 +11,10 @@ BOOST_AUTO_TEST_CASE(test_wheels)
 	const glm::vec3 axle = glm::vec3(1.f, 0.f, 0.f);
 	const float radius = 0.25f;
 
-	dynamics.addWheel(glm::vec3( 1.f, 1.f, 0.f), axle, radius);
-	dynamics.addWheel(glm::vec3(-1.f, 1.f, 0.f), axle, radius);
-	dynamics.addWheel(glm::vec3( 1.f,-1.f, 0.f), axle, radius);
-	dynamics.addWheel(glm::vec3(-1.f,-1.f, 0.f), axle, radius);
+	dynamics.addWheel(glm::vec3( 1.f, 1.f, 0.f), axle, radius, 1.f);
+	dynamics.addWheel(glm::vec3(-1.f, 1.f, 0.f), axle, radius, 1.f);
+	dynamics.addWheel(glm::vec3( 1.f,-1.f, 0.f), axle, radius, 1.f);
+	dynamics.addWheel(glm::vec3(-1.f,-1.f, 0.f), axle, radius, 1.f);
 
 	BOOST_CHECK_EQUAL(4, dynamics.getWheels().size());
 
@@ -35,9 +35,8 @@ BOOST_AUTO_TEST_CASE(test_dynamics)
 	BOOST_REQUIRE(vehicle->info != nullptr);
 	BOOST_REQUIRE(vehicle->vehicle != nullptr);
 
-	// We should have the vehicle rest on a surface
-	// but I can't be bothered to write that now.
-	// gg me rip
+	// This should test acceleration and handling versus some
+	// ground truth, but no data yet.
 
 	Global::get().e->destroyObject(vehicle);
 }

--- a/tests/test_vehicle.cpp
+++ b/tests/test_vehicle.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(test_door_position)
 	BOOST_REQUIRE(vehicle->info != nullptr);
 	BOOST_REQUIRE(vehicle->vehicle != nullptr);
 
-	BOOST_CHECK( vehicle->getSeatEntryPosition(0).x > 5.f );
+	BOOST_CHECK( vehicle->getSeatEntryPositionWorld(0).x > 5.f );
 
 
 	Global::get().e->destroyObject(vehicle);


### PR DESCRIPTION
This cleans up some usage of bullet within vehicles and instances, and introduces a new vehicle physics implementation in VehicleDynamics.

VehicleDynamics replaces btRaycastVehicle giving finer control over the behaviour. It's still far from being correct and seems way too bouncy, but we can iterate on this with something to compare it against.

To Fix:
- [ ] Everything is wobbly for some people
- [ ] Exit a vehicle & accelerate, stop accelerating -> brakes will still be applied when entering.