### PR TITLE
MotionStates & physics cleanup

### DIFF
--- a/rwengine/include/dynamics/CollisionInstance.hpp
+++ b/rwengine/include/dynamics/CollisionInstance.hpp
@@ -11,16 +11,17 @@ struct DynamicObjectData;
 struct VehicleHandlingInfo;
 
 /**
- * @brief Utility object for managing bullet objects.
- *
- * Stores handles to a btRigidBody and a set of collision shapes
+ * @brief CollisionInstance stores bullet body information
  */
 class CollisionInstance
 {
 public:
 
 	CollisionInstance()
-		: body(nullptr), vertArray(nullptr), motionState(nullptr), collisionHeight(0.f)
+		: m_body(nullptr)
+		, m_vertArray(nullptr)
+		, m_motionState(nullptr)
+		, m_collisionHeight(0.f)
 	{ }
 
 	~CollisionInstance();
@@ -30,12 +31,19 @@ public:
 						   DynamicObjectData* dynamics = nullptr,
 						   VehicleHandlingInfo* handling = nullptr);
 
-	btRigidBody* body;
-	std::vector<btCollisionShape*> shapes;
-	btTriangleIndexVertexArray* vertArray;
-	btMotionState* motionState;
+	btRigidBody *getBulletBody() const { return m_body; }
 
-	float collisionHeight;
+	float getBoundingHeight() const { return m_collisionHeight; }
+
+	void changeMass(float newMass);
+
+private:
+	btRigidBody* m_body;
+	std::vector<btCollisionShape*> m_shapes;
+	btTriangleIndexVertexArray* m_vertArray;
+	btMotionState* m_motionState;
+
+	float m_collisionHeight;
 
 };
 

--- a/rwengine/include/engine/GameWorld.hpp
+++ b/rwengine/include/engine/GameWorld.hpp
@@ -245,32 +245,6 @@ public:
 	GameObject *getBlipTarget(const BlipData &blip) const;
 
 	/**
-	 * Stores objects within a grid cell, and their maximum
-	 * bounding radius
-	 */
-	struct GridCell
-	{
-		/**
-		 * Static instances within this grid cell
-		 */
-		std::set<GameObject*> instances;
-		float boundingRadius = 0.f;
-	};
-	std::array<GridCell, WORLD_GRID_CELLS> worldGrid;
-
-	/**
-	 * returns true if the given object should be stored
-	 * within the grid
-	 */
-	bool shouldBeOnGrid(GameObject* object);
-	void addToGrid(GameObject* object);
-
-	/**
-	 * Returns the grid coordinates for a world coordinates
-	 */
-	glm::ivec2 worldToGrid(const glm::vec2& world);
-
-	/**
 	 * Map of Model Names to Instances
 	 */
 	std::map<std::string, InstanceObject*> modelInstances;

--- a/rwengine/include/objects/CharacterObject.hpp
+++ b/rwengine/include/objects/CharacterObject.hpp
@@ -158,14 +158,12 @@ public:
 
 	virtual void setPosition(const glm::vec3& pos);
 
-	virtual glm::vec3 getPosition() const;
-
-	virtual glm::quat getRotation() const;
-
 	bool isAlive() const;
 	bool takeDamage(const DamageInfo& damage) override;
 
 	bool enterVehicle(VehicleObject* vehicle, size_t seat);
+
+	bool isEnteringOrExitingVehicle() const;
 
 	/**
 	 * @brief isStopped

--- a/rwengine/include/objects/GameObject.hpp
+++ b/rwengine/include/objects/GameObject.hpp
@@ -98,10 +98,10 @@ public:
 	
 	virtual void setPosition(const glm::vec3& pos);
 
-	virtual glm::vec3 getPosition() const { return position; }
+	const glm::vec3& getPosition() const { return position; }
 	const glm::vec3& getLastPosition() const { return _lastPosition; }
 
-	virtual glm::quat getRotation() const;
+	const glm::quat& getRotation() const { return rotation; }
 	virtual void setRotation(const glm::quat &orientation);
 
 	float getHeading() const;
@@ -185,7 +185,15 @@ public:
 	
 	void setLifetime(ObjectLifetime ol) { lifetime = ol; }
 	ObjectLifetime getLifetime() const { return lifetime; }
-	
+
+	void updateTransform(const glm::vec3& pos, const glm::quat& rot)
+	{
+		_lastPosition = position;
+		_lastRotation = rotation;
+		position = pos;
+		rotation = rot;
+	}
+
 private:
 	ObjectLifetime lifetime;
 };

--- a/rwengine/include/objects/InstanceObject.hpp
+++ b/rwengine/include/objects/InstanceObject.hpp
@@ -31,9 +31,6 @@ public:
 
 	void changeModel(std::shared_ptr<ObjectData> incoming);
 
-	glm::vec3 getPosition() const override;
-	glm::quat getRotation() const override;
-
 	virtual void setRotation(const glm::quat& r);
 	
 	virtual bool takeDamage(const DamageInfo& damage);

--- a/rwengine/include/objects/VehicleObject.hpp
+++ b/rwengine/include/objects/VehicleObject.hpp
@@ -4,7 +4,13 @@
 #include <objects/GameObject.hpp>
 #include <map>
 #include <objects/VehicleInfo.hpp>
-#include <dynamics/CollisionInstance.hpp>
+
+class CollisionInstance;
+class btVehicleRaycaster;
+class btRaycastVehicle;
+class btRigidBody;
+class btHingeConstraint;
+class btTransform;
 
 /**
  * @class VehicleObject
@@ -27,8 +33,7 @@ public:
 	std::map<size_t, GameObject*> seatOccupants;
 
 	CollisionInstance* collision;
-	btRigidBody* physBody;
-	btVehicleRaycaster* physRaycaster = nullptr;
+	btVehicleRaycaster* physRaycaster;
 	btRaycastVehicle* physVehicle;
 	
 	struct Part
@@ -143,21 +148,6 @@ private:
 	void registerPart(ModelFrame* mf);
 	void createObjectHinge(btTransform &local, Part* part);
 	void destroyObjectHinge(Part* part);
-};
-
-/**
- * Implements vehicle ray casting behaviour.
- * i.e. ignore the god damn vehicle body when casting rays.
- */
-class VehicleRaycaster : public btVehicleRaycaster
-{
-	btDynamicsWorld* _world;
-	VehicleObject* _vehicle;
-public:
-	VehicleRaycaster(VehicleObject* vehicle, btDynamicsWorld* world)
-		: _world(world), _vehicle(vehicle) {}
-
-	void* castRay(const btVector3 &from, const btVector3 &to, btVehicleRaycasterResult &result);
 };
 
 #endif

--- a/rwengine/include/objects/VehicleObject.hpp
+++ b/rwengine/include/objects/VehicleObject.hpp
@@ -145,7 +145,7 @@ public:
 private:
 
 	void registerPart(ModelFrame* mf);
-	void createObjectHinge(btTransform &local, Part* part);
+	void createObjectHinge(Part* part);
 	void destroyObjectHinge(Part* part);
 };
 

--- a/rwengine/include/objects/VehicleObject.hpp
+++ b/rwengine/include/objects/VehicleObject.hpp
@@ -57,11 +57,7 @@ public:
 	
 	void setPosition(const glm::vec3& pos);
 
-	glm::vec3 getPosition() const;
-
 	void setRotation(const glm::quat &orientation);
-
-	glm::quat getRotation() const;
 
 	Type type() { return Vehicle; }
 
@@ -111,7 +107,10 @@ public:
 	glm::vec3 getSeatEntryPosition(size_t seat) const {
 		auto pos = info->seats[seat].offset;
 		pos -= glm::vec3(glm::sign(pos.x) * -0.81756252f, 0.34800607f, -0.486281008f);
-		return getPosition() + getRotation() * pos;
+		return pos;
+	}
+	glm::vec3 getSeatEntryPositionWorld(size_t seat) const {
+		return getPosition() + getRotation() * getSeatEntryPosition(seat);
 	}
 	
 	Part* getSeatEntryDoor(size_t seat);

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -207,7 +207,7 @@ bool Activities::EnterVehicle::update(CharacterObject *character, CharacterContr
 		float nearest = std::numeric_limits<float>::max();
 		for(unsigned int s = 1; s < vehicle->info->seats.size(); ++s)
 		{
-			auto entry = vehicle->getSeatEntryPosition(s);
+			auto entry = vehicle->getSeatEntryPositionWorld(s);
 			float dist = glm::distance(entry, character->getPosition());
 			if( dist < nearest )
 			{
@@ -218,6 +218,7 @@ bool Activities::EnterVehicle::update(CharacterObject *character, CharacterContr
 	}
 	
 	auto entryDoor = vehicle->getSeatEntryDoor(seat);
+	auto entryPos = vehicle->getSeatEntryPositionWorld(seat);
 
 	auto anm_open = character->animations.car_open_lhs;
 	auto anm_enter = character->animations.car_getin_lhs;
@@ -262,8 +263,7 @@ bool Activities::EnterVehicle::update(CharacterObject *character, CharacterContr
 		}
 	}
 	else {
-		glm::vec3 target = vehicle->getSeatEntryPosition(seat);
-		glm::vec3 targetDirection = target - character->getPosition();
+		glm::vec3 targetDirection = entryPos - character->getPosition();
 		targetDirection.z = 0.f;
 
 		float targetDistance = glm::length(targetDirection);
@@ -387,7 +387,7 @@ bool Activities::ExitVehicle::update(CharacterObject *character, CharacterContro
 
 	if( character->animator->getAnimation(AnimIndexAction) == anm_exit ) {
 		if( character->animator->isCompleted(AnimIndexAction) ) {
-			auto exitpos = vehicle->getSeatEntryPosition(seat);
+			auto exitpos = vehicle->getSeatEntryPositionWorld(seat);
 
 			character->enterVehicle(nullptr, seat);
 			character->setPosition(exitpos);

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -1,6 +1,7 @@
 #include <ai/CharacterController.hpp>
 #include <objects/CharacterObject.hpp>
 #include <objects/VehicleObject.hpp>
+#include <BulletDynamics/btBulletDynamicsCommon.h>
 
 #include <data/Model.hpp>
 #include <engine/Animator.hpp>

--- a/rwengine/src/dynamics/CollisionInstance.cpp
+++ b/rwengine/src/dynamics/CollisionInstance.cpp
@@ -6,23 +6,23 @@
 
 CollisionInstance::~CollisionInstance()
 {
-	if( body ) {
-		GameObject* object = static_cast<GameObject*>(body->getUserPointer());
+	if( m_body ) {
+		GameObject* object = static_cast<GameObject*>(m_body->getUserPointer());
 
 		// Remove body from existance.
-		object->engine->dynamicsWorld->removeRigidBody(body);
+		object->engine->dynamicsWorld->removeRigidBody(m_body);
 		
-		for(btCollisionShape* shape : shapes) {
+		for(btCollisionShape* shape : m_shapes) {
 			delete shape;
 		}
 		
-		delete body;
+		delete m_body;
 	}
-	if( vertArray ) {
-		delete vertArray;
+	if( m_vertArray ) {
+		delete m_vertArray;
 	}
-	if( motionState ) {
-		delete motionState;
+	if( m_motionState ) {
+		delete m_motionState;
 	}
 }
 
@@ -35,14 +35,14 @@ bool CollisionInstance::createPhysicsBody(GameObject *object, const std::string&
 		auto p = object->getPosition();
 		auto r = object->getRotation();
 
-		motionState = new btDefaultMotionState;
-		motionState->setWorldTransform(btTransform(
+		m_motionState = new btDefaultMotionState;
+		m_motionState->setWorldTransform(btTransform(
 									btQuaternion(r.x, r.y, r.z, -r.w).inverse(),
 									btVector3(p.x, p.y, p.z)
 									));
-		shapes.push_back(cmpShape);
+		m_shapes.push_back(cmpShape);
 
-		btRigidBody::btRigidBodyConstructionInfo info(0.f, motionState, cmpShape);
+		btRigidBody::btRigidBodyConstructionInfo info(0.f, m_motionState, cmpShape);
 
 		CollisionModel& physInst = *phyit->second.get();
 
@@ -62,7 +62,7 @@ bool CollisionInstance::createPhysicsBody(GameObject *object, const std::string&
 			colMin = std::min(colMin, mid.z - size.z);
 			colMax = std::max(colMax, mid.z + size.z);
 
-			shapes.push_back(bshape);
+			m_shapes.push_back(bshape);
 		}
 
 		// Spheres
@@ -76,26 +76,26 @@ bool CollisionInstance::createPhysicsBody(GameObject *object, const std::string&
 			colMin = std::min(colMin, sphere.center.z - sphere.radius);
 			colMax = std::max(colMax, sphere.center.z + sphere.radius);
 
-			shapes.push_back(sshape);
+			m_shapes.push_back(sshape);
 		}
 
 		if( physInst.vertices.size() > 0 && physInst.indices.size() >= 3 ) {
-			vertArray = new btTriangleIndexVertexArray(
+			m_vertArray = new btTriangleIndexVertexArray(
 						physInst.indices.size()/3,
 						(int*) physInst.indices.data(),
 						sizeof(uint32_t)*3,
 						physInst.vertices.size(),
 						&(physInst.vertices[0].x),
 					sizeof(glm::vec3));
-			btBvhTriangleMeshShape* trishape = new btBvhTriangleMeshShape(vertArray, false);
+			btBvhTriangleMeshShape* trishape = new btBvhTriangleMeshShape(m_vertArray, false);
 			trishape->setMargin(0.05f);
 			btTransform t; t.setIdentity();
 			cmpShape->addChildShape(t, trishape);
 
-			shapes.push_back(trishape);
+			m_shapes.push_back(trishape);
 		}
 
-		collisionHeight = colMax - colMin;
+		m_collisionHeight = colMax - colMin;
 
 		if( dynamics ) {
 			if( dynamics->uprootForce > 0.f ) {
@@ -115,12 +115,12 @@ bool CollisionInstance::createPhysicsBody(GameObject *object, const std::string&
 			info.m_localInertia = inert;
 		}
 
-		body = new btRigidBody(info);
-		body->setUserPointer(object);
-		object->engine->dynamicsWorld->addRigidBody(body);
+		m_body = new btRigidBody(info);
+		m_body->setUserPointer(object);
+		object->engine->dynamicsWorld->addRigidBody(m_body);
 
 		if( dynamics && dynamics->uprootForce > 0.f ) {
-			body->setCollisionFlags(body->getCollisionFlags()
+			m_body->setCollisionFlags(m_body->getCollisionFlags()
 									| btCollisionObject::CF_CUSTOM_MATERIAL_CALLBACK);
 		}
 	}
@@ -130,4 +130,15 @@ bool CollisionInstance::createPhysicsBody(GameObject *object, const std::string&
 	}
 
 	return true;
+}
+
+void CollisionInstance::changeMass(float newMass)
+{
+	GameObject* object = static_cast<GameObject*>(m_body->getUserPointer());
+	auto dynamicsWorld = object->engine->dynamicsWorld;
+	dynamicsWorld->removeRigidBody(m_body);
+	btVector3 inert;
+	m_body->getCollisionShape()->calculateLocalInertia(newMass, inert);
+	m_body->setMassProps(newMass, inert);
+	dynamicsWorld->addRigidBody(m_body);
 }

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -209,11 +209,6 @@ InstanceObject *GameWorld::createInstance(const uint16_t id, const glm::vec3& po
 		instancePool.insert(instance);
         allObjects.push_back(instance);
 
-		if( shouldBeOnGrid(instance) )
-		{
-			addToGrid( instance );
-		}
-
 		modelInstances.insert({
 			oi->modelName,
 			instance
@@ -578,14 +573,6 @@ GameObject*GameWorld::getBlipTarget(const BlipData& blip) const
 
 void GameWorld::destroyObject(GameObject* object)
 {
-	auto coord = worldToGrid(glm::vec2(object->getPosition()));
-	if( coord.x < 0 || coord.y < 0 || coord.x >= WORLD_GRID_WIDTH || coord.y >= WORLD_GRID_WIDTH )
-	{
-		return;
-	}
-	auto index = (coord.x * WORLD_GRID_WIDTH) + coord.y;
-	worldGrid[index].instances.erase(object);
-	
 	auto& pool = getTypeObjectPool(object);
 	pool.remove(object);
 
@@ -611,42 +598,6 @@ void GameWorld::destroyQueuedObjects()
 		destroyObject( *deletionQueue.begin() );
 		deletionQueue.erase( deletionQueue.begin() );
 	}
-}
-
-bool GameWorld::shouldBeOnGrid(GameObject* object)
-{
-	if( object->type() != GameObject::Instance )
-	{
-		// Only static instances currently.
-		return false;
-	}
-	auto instance = static_cast<InstanceObject*>(object);
-	return instance->body == nullptr || instance->body->body->isStaticObject();
-}
-
-void GameWorld::addToGrid(GameObject* object)
-{
-	auto coord = worldToGrid(glm::vec2(object->getPosition()));
-	if( coord.x < 0 || coord.y < 0 || coord.x >= WORLD_GRID_WIDTH || coord.y >= WORLD_GRID_WIDTH )
-	{
-		return;
-	}
-	auto index = (coord.x * WORLD_GRID_WIDTH) + coord.y;
-	worldGrid[index].instances.insert(object);
-	if( object->model->resource )
-	{
-		float cellhalf = WORLD_CELL_SIZE/2.f;
-		auto world = glm::vec3(glm::vec2(coord) * glm::vec2(WORLD_CELL_SIZE) - glm::vec2(WORLD_GRID_SIZE/2.f) + glm::vec2(cellhalf), 0.f);
-		auto offset = world - object->getPosition();
-		float maxRadius = glm::length(offset) + object->model->resource->getBoundingRadius();
-		worldGrid[index].boundingRadius = std::max(worldGrid[index].boundingRadius, maxRadius);
-	}
-}
-
-glm::ivec2 GameWorld::worldToGrid(const glm::vec2& world)
-{
-	static const float lowerCoord = -(WORLD_GRID_SIZE)/2.f;
-	return glm::ivec2((world - glm::vec2(lowerCoord)) / glm::vec2(WORLD_CELL_SIZE));
 }
 
 VisualFX* GameWorld::createEffect(VisualFX::EffectType type)

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -316,8 +316,6 @@ void CharacterObject::updateCharacter(float dt)
 	if(physCharacter) {
 		glm::vec3 walkDir = updateMovementAnimation(dt);
 
-		position = getPosition();
-
 		if (canTurn()) {
 			rotation = glm::angleAxis(m_look.x, glm::vec3{0.f, 0.f, 1.f});
 		}
@@ -399,39 +397,6 @@ void CharacterObject::setPosition(const glm::vec3& pos)
 	position = pos;
 }
 
-glm::vec3 CharacterObject::getPosition() const
-{
-	if(physCharacter) {
-		btVector3 Pos = physCharacter->getGhostObject()->getWorldTransform().getOrigin();
-		return glm::vec3(Pos.x(), Pos.y(), Pos.z());
-	}
-	if(currentVehicle) {
-		/// @todo this is hacky.
-		if( animator->getAnimation(AnimIndexAction) == animations.car_getout_lhs ) {
-			return currentVehicle->getSeatEntryPosition(currentSeat);
-		}
-
-		auto v = getCurrentVehicle();
-		auto R = glm::mat3_cast(v->getRotation());
-		glm::vec3 offset;
-		auto o = (animator->getAnimation(AnimIndexAction) == animations.car_getin_lhs) ? enter_offset : glm::vec3();
-		if(getCurrentSeat() < v->info->seats.size()) {
-			offset = R * (v->info->seats[getCurrentSeat()].offset -
-					o);
-		}
-		return currentVehicle->getPosition() + offset;
-	}
-	return position;
-}
-
-glm::quat CharacterObject::getRotation() const
-{
-	if(currentVehicle) {
-		return currentVehicle->getRotation();
-	}
-	return GameObject::getRotation();
-}
-
 bool CharacterObject::isAlive() const
 {
 	return currentState.health > 0.f;
@@ -463,6 +428,12 @@ bool CharacterObject::enterVehicle(VehicleObject* vehicle, size_t seat)
 		}
 	}
 	return false;
+}
+
+bool CharacterObject::isEnteringOrExitingVehicle() const
+{
+	return animator->getAnimation(AnimIndexAction) == animations.car_getout_lhs ||
+			animator->getAnimation(AnimIndexAction) == animations.car_getin_lhs;
 }
 
 bool CharacterObject::isStopped() const

--- a/rwengine/src/objects/GameObject.cpp
+++ b/rwengine/src/objects/GameObject.cpp
@@ -23,11 +23,6 @@ void GameObject::setPosition(const glm::vec3& pos)
 	_lastPosition = position = pos;
 }
 
-glm::quat GameObject::getRotation() const
-{
-	return rotation;
-}
-
 void GameObject::setRotation(const glm::quat& orientation)
 {
 	rotation = orientation;

--- a/rwengine/src/objects/InstanceObject.cpp
+++ b/rwengine/src/objects/InstanceObject.cpp
@@ -49,12 +49,8 @@ void InstanceObject::tick(float dt)
 				body->changeMass(dynamics->mass);
 			}
 		}
-		
-		_updateLastTransform();
 
-		/// @todo replace with position from motionstate
-		auto _bws = body->getBulletBody()->getWorldTransform().getOrigin();
-		glm::vec3 ws(_bws.x(), _bws.y(), _bws.z());
+		const glm::vec3& ws = getPosition();
 		auto wX = (int) ((ws.x + WATER_WORLD_SIZE/2.f) / (WATER_WORLD_SIZE/WATER_HQ_DATA_SIZE));
 		auto wY = (int) ((ws.y + WATER_WORLD_SIZE/2.f) / (WATER_WORLD_SIZE/WATER_HQ_DATA_SIZE));
 		float vH = ws.z;// - _collisionHeight/2.f;
@@ -134,16 +130,6 @@ void InstanceObject::changeModel(std::shared_ptr<ObjectData> incoming)
 			body = bod;
 		}
 	}
-}
-
-glm::vec3 InstanceObject::getPosition() const
-{
-	return position;
-}
-
-glm::quat InstanceObject::getRotation() const
-{
-	return rotation;
 }
 
 void InstanceObject::setRotation(const glm::quat &r)

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -1,6 +1,7 @@
 #include <objects/VehicleObject.hpp>
 #include <objects/CharacterObject.hpp>
 #include <engine/GameWorld.hpp>
+#include <dynamics/CollisionInstance.hpp>
 #include <BulletDynamics/Vehicle/btRaycastVehicle.h>
 #include <dynamics/RaycastCallbacks.hpp>
 #include <data/CollisionModel.hpp>
@@ -12,15 +13,56 @@
 #define PART_CLOSE_VELOCITY 0.25f
 constexpr float kVehicleMaxExitVelocity = 0.15f;
 
+/**
+ * A raycaster that will ignore the body of the vehicle when casting rays
+ */
+class VehicleRaycaster : public btVehicleRaycaster
+{
+	btDynamicsWorld* _world;
+	VehicleObject* _vehicle;
+public:
+	VehicleRaycaster(VehicleObject* vehicle, btDynamicsWorld* world)
+		: _world(world), _vehicle(vehicle) {}
+
+	void* castRay(const btVector3 &from, const btVector3 &to, btVehicleRaycasterResult &result)
+	{
+		ClosestNotMeRayResultCallback rayCallback( _vehicle->collision->getBulletBody(), from, to );
+		const void *res = 0;
+
+		_world->rayTest(from, to, rayCallback);
+
+		if( rayCallback.hasHit() ) {
+			const btRigidBody* body = btRigidBody::upcast( rayCallback.m_collisionObject );
+
+			if( body && body->hasContactResponse() ) {
+				result.m_hitPointInWorld = rayCallback.m_hitPointWorld;
+				result.m_hitNormalInWorld = rayCallback.m_hitNormalWorld;
+				result.m_hitNormalInWorld.normalize();
+				result.m_distFraction = rayCallback.m_closestHitFraction;
+				res = body;
+			}
+		}
+
+		return (void* )res;
+	}
+};
+
 VehicleObject::VehicleObject(GameWorld* engine, const glm::vec3& pos, const glm::quat& rot, const ModelRef& model, VehicleDataHandle data, VehicleInfoHandle info, const glm::u8vec3& prim, const glm::u8vec3& sec)
-	: GameObject(engine, pos, rot, model),
-	  steerAngle(0.f), throttle(0.f), brake(0.f), handbrake(true),
-	  vehicle(data), info(info), colourPrimary(prim),
-	  colourSecondary(sec), collision(nullptr), physBody(nullptr), physVehicle(nullptr)
+	: GameObject(engine, pos, rot, model)
+	, steerAngle(0.f)
+	, throttle(0.f)
+	, brake(0.f)
+	, handbrake(true)
+	, vehicle(data)
+	, info(info)
+	, colourPrimary(prim)
+	, colourSecondary(sec)
+	, collision(nullptr)
+	, physRaycaster(nullptr)
+	, physVehicle(nullptr)
 {
 	collision = new CollisionInstance;
 	if( collision->createPhysicsBody(this, data->modelName, nullptr, &info->handling) ) {
-		physBody = collision->body;
 
 		physRaycaster = new VehicleRaycaster(this, engine->dynamicsWorld);
 		btRaycastVehicle::btVehicleTuning tuning;
@@ -29,7 +71,7 @@ VehicleObject::VehicleObject(GameWorld* engine, const glm::vec3& pos, const glm:
 		tuning.m_frictionSlip = 3.f;
 		tuning.m_maxSuspensionTravelCm = travel * 100.f;
 
-		physVehicle = new btRaycastVehicle(tuning, physBody, physRaycaster);
+		physVehicle = new btRaycastVehicle(tuning, collision->getBulletBody(), physRaycaster);
 		physVehicle->setCoordinateSystem(0, 2, 1);
 		//physBody->setActivationState(DISABLE_DEACTIVATION);
 		engine->dynamicsWorld->addAction(physVehicle);
@@ -103,49 +145,43 @@ VehicleObject::~VehicleObject()
 void VehicleObject::setPosition(const glm::vec3& pos)
 {
 	GameObject::setPosition(pos);
-	if( physBody ) {
-		// Move each active part
+	if( collision->getBulletBody() ) {
+		auto bodyOrigin = btVector3(position.x, position.y, position.z);
 		for(auto& part : dynamicParts)
 		{
 			if( part.second.body == nullptr ) continue;
 			auto body = part.second.body;
-			auto rel = body->getWorldTransform().getOrigin()
-				- physBody->getWorldTransform().getOrigin();
+			auto rel = body->getWorldTransform().getOrigin() -
+					bodyOrigin;
 			body->getWorldTransform().setOrigin(
 				btVector3(pos.x + rel.x(), pos.y + rel.y(), pos.z + rel.z()));
 		}
 
-		auto t = physBody->getWorldTransform();
+		auto t = collision->getBulletBody()->getWorldTransform();
 		t.setOrigin(btVector3(pos.x, pos.y, pos.z));
-		physBody->setWorldTransform(t);
+		collision->getBulletBody()->setWorldTransform(t);
 	}
 }
 
 glm::vec3 VehicleObject::getPosition() const
 {
-	if( physBody ) {
-		btVector3 Pos = physBody->getWorldTransform().getOrigin();
-		return glm::vec3(Pos.x(), Pos.y(), Pos.z());
-	}
+	/// @todo update our position from the motion state
 	return position;
 }
 
 void VehicleObject::setRotation(const glm::quat &orientation)
 {
-	if( physBody ) {
-		auto t = physBody->getWorldTransform();
+	if( collision->getBulletBody() ) {
+		auto t = collision->getBulletBody()->getWorldTransform();
 		t.setRotation(btQuaternion(orientation.x, orientation.y, orientation.z, orientation.w));
-		physBody->setWorldTransform(t);
+		collision->getBulletBody()->setWorldTransform(t);
 	}
 	GameObject::setRotation(orientation);
 }
 
 glm::quat VehicleObject::getRotation() const
 {
-	if(physVehicle) {
-		btQuaternion rot = physVehicle->getChassisWorldTransform().getRotation();
-		return glm::quat(rot.w(), rot.x(), rot.y(), rot.z());
-	}
+	/// @todo update our rotation from the motion state
 	return rotation;
 }
 
@@ -166,8 +202,10 @@ void VehicleObject::tickPhysics(float dt)
 		// todo: a real engine function
 		float velFac = info->handling.maxVelocity;
 		float engineForce = info->handling.acceleration * throttle * velFac;
-		if( fabs(engineForce) >= 0.001f ) physBody->activate(true);
-		
+		if (fabs(engineForce) >= 0.001f) {
+			collision->getBulletBody()->activate(true);
+		}
+
 		float brakeF = getBraking();
 		
 		if( handbrake )
@@ -198,10 +236,11 @@ void VehicleObject::tickPhysics(float dt)
 			if( isInWater() ) {
 				float sign = std::signbit(steerAngle) ? -1.f : 1.f;
 				float steer = std::min(info->handling.steeringLock*(3.141f/180.f), std::abs(steerAngle)) * sign;
-				auto orient = physBody->getOrientation();
+				/// @todo get orientation from motion state
+				auto orient = collision->getBulletBody()->getOrientation();
 
 				// Find the local-space velocity
-				auto velocity = physBody->getLinearVelocity();
+				auto velocity = collision->getBulletBody()->getLinearVelocity();
 				velocity = velocity.rotate(-orient.getAxis(), orient.getAngle());
 
 				// Rudder force is proportional to velocity.
@@ -210,19 +249,19 @@ void VehicleObject::tickPhysics(float dt)
 						.rotate(orient.getAxis(), orient.getAngle());
 				btVector3 rudderPoint = btVector3(0.f, -info->handling.dimensions.y/2.f, 0.f)
 						.rotate(orient.getAxis(), orient.getAngle());
-				physBody->applyForce(
+				collision->getBulletBody()->applyForce(
 							rForce,
 							rudderPoint);
 
 				btVector3 rudderVector = btVector3(0.f, 1.f, 0.f)
 						.rotate(orient.getAxis(), orient.getAngle());
-				physBody->applyForce(
+				collision->getBulletBody()->applyForce(
 							rudderVector * engineForce * 100.f,
 							rudderPoint);
 
 
 				btVector3 dampforce( 10000.f * velocity.x(), velocity.y() * 100.f, 0.f );
-				physBody->applyCentralForce(-dampforce.rotate(orient.getAxis(), orient.getAngle()));
+				collision->getBulletBody()->applyCentralForce(-dampforce.rotate(orient.getAxis(), orient.getAngle()));
 			}
 		}
 
@@ -231,7 +270,7 @@ void VehicleObject::tickPhysics(float dt)
 		auto wY = (int) ((ws.y + WATER_WORLD_SIZE/2.f) / (WATER_WORLD_SIZE/WATER_HQ_DATA_SIZE));
 		btVector3 bbmin, bbmax;
 		// This is in world space.
-		physBody->getAabb(bbmin, bbmax);
+		collision->getBulletBody()->getAabb(bbmin, bbmax);
 		float vH = bbmin.z();
 		float wH = 0.f;
 
@@ -266,9 +305,9 @@ void VehicleObject::tickPhysics(float dt)
 
 		if( inWater ) {
 			// Ensure that vehicles don't fall asleep at the top of a wave.
-			if(! physBody->isActive() )
+			if(! collision->getBulletBody()->isActive() )
 			{
-				physBody->activate(true);
+				collision->getBulletBody()->activate(true);
 			}
 			
 			float bbZ = info->handling.dimensions.z/2.f;
@@ -278,7 +317,7 @@ void VehicleObject::tickPhysics(float dt)
 
 			if( vehicle->type != VehicleData::BOAT ) {
 				// Damper motion
-				physBody->setDamping(0.95f, 0.9f);
+				collision->getBulletBody()->setDamping(0.95f, 0.9f);
 			}
 
 			if( vehicle->type == VehicleData::BOAT ) {
@@ -305,10 +344,10 @@ void VehicleObject::tickPhysics(float dt)
 		}
 		else {
 			if( vehicle->type == VehicleData::BOAT ) {
-				physBody->setDamping(0.1f, 0.8f);
+				collision->getBulletBody()->setDamping(0.1f, 0.8f);
 			}
 			else {
-				physBody->setDamping(0.05f, 0.0f);
+				collision->getBulletBody()->setDamping(0.05f, 0.0f);
 			}
 		}
 
@@ -539,8 +578,9 @@ void VehicleObject::applyWaterFloat(const glm::vec3 &relPt)
 
 		if ( ws.z <= h ) {
 			float x = (h - ws.z);
-			float F = WATER_BUOYANCY_K * x + -WATER_BUOYANCY_C * physBody->getLinearVelocity().z();
-			physBody->applyImpulse(btVector3(0.f, 0.f, F),
+			float F = WATER_BUOYANCY_K * x +
+					-WATER_BUOYANCY_C * collision->getBulletBody()->getLinearVelocity().z();
+			collision->getBulletBody()->applyImpulse(btVector3(0.f, 0.f, F),
 								 btVector3(relPt.x, relPt.y, relPt.z));
 		}
 	}
@@ -550,7 +590,7 @@ void VehicleObject::setPartLocked(VehicleObject::Part* part, bool locked)
 {
 	if( part->body == nullptr && locked == false )
 	{
-		createObjectHinge(physBody->getWorldTransform(), part);
+		createObjectHinge(collision->getBulletBody()->getWorldTransform(), part);
 	}
 	else if( part->body != nullptr && locked == true )
 	{
@@ -711,7 +751,7 @@ void VehicleObject::createObjectHinge(btTransform& local, Part *part)
 	subObject->setUserPointer(this);
 
 	auto hinge = new btHingeConstraint(
-				*physBody,
+				*collision->getBulletBody(),
 				*subObject,
 				tr.getOrigin(), hingePosition,
 				hingeAxis, hingeAxis);
@@ -755,27 +795,4 @@ void VehicleObject::setSecondaryColour(uint8_t color)
 bool VehicleObject::isStopped() const
 {
 	return fabsf(physVehicle->getCurrentSpeedKmHour()) < 0.75f;
-}
-
-void *VehicleRaycaster::castRay(const btVector3 &from, const btVector3 &to, btVehicleRaycaster::btVehicleRaycasterResult &result)
-{
-	ClosestNotMeRayResultCallback rayCallback( _vehicle->physBody, from, to );
-
-	const void *res = 0;
-
-	_world->rayTest(from, to, rayCallback);
-
-	if( rayCallback.hasHit() ) {
-		const btRigidBody* body = btRigidBody::upcast( rayCallback.m_collisionObject );
-
-		if( body && body->hasContactResponse() ) {
-			result.m_hitPointInWorld = rayCallback.m_hitPointWorld;
-			result.m_hitNormalInWorld = rayCallback.m_hitNormalWorld;
-			result.m_hitNormalInWorld.normalize();
-			result.m_distFraction = rayCallback.m_closestHitFraction;
-			res = body;
-		}
-	}
-
-	return (void* )res;
 }

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -574,8 +574,8 @@ bool VehicleObject::takeDamage(const GameObject::DamageInfo& dmg)
 										 , dpoint);
 				if( td < geom->geometryBounds.radius * 1.2f ) {
 					setPartState(p, DAM);
-					setPartLocked(p, false);
 				}
+				/// @todo determine when doors etc. should un-latch
 			}
 		}
 	}

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -163,12 +163,6 @@ void VehicleObject::setPosition(const glm::vec3& pos)
 	}
 }
 
-glm::vec3 VehicleObject::getPosition() const
-{
-	/// @todo update our position from the motion state
-	return position;
-}
-
 void VehicleObject::setRotation(const glm::quat &orientation)
 {
 	if( collision->getBulletBody() ) {
@@ -179,11 +173,6 @@ void VehicleObject::setRotation(const glm::quat &orientation)
 	GameObject::setRotation(orientation);
 }
 
-glm::quat VehicleObject::getRotation() const
-{
-	/// @todo update our rotation from the motion state
-	return rotation;
-}
 
 #include <glm/gtc/type_ptr.hpp>
 
@@ -232,11 +221,30 @@ void VehicleObject::tickPhysics(float dt)
 			}
 		}
 
+		// Update passenger positions
+		for (auto& seat : seatOccupants)
+		{
+			auto character = static_cast<CharacterObject*>(seat.second);
+
+			glm::vec3 passPosition;
+			if (character->isEnteringOrExitingVehicle())
+			{
+				passPosition = getSeatEntryPositionWorld(seat.first);
+			}
+			else
+			{
+				passPosition = getPosition();
+				if (seat.first < info->seats.size()) {
+					passPosition += getRotation() * (info->seats[seat.first].offset);
+				}
+			}
+			seat.second->updateTransform(passPosition, getRotation());
+		}
+
 		if( vehicle->type == VehicleData::BOAT ) {
 			if( isInWater() ) {
 				float sign = std::signbit(steerAngle) ? -1.f : 1.f;
 				float steer = std::min(info->handling.steeringLock*(3.141f/180.f), std::abs(steerAngle)) * sign;
-				/// @todo get orientation from motion state
 				auto orient = collision->getBulletBody()->getOrientation();
 
 				// Find the local-space velocity
@@ -265,7 +273,7 @@ void VehicleObject::tickPhysics(float dt)
 			}
 		}
 
-		auto ws = getPosition();
+		const auto& ws = getPosition();
 		auto wX = (int) ((ws.x + WATER_WORLD_SIZE/2.f) / (WATER_WORLD_SIZE/WATER_HQ_DATA_SIZE));
 		auto wY = (int) ((ws.y + WATER_WORLD_SIZE/2.f) / (WATER_WORLD_SIZE/WATER_HQ_DATA_SIZE));
 		btVector3 bbmin, bbmax;

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -298,7 +298,28 @@ void ObjectRenderer::renderInstance(InstanceObject *instance,
 void ObjectRenderer::renderCharacter(CharacterObject *pedestrian,
 									 RenderList& outList)
 {
-	glm::mat4 matrixModel = pedestrian->getTimeAdjustedTransform( m_renderAlpha );
+	glm::mat4 matrixModel;
+
+	if (pedestrian->getCurrentVehicle())
+	{
+		auto vehicle = pedestrian->getCurrentVehicle();
+		auto seat = pedestrian->getCurrentSeat();
+		matrixModel = vehicle->getTimeAdjustedTransform( m_renderAlpha );
+		if (pedestrian->isEnteringOrExitingVehicle())
+		{
+			matrixModel = glm::translate(matrixModel, vehicle->getSeatEntryPosition(seat));
+		}
+		else
+		{
+			if (seat < vehicle->info->seats.size()) {
+				matrixModel = glm::translate(matrixModel, vehicle->info->seats[seat].offset);
+			}
+		}
+	}
+	else
+	{
+		matrixModel = pedestrian->getTimeAdjustedTransform( m_renderAlpha );
+	}
 
 	if(!pedestrian->model->resource) return;
 

--- a/rwgame/ingamestate.cpp
+++ b/rwgame/ingamestate.cpp
@@ -8,6 +8,7 @@
 #include <objects/CharacterObject.hpp>
 #include <objects/VehicleObject.hpp>
 #include <objects/ItemPickup.hpp>
+#include <dynamics/CollisionInstance.hpp>
 #include <data/Model.hpp>
 #include <items/WeaponItem.hpp>
 #include <engine/GameWorld.hpp>
@@ -161,7 +162,7 @@ void IngameState::tick(float dt)
 			lookTargetPosition = targetPosition;
 			lookTargetPosition.z += (vehicle->info->handling.dimensions.z * 0.5f);
 			targetPosition.z += (vehicle->info->handling.dimensions.z * 0.5f);
-			physTarget = vehicle->physBody;
+			physTarget = vehicle->collision->getBulletBody();
 
 			if (!m_vehicleFreeLook)
 			{

--- a/tests/test_vehicle.cpp
+++ b/tests/test_vehicle.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(test_door_position)
 	BOOST_REQUIRE(vehicle->info != nullptr);
 	BOOST_REQUIRE(vehicle->vehicle != nullptr);
 
-	BOOST_CHECK( vehicle->getSeatEntryPosition(0).x > 5.f );
+	BOOST_CHECK( vehicle->getSeatEntryPositionWorld(0).x > 5.f );
 
 
 	Global::get().e->destroyObject(vehicle);


### PR DESCRIPTION
This is a subset of changes included in #119 that aren't related to vehicles. Vehicle physics requires a bit more work so these changes can be fast-tracked since they're complete.

- Remove defunct code
- Use bullet motion states to update object transformations
- make getPosition/getRotation non-virtual 
- Instances (lamposts, boxes etc) will now move along with their rigid body

Fixes #72 (doors will be fixed in the next PR)