### PR TITLE
Seperate Input state from binding

### DIFF
--- a/rwengine/include/engine/GameInputState.hpp
+++ b/rwengine/include/engine/GameInputState.hpp
@@ -3,6 +3,8 @@
 
 struct GameInputState
 {
+	static constexpr float kButtonOnThreshold = 0.1f;
+
 	/// Inputs that can be controlled
 	/// @todo find any sensible values
 	enum Control {
@@ -55,6 +57,16 @@ struct GameInputState
 	 * For buttons, this will result in either 0 or 1.
 	 */
 	float currentLevels[_MaxControls] = { };
+
+	float operator[] (Control c) const
+	{
+		return currentLevels[c];
+	}
+
+	bool pressed(Control c) const
+	{
+		return currentLevels[c] > kButtonOnThreshold;
+	}
 };
 
 #endif

--- a/rwengine/include/engine/GameInputState.hpp
+++ b/rwengine/include/engine/GameInputState.hpp
@@ -1,0 +1,60 @@
+#ifndef RWENGINE_GAMEINPUTSTATE_HPP
+#define RWENGINE_GAMEINPUTSTATE_HPP
+
+struct GameInputState
+{
+	/// Inputs that can be controlled
+	/// @todo find any sensible values
+	enum Control {
+		/* On Foot */
+		FireWeapon = 0,
+		NextWeapon,
+		NextTarget = NextWeapon,
+		LastWeapon,
+		LastTarget = LastWeapon,
+		GoForward,
+		GoBackwards,
+		GoLeft,
+		GoRight,
+		ZoomIn,
+		ZoomOut,
+		EnterExitVehicle,
+		ChangeCamera,
+		Jump,
+		Sprint,
+		AimWeapon,
+		Crouch,
+		Walk,
+		LookBehind,
+
+		/* In Vehicle */
+		VehicleFireWeapon = FireWeapon,
+		VehicleAccelerate,
+		VehicleBrake,
+		VehicleLeft = GoLeft,
+		VehicleRight = GoRight,
+		VehicleDown,
+		VehicleUp,
+		ChangeRadio,
+		Horn,
+		Submission,
+		Handbrake,
+		LookLeft,
+		LookRight,
+		VehicleAimLeft,
+		VehicleAimRight,
+		VehicleAimUp,
+		VehicleAimDown,
+
+		_MaxControls
+	};
+
+	/**
+	 * Current state of each control [0 to 1].
+	 *
+	 * For buttons, this will result in either 0 or 1.
+	 */
+	float currentLevels[_MaxControls] = { };
+};
+
+#endif

--- a/rwengine/include/engine/GameState.hpp
+++ b/rwengine/include/engine/GameState.hpp
@@ -10,6 +10,7 @@
 #include <objects/ObjectTypes.hpp>
 #include <engine/ScreenText.hpp>
 #include <data/VehicleGenerator.hpp>
+#include <engine/GameInputState.hpp>
 
 class GameWorld;
 class GameObject;
@@ -331,6 +332,11 @@ struct GameState
 	std::bitset<32> importExportPortland;
 	std::bitset<32> importExportShoreside;
 	std::bitset<32> importExportUnused;
+
+	/**
+	 * State of the game input
+	 */
+	GameInputState input;
 
 	/**
 	 * World to use for this state, this isn't saved, just used at runtime

--- a/rwengine/include/objects/CharacterObject.hpp
+++ b/rwengine/include/objects/CharacterObject.hpp
@@ -47,6 +47,7 @@ struct AnimationGroup
 	Animation* walk;
 	Animation* walk_start;
 	Animation* run;
+	Animation* sprint;
 
 	Animation* walk_right;
 	Animation* walk_right_start;

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -33,6 +33,7 @@ CharacterObject::CharacterObject(GameWorld* engine, const glm::vec3& pos, const 
 	animations.walk = engine->data->animations["walk_player"];
 	animations.walk_start = engine->data->animations["walk_start"];
 	animations.run  = engine->data->animations["run_player"];
+	animations.sprint  = engine->data->animations["sprint_civi"];
 
 	animations.walk_right = engine->data->animations["walk_player_right"];
 	animations.walk_right_start = engine->data->animations["walk_start_right"];
@@ -178,8 +179,12 @@ glm::vec3 CharacterObject::updateMovementAnimation(float dt)
 	else if (movementLength > movementEpsilon)
 	{
 		if (running && !isActionHappening) {
-			// No slow running
-			movementAnimation = animations.run;
+			if (movementLength > 1.f) {
+				movementAnimation = animations.sprint;
+			}
+			else {
+				movementAnimation = animations.run;
+			}
 			animationSpeed = 1.f;
 		}
 		else {

--- a/rwgame/ingamestate.cpp
+++ b/rwgame/ingamestate.cpp
@@ -15,11 +15,74 @@
 #include <script/ScriptMachine.hpp>
 #include <dynamics/RaycastCallbacks.hpp>
 
+#include <unordered_map>
+
 constexpr float kAutoLookTime = 2.f;
 constexpr float kAutolookMinVelocity = 0.2f;
 const float kMaxRotationRate = glm::half_pi<float>();
 const float kCameraPitchLimit = glm::quarter_pi<float>() * 0.5f;
 const float kVehicleCameraPitch = glm::half_pi<float>() - glm::quarter_pi<float>() * 0.25f;
+
+// Hardcoded Controls SDLK_* -> GameInputState::Control
+const std::unordered_multimap<int, GameInputState::Control> kDefaultControls = {
+	/* On Foot */
+	{ SDLK_LCTRL,     GameInputState::FireWeapon },
+	{ SDLK_KP_0,      GameInputState::FireWeapon },
+	{ SDLK_KP_ENTER,  GameInputState::NextWeapon },
+	{ SDLK_KP_PERIOD, GameInputState::LastWeapon },
+	{ SDLK_w,         GameInputState::GoForward },
+	{ SDLK_UP,        GameInputState::GoForward },
+	{ SDLK_s,         GameInputState::GoBackwards },
+	{ SDLK_DOWN,      GameInputState::GoBackwards },
+	{ SDLK_a,         GameInputState::GoLeft },
+	{ SDLK_LEFT,      GameInputState::GoLeft },
+	{ SDLK_d,         GameInputState::GoRight },
+	{ SDLK_RIGHT,     GameInputState::GoRight },
+	{ SDLK_PAGEUP,    GameInputState::ZoomIn },
+	{ SDLK_z,         GameInputState::ZoomIn },
+	{ SDLK_PAGEDOWN,  GameInputState::ZoomOut },
+	{ SDLK_x,         GameInputState::ZoomOut },
+	{ SDLK_f,         GameInputState::EnterExitVehicle },
+	{ SDLK_RETURN,    GameInputState::EnterExitVehicle },
+	{ SDLK_c,         GameInputState::ChangeCamera },
+	{ SDLK_HOME,      GameInputState::ChangeCamera },
+	{ SDLK_RCTRL,     GameInputState::Jump },
+	{ SDLK_SPACE,     GameInputState::Jump },
+	{ SDLK_LSHIFT,    GameInputState::Sprint },
+	{ SDLK_RSHIFT,    GameInputState::Sprint },
+	{ SDLK_LALT,      GameInputState::Walk },
+	{ SDLK_DELETE,    GameInputState::AimWeapon },
+	{ SDLK_CAPSLOCK,  GameInputState::LookBehind },
+
+	/* In Vehicle */
+	{ SDLK_LCTRL,     GameInputState::VehicleFireWeapon },
+	{ SDLK_a,         GameInputState::VehicleLeft },
+	{ SDLK_LEFT,      GameInputState::VehicleLeft },
+	{ SDLK_d,         GameInputState::VehicleRight },
+	{ SDLK_RIGHT,     GameInputState::VehicleRight },
+	{ SDLK_w,         GameInputState::VehicleAccelerate },
+	{ SDLK_UP,        GameInputState::VehicleAccelerate },
+	{ SDLK_d,         GameInputState::VehicleBrake },
+	{ SDLK_DOWN,      GameInputState::VehicleBrake },
+	{ SDLK_INSERT,    GameInputState::ChangeRadio },
+	{ SDLK_r,         GameInputState::ChangeRadio },
+	{ SDLK_LSHIFT,    GameInputState::Horn },
+	{ SDLK_RSHIFT,    GameInputState::Horn },
+	{ SDLK_KP_PLUS,   GameInputState::Submission },
+	{ SDLK_CAPSLOCK,  GameInputState::Submission },
+	{ SDLK_RCTRL,     GameInputState::Handbrake },
+	{ SDLK_SPACE,     GameInputState::Handbrake },
+	{ SDLK_KP_9,      GameInputState::VehicleAimUp },
+	{ SDLK_KP_2,      GameInputState::VehicleAimDown },
+	{ SDLK_KP_4,      GameInputState::VehicleAimLeft },
+	{ SDLK_KP_6,      GameInputState::VehicleAimRight },
+	{ SDLK_KP_9,      GameInputState::VehicleDown },
+	{ SDLK_KP_2,      GameInputState::VehicleUp },
+	{ SDLK_KP_1,      GameInputState::LookLeft },
+	{ SDLK_q,         GameInputState::LookLeft },
+	{ SDLK_KP_2,      GameInputState::LookRight },
+	{ SDLK_e,         GameInputState::LookRight },
+};
 
 IngameState::IngameState(RWGame* game, bool newgame, const std::string& save)
 	: State(game)

--- a/rwgame/ingamestate.cpp
+++ b/rwgame/ingamestate.cpp
@@ -289,6 +289,8 @@ void IngameState::tick(float dt)
 		const auto& input = getWorld()->state->input;
 		movement.x = input[GameInputState::GoForward] - input[GameInputState::GoBackwards];
 		movement.y = input[GameInputState::GoLeft] - input[GameInputState::GoRight];
+		/// @todo replace with correct sprint behaviour
+		float speed = input.pressed(GameInputState::Sprint) ? 2.f : 1.f;
 
 		if( player->isInputEnabled() )
 		{
@@ -330,7 +332,7 @@ void IngameState::tick(float dt)
 				{
 					glm::vec3 direction = glm::normalize(movement);
 					movementAngle += atan2(direction.y, direction.x);
-					player->setMoveDirection(glm::vec3(1.f, 0.f, 0.f));
+					player->setMoveDirection(glm::vec3(speed, 0.f, 0.f));
 				}
 				else
 				{

--- a/rwgame/ingamestate.cpp
+++ b/rwgame/ingamestate.cpp
@@ -401,6 +401,8 @@ void IngameState::handleEvent(const SDL_Event& event)
 		break;
 	default: break;
 	}
+
+	updateInputState(event);
 	
 	if( player && player->isInputEnabled() )
 	{
@@ -492,6 +494,23 @@ void IngameState::handlePlayerInput(const SDL_Event& event)
 		break;
 	default:
 		break;
+	}
+}
+
+void IngameState::updateInputState(const SDL_Event& event)
+{
+	switch (event.type) {
+	case SDL_KEYDOWN:
+	case SDL_KEYUP: {
+		auto sym = event.key.keysym.sym;
+		auto level = event.type == SDL_KEYDOWN ? 1.f : 0.f;
+		auto& levels = getWorld()->state->input.currentLevels;
+
+		auto range = kDefaultControls.equal_range(sym);
+		for (auto it = range.first; it != range.second; ++it) {
+			levels[it->second] = level;
+		}
+	} break;
 	}
 }
 

--- a/rwgame/ingamestate.hpp
+++ b/rwgame/ingamestate.hpp
@@ -55,6 +55,7 @@ public:
 
 	virtual void handleEvent(const SDL_Event& event);
 	virtual void handlePlayerInput(const SDL_Event& event);
+	void updateInputState(const SDL_Event& event);
 
 	virtual bool shouldWorldUpdate();
 

--- a/rwgame/ingamestate.hpp
+++ b/rwgame/ingamestate.hpp
@@ -22,8 +22,6 @@ class IngameState : public State
     std::string save;
 	bool newgame;
 	ViewCamera _look;
-	/** Player input */
-	glm::vec3 _movement;
 	glm::vec3 cameraPosition;
 	/** Timer to hold user camera position */
 	float autolookTimer;


### PR DESCRIPTION
This separates the SDL key bindings from the logic of those events, and also makes input state part of the engine code. This will make it easier to implement certain opcodes.

- [x] Record logical input state in the engine code
- [x] Use logical input state for controlling the player
- [x] Add player sprint, as we have proper bindings now.