### PR TITLE
Use RGBA for screenshots to use 4-byte row alignment

### DIFF
--- a/rwengine/src/render/OpenGLRenderer.cpp
+++ b/rwengine/src/render/OpenGLRenderer.cpp
@@ -422,8 +422,8 @@ void OpenGLRenderer::invalidate()
 
 unsigned char* OpenGLRenderer::readPixels(const glm::ivec2& size) const
 {
-	unsigned char* buffer = new unsigned char[size.x * size.y * 3];
-	glReadPixels(0, 0, size.x, size.y, GL_RGB, GL_UNSIGNED_BYTE, buffer);
+	unsigned char* buffer = new unsigned char[size.x * size.y * 4];
+	glReadPixels(0, 0, size.x, size.y, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
 
 	return buffer;
 }

--- a/rwgame/GameWindow.cpp
+++ b/rwgame/GameWindow.cpp
@@ -76,14 +76,14 @@ void GameWindow::captureToFile(const std::string& path, GameRenderer* renderer)
 		} }, { [](png_structp) { } } );
 
 	auto size = getSize();
-	png_set_IHDR(png_ptr, info_ptr, size.x, size.y, 8, PNG_COLOR_TYPE_RGB,
+	png_set_IHDR(png_ptr, info_ptr, size.x, size.y, 8, PNG_COLOR_TYPE_RGBA,
 		PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_BASE, PNG_FILTER_TYPE_BASE);
 
 	png_write_info(png_ptr, info_ptr);
 
 	unsigned char* buffer = renderer->getRenderer()->readPixels(size);
 	for (int y = size.y-1; y >= 0; y--)
-		png_write_row(png_ptr, &buffer[y * size.x * 3]);
+		png_write_row(png_ptr, &buffer[y * size.x * 4]);
 
 	png_write_end(png_ptr, nullptr);
 	png_destroy_write_struct(&png_ptr, &info_ptr);


### PR DESCRIPTION
On my screen resolution `1366x768` the default 4-byte alignment of `GL_PACK_ALIGNMENT` causes glReadPixels to not work as expected for RGB output. Save RGBA instead to ensure that rows are always 4-byte aligned,