### PR TITLE
Parked traffic and out-of-view spawning

### DIFF
--- a/rwengine/include/ai/TrafficDirector.hpp
+++ b/rwengine/include/ai/TrafficDirector.hpp
@@ -9,6 +9,7 @@
 
 class GameObject;
 class GameWorld;
+class ViewCamera;
 
 class TrafficDirector
 {
@@ -16,17 +17,17 @@ public:
 	
 	TrafficDirector(AIGraph* graph, GameWorld* world);
 	
-	std::vector< AIGraphNode* > findAvailableNodes(AIGraphNode::NodeType type, const glm::vec3& near, float radius);
+	std::vector< AIGraphNode* > findAvailableNodes(AIGraphNode::NodeType type, const ViewCamera& camera, float radius);
 	
 	void setDensity(AIGraphNode::NodeType type, float density);
 
 	/**
 	 * Creates new traffic at available locations.
-	 * @param center The area to spawn around
+	 * @param camera The camera to spawn around
 	 * @param radius the maximum distance to spawn in
 	 * @param max The maximum number of traffic to create.
 	 */
-	std::vector<GameObject*> populateNearby( const glm::vec3& center, float radius, int maxSpawn = -1 );
+	std::vector<GameObject*> populateNearby( const ViewCamera& camera, float radius, int maxSpawn = -1 );
 
 	/**
 	 * Sets the maximum number of pedestrians and cars in the traffic system

--- a/rwengine/include/data/VehicleGenerator.hpp
+++ b/rwengine/include/data/VehicleGenerator.hpp
@@ -1,0 +1,35 @@
+#ifndef RWENGINE_VEHICLEGENERATOR_HPP
+#define RWENGINE_VEHICLEGENERATOR_HPP
+
+/**
+ * Stores information about where the game can generate vehicles.
+ */
+struct VehicleGenerator
+{
+	glm::vec3 position;
+	float heading;
+	/// ID of the vehicle to spawn, or -1 for random.
+	int vehicleID;
+	/// @todo not yet used
+	int colourFG;
+	/// @todo not yet used
+	int colourBG;
+	bool alwaysSpawn;
+	/// @todo not yet used
+	short alarmThreshold;
+	/// @todo not yet used
+	short lockedThreshold;
+
+	int minDelay;
+	/// @todo not yet used
+	int maxDelay;
+	int lastSpawnTime;
+
+	/**
+	 * Number of vehicles left to spawn 0-100, 101 = never decrement.
+	 * Intentionally disabled to match behaviour
+	*/
+	int remainingSpawns;
+};
+
+#endif

--- a/rwengine/include/data/VehicleGenerator.hpp
+++ b/rwengine/include/data/VehicleGenerator.hpp
@@ -1,5 +1,6 @@
 #ifndef RWENGINE_VEHICLEGENERATOR_HPP
 #define RWENGINE_VEHICLEGENERATOR_HPP
+#include <glm/glm.hpp>
 
 /**
  * Stores information about where the game can generate vehicles.
@@ -30,6 +31,32 @@ struct VehicleGenerator
 	 * Intentionally disabled to match behaviour
 	*/
 	int remainingSpawns;
+
+	VehicleGenerator(const glm::vec3& position_,
+					 float heading_,
+					 int modelID_,
+					 int colourFG_,
+					 int colourBG_,
+					 bool alwaysSpawn_,
+					 short alarmThreshold_,
+					 short lockedThreshold_,
+					 int minDelay_,
+					 int maxDelay_,
+					 int lastSpawnTime_,
+					 int remainingSpawns_)
+		: position(position_)
+		, heading(heading_)
+		, vehicleID(modelID_)
+		, colourFG(colourFG_)
+		, colourBG(colourBG_)
+		, alwaysSpawn(alwaysSpawn_)
+		, alarmThreshold(alarmThreshold_)
+		, lockedThreshold(lockedThreshold_)
+		, minDelay(minDelay_)
+		, maxDelay(maxDelay_)
+		, lastSpawnTime(lastSpawnTime_)
+		, remainingSpawns(remainingSpawns_)
+	{}
 };
 
 #endif

--- a/rwengine/include/engine/GameState.hpp
+++ b/rwengine/include/engine/GameState.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <objects/ObjectTypes.hpp>
 #include <engine/ScreenText.hpp>
+#include <data/VehicleGenerator.hpp>
 
 class GameWorld;
 class GameObject;
@@ -165,30 +166,6 @@ struct TextDisplayData
 
 	glm::vec4 colourFG;
 	glm::vec4 colourBG;
-};
-
-/**
- * Stores information about where the game can generate vehicles.
- */
-struct VehicleGenerator
-{
-	glm::vec3 position;
-	float heading;
-	/** ID of the vehicle to spawn, or -1 for random. */
-	int vehicleID;
-	int colourFG;
-	int colourBG;
-	bool alwaysSpawn;
-	short alarmThreshold;
-	short lockedThreshold;
-	
-	int minDelay;
-	int maxDelay;
-	/** Incrementing timer (in ms), will only spawn a vehicle when minDelay < spawnTimer and will always spawn if maxDelay < spawnTimer */
-	int lastSpawnTime;
-	
-	/** Number of vehicles left to spawn 0-100, 101 = never decrement. */
-	int remainingSpawns;
 };
 
 /**

--- a/rwengine/include/engine/GameWorld.hpp
+++ b/rwengine/include/engine/GameWorld.hpp
@@ -21,6 +21,7 @@ class CharacterObject;
 class InstanceObject;
 class VehicleObject;
 
+class ViewCamera;
 #include <render/VisualFX.hpp>
 #include <data/ObjectData.hpp>
 
@@ -76,10 +77,23 @@ public:
 	 * @param name The name of the IPL as it appears in the games' gta.dat
 	 */
 	bool placeItems(const std::string& name);
-	
-	void createTraffic(const glm::vec3& near);
-	void cleanupTraffic(const glm::vec3& focus);
-	
+
+	/**
+	 * @brief createTraffic spawn transitory peds and vehicles
+	 * @param viewCamera The camera to create traffic near
+	 *
+	 * The position and frustum of the passed in camera is used to determine
+	 * the radius where traffic can be spawned, and the frustum is used to avoid
+	 * spawning traffic in view of the player.
+	 */
+	void createTraffic(const ViewCamera& viewCamera);
+
+	/**
+	 * @brief cleanupTraffic Cleans up traffic too far away from the given camera
+	 * @param viewCamera
+	 */
+	void cleanupTraffic(const ViewCamera& viewCamera);
+
 	/**
 	 * Creates an instance
 	 */

--- a/rwengine/include/engine/GameWorld.hpp
+++ b/rwengine/include/engine/GameWorld.hpp
@@ -27,6 +27,7 @@ class VehicleObject;
 struct BlipData;
 class InventoryItem;
 struct WeaponScan;
+struct VehicleGenerator;
 
 #include <data/Chase.hpp>
 
@@ -327,6 +328,11 @@ public:
 	
 	void setPaused(bool pause);
 	bool isPaused() const;
+
+	/**
+	 * Attempt to spawn a vehicle at a vehicle generator
+	 */
+	VehicleObject* tryToSpawnVehicle(VehicleGenerator& gen);
 
 private:
 

--- a/rwengine/src/ai/TrafficDirector.cpp
+++ b/rwengine/src/ai/TrafficDirector.cpp
@@ -2,8 +2,10 @@
 #include <ai/AIGraphNode.hpp>
 #include <ai/CharacterController.hpp>
 #include <engine/GameWorld.hpp>
+#include <engine/GameState.hpp>
 #include <objects/GameObject.hpp>
 #include <objects/CharacterObject.hpp>
+#include <objects/VehicleObject.hpp>
 #include <core/Logger.hpp>
 
 #include <glm/gtx/string_cast.hpp>
@@ -71,6 +73,18 @@ std::vector<GameObject*> TrafficDirector::populateNearby(const glm::vec3& center
 	int availablePeds = maximumPedestrians - world->pedestrianPool.objects.size();
 
 	std::vector<GameObject*> created;
+
+	// Spawn vehicles at vehicle generators
+	/// @todo avoid spawning in view frustum unless alwaysSpawn == true
+
+	for (auto& gen : world->state->vehicleGenerators) {
+		if (glm::distance2(center, gen.position) < radius * radius) {
+			auto spawned = world->tryToSpawnVehicle(gen);
+			if (spawned) {
+				created.push_back(spawned);
+			}
+		}
+	}
 
 	auto type = AIGraphNode::Pedestrian;
 	auto available = findAvailableNodes(type, center, radius);

--- a/rwengine/src/ai/TrafficDirector.cpp
+++ b/rwengine/src/ai/TrafficDirector.cpp
@@ -85,11 +85,21 @@ std::vector<GameObject*> TrafficDirector::populateNearby(const ViewCamera& camer
 	float halfRadius2 = std::pow(radius/ 2.f, 2.f);
 
 	// Spawn vehicles at vehicle generators
+	auto camera2D = glm::vec2(camera.position);
 	for (auto& gen : world->state->vehicleGenerators) {
-		float dist2 = glm::distance2(camera.position, gen.position);
+		/// @todo verify how vehicle generator proximity is determined
+		auto gen2D = glm::vec2(gen.position);
+		float dist2 = glm::distance2(camera2D, gen2D);
 		if (dist2 < radius * radius) {
-			if (dist2 <= halfRadius2 && camera.frustum.intersects(gen.position, 1.f)) {
-				if (! gen.alwaysSpawn) {
+			auto position = gen.position;
+			// Check that the on-ground position is not in view
+			if (gen.position.z < -90.f) {
+				position = world->getGroundAtPosition(position);
+			}
+
+			if (dist2 <= halfRadius2 &&
+			    camera.frustum.intersects(position, 1.f)) {
+				if (!gen.alwaysSpawn) {
 					// Don't spawn in the view frustum unless we're forced to
 					continue;
 				}

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -239,6 +239,18 @@ void GameWorld::cleanupTraffic(const glm::vec3& focus)
 			destroyObjectQueued( p.second );
 		}
 	}
+	for ( auto& p : vehiclePool.objects )
+	{
+		if ( p.second->getLifetime() != GameObject::TrafficLifetime )
+		{
+			continue;
+		}
+
+		if ( glm::distance( focus, p.second->getPosition() ) >= 100.f )
+		{
+			destroyObjectQueued( p.second );
+		}
+	}
 	destroyQueuedObjects();
 }
 
@@ -944,5 +956,62 @@ void GameWorld::setPaused(bool pause)
 bool GameWorld::isPaused() const
 {
 	return paused;
+}
+
+VehicleObject* GameWorld::tryToSpawnVehicle(VehicleGenerator& gen)
+{
+	constexpr float kMinClearRadius = 10.f;
+
+	if (gen.remainingSpawns <= 0) {
+		return nullptr;
+	}
+
+	/// @todo take into account maxDelay as well
+	if (gen.lastSpawnTime + gen.minDelay > int(state->basic.timeMS)) {
+		return nullptr;
+	}
+
+	/// @todo verify this logic
+	auto position = gen.position;
+	if (position.z < -90.f) {
+		position = getGroundAtPosition(position);
+	}
+
+	// Ensure there's no existing vehicles near our spawn point
+	for (auto& v : vehiclePool.objects)
+	{
+		if (glm::distance2(position, v.second->getPosition())
+				< kMinClearRadius * kMinClearRadius) {
+			return nullptr;
+		}
+	}
+
+	int id = gen.vehicleID;
+	if (id == -1) {
+		// Random ID found by dice roll
+		id = 134;
+		/// @todo use zone information to decide vehicle id
+	}
+
+	auto vehicle = createVehicle(
+				id,
+				position);
+	vehicle->setHeading(gen.heading);
+	vehicle->setLifetime(GameObject::TrafficLifetime);
+
+	/// @todo apply vehicle colours
+	/// @todo apply locked & alarm thresholds
+
+	// According to http://www.gtamodding.com/wiki/014C the spawn limit
+	// doesn't work.
+#if 0
+	if (gen.remainingSpawns < 101) {
+		gen.remainingSpawns --;
+	}
+#endif
+
+	gen.lastSpawnTime = state->basic.timeMS;
+
+	return vehicle;
 }
 

--- a/rwengine/src/engine/SaveGame.cpp
+++ b/rwengine/src/engine/SaveGame.cpp
@@ -1189,6 +1189,24 @@ bool SaveGame::loadGame(GameState& state, const std::string& file)
 		vehicle->setSecondaryColour(car.colorBG);
 	}
 
+	for (unsigned g = 0; g < carGenerators.size(); ++g) {
+		auto& gen = carGenerators[g];
+		state.vehicleGenerators.emplace_back(
+		    gen.position,
+		    gen.angle,
+		    gen.modelId,
+		    gen.colourFG,
+		    gen.colourBG,
+		    gen.force,
+		    gen.alarmChance,
+		    gen.lockedChance,
+		    gen.minDelay,
+		    gen.maxDelay,
+		    gen.timestamp,
+		    101  /// @todo determine where the remainingSpawns should be
+		);
+	}
+
 	// Load import / export lists
 	state.importExportPortland = garageData.bfImportExportPortland;
 	state.importExportShoreside = garageData.bfImportExportShoreside;

--- a/rwengine/src/script/modules/GameModule.cpp
+++ b/rwengine/src/script/modules/GameModule.cpp
@@ -113,21 +113,29 @@ void game_create_vehicle_generator(const ScriptArguments& args)
 		return;
 	}
 	
-	VehicleGenerator vg;
-	vg.position = position;
-	vg.heading = args[3].real;
-	vg.vehicleID = args[4].integer;
-	vg.colourFG = args[5].integer;
-	vg.colourBG = args[6].integer;
-	vg.alwaysSpawn = args[7].integer != 0;
-	vg.alarmThreshold = args[8].integer;
-	vg.lockedThreshold = args[9].integer;
-	vg.minDelay = args[10].integer;
-	vg.maxDelay = args[11].integer;
-	
-	vg.lastSpawnTime = 0;
-	vg.remainingSpawns = 0;
-	
+	float heading = args[3].real;
+	int vehicleID = args[4].integer;
+	int colourFG = args[5].integer;
+	int colourBG = args[6].integer;
+	bool alwaysSpawn = args[7].integer != 0;
+	short alarmThreshold = args[8].integer;
+	short lockedThreshold = args[9].integer;
+	int minDelay = args[10].integer;
+	int maxDelay = args[11].integer;
+
+	VehicleGenerator vg{position,
+	                    heading,
+	                    vehicleID,
+	                    colourFG,
+	                    colourBG,
+	                    alwaysSpawn,
+	                    alarmThreshold,
+	                    lockedThreshold,
+	                    minDelay,
+	                    maxDelay,
+	                    0,
+	                    0};
+
 	*args[12].globalInteger = args.getWorld()->state->vehicleGenerators.size();
 	
 	args.getWorld()->state->vehicleGenerators.push_back(vg);

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -722,6 +722,20 @@ void RWGame::renderDebugPaths(float time)
 		debug->drawLine(max, max - btVector3(0.f, 0.f, 0.5f), maxColor);
 	}
 
+	// Draw vehicle generators
+	for(size_t v = 0; v < state->vehicleGenerators.size(); ++v) {
+		auto& generator = state->vehicleGenerators[v];
+		btVector3 color(1.f, 0.f, 0.f);
+		btVector3 position(generator.position.x,generator.position.y,generator.position.z);
+		float heading = glm::radians(generator.heading);
+		auto back  = btVector3(0.f,-1.f, 0.f).rotate(btVector3(0.f, 0.f, 1.f), heading);
+		auto right = btVector3(0.15f, -0.15f, 0.f).rotate(btVector3(0.f, 0.f, 1.f), heading);
+		auto left  = btVector3(-0.15f,-0.15f, 0.f).rotate(btVector3(0.f, 0.f, 1.f), heading);
+		debug->drawLine(position, position+back, color);
+		debug->drawLine(position, position+right, color);
+		debug->drawLine(position, position+left, color);
+	}
+
 	debug->flush(renderer);
 }
 

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -463,13 +463,13 @@ void RWGame::tick(float dt)
 				throw;
 			}
 		}
-		
-		if ( state->playerObject )
-		{
+
+		/// @todo this doesn't make sense as the condition
+		if ( state->playerObject ) {
+			nextCam.frustum.update(nextCam.frustum.projection() * nextCam.getView());
 			// Use the current camera position to spawn pedestrians.
-			auto p = nextCam.position;
-			world->cleanupTraffic(p);
-			world->createTraffic(p);
+			world->cleanupTraffic(nextCam);
+			world->createTraffic(nextCam);
 		}
 	}
 	

--- a/tests/test_lifetime.cpp
+++ b/tests/test_lifetime.cpp
@@ -1,6 +1,7 @@
 #include <boost/test/unit_test.hpp>
 #include <glm/gtx/string_cast.hpp>
 #include <objects/InstanceObject.hpp>
+#include <render/ViewCamera.hpp>
 #include "test_globals.hpp"
 
 BOOST_AUTO_TEST_SUITE(LifetimeTests)
@@ -19,7 +20,9 @@ BOOST_AUTO_TEST_CASE(test_cleanup)
 		BOOST_CHECK( search != objects.end() );
 	}
 	
-	Global::get().e->cleanupTraffic(glm::vec3(0.f, 0.f, 0.f));
+	ViewCamera testCamera;
+	testCamera.position = glm::vec3(0.f, 0.f, 0.f);
+	Global::get().e->cleanupTraffic(testCamera);
 	
 	{
 		auto search = objects.find(id);

--- a/tests/test_trafficdirector.cpp
+++ b/tests/test_trafficdirector.cpp
@@ -5,6 +5,7 @@
 #include <ai/AIGraph.hpp>
 #include <objects/InstanceObject.hpp>
 #include <objects/CharacterObject.hpp>
+#include <render/ViewCamera.hpp>
 
 bool operator!=(const AIGraphNode* lhs, const glm::vec3 &rhs) { return lhs->position != rhs; }
 std::ostream &operator<<(std::ostream &os, const AIGraphNode* yt) { os << glm::to_string(yt->position); return os; }
@@ -68,8 +69,10 @@ BOOST_AUTO_TEST_CASE(test_available_nodes)
 	graph.createPathNodes(glm::vec3(), glm::quat(), path);
 	
 	TrafficDirector director(&graph, Global::get().e);
+
+	ViewCamera testCamera(glm::vec3(-5.f, -5.f, 0.f));
 	
-	auto open = director.findAvailableNodes(AIGraphNode::Pedestrian, glm::vec3(-5.f, -5.f, 0.f), 10.f);
+	auto open = director.findAvailableNodes(AIGraphNode::Pedestrian, testCamera, 10.f);
 	
 	std::vector<glm::vec3> expected {
 			{ 0.f,-10.f, 0.f },


### PR DESCRIPTION
This adds:
- spawning of vehicles from vehicle generators
-  limits spawning to outside of the view near the player (with exceptions)

Fixes #16 

Issues:
- [x] The time limit on vehicle generators is not respected
- [x] Many vehicle generators are at -100.f and never get used
- [ ] Vehicle can spawn in the ground
- [x] Save game data isn't used