### PR TITLE
Remove GLSL extensions that are in core

### DIFF
--- a/rwengine/src/render/GameShaders.cpp
+++ b/rwengine/src/render/GameShaders.cpp
@@ -5,7 +5,6 @@ namespace GameShaders {
 const char* WaterHQ::VertexShader = R"(
 #version 330
 #extension GL_ARB_explicit_attrib_location : enable
-#extension GL_ARB_uniform_buffer_object : enable
 
 layout(location = 0) in vec2 position;
 out vec2 TexCoords;
@@ -78,7 +77,6 @@ void main() {
 const char* Mask3D::VertexShader = R"(
 #version 330
 #extension GL_ARB_explicit_attrib_location : enable
-#extension GL_ARB_uniform_buffer_object : enable
 
 layout(location = 0) in vec3 position;
 
@@ -113,7 +111,6 @@ void main() {
 const char* Sky::VertexShader = R"(
 #version 330
 #extension GL_ARB_explicit_attrib_location : enable
-#extension GL_ARB_uniform_buffer_object : enable
 
 layout(std140) uniform SceneData {
 	mat4 projection;
@@ -150,7 +147,6 @@ void main() {
 const char* WorldObject::VertexShader = R"(
 #version 330
 #extension GL_ARB_explicit_attrib_location : enable
-#extension GL_ARB_uniform_buffer_object : enable
 
 layout(location = 0) in vec3 position;
 layout(location = 1) in vec3 normal;
@@ -194,7 +190,6 @@ void main()
 
 const char* WorldObject::FragmentShader = R"(
 #version 330
-#extension GL_ARB_uniform_buffer_object : enable
 
 in vec3 Normal;
 in vec2 TexCoords;
@@ -248,7 +243,6 @@ void main()
 
 const char* Particle::FragmentShader = R"(
 #version 330
-#extension GL_ARB_uniform_buffer_object : enable
 
 in vec3 Normal;
 in vec2 TexCoords;
@@ -292,7 +286,6 @@ void main()
 const char* ScreenSpaceRect::VertexShader = R"(
 #version 330
 #extension GL_ARB_explicit_attrib_location : enable
-#extension GL_ARB_uniform_buffer_object : enable
 
 layout(location = 0) in vec2 position;
 out vec2 TexCoords;
@@ -325,7 +318,6 @@ void main()
 const char* DefaultPostProcess::VertexShader = R"(
 #version 330
 #extension GL_ARB_explicit_attrib_location : enable
-#extension GL_ARB_uniform_buffer_object : enable
 
 layout(location = 0) in vec2 position;
 out vec2 TexCoords;

--- a/rwengine/src/render/GameShaders.cpp
+++ b/rwengine/src/render/GameShaders.cpp
@@ -4,7 +4,6 @@ namespace GameShaders {
 
 const char* WaterHQ::VertexShader = R"(
 #version 330
-#extension GL_ARB_explicit_attrib_location : enable
 
 layout(location = 0) in vec2 position;
 out vec2 TexCoords;
@@ -76,7 +75,6 @@ void main() {
 
 const char* Mask3D::VertexShader = R"(
 #version 330
-#extension GL_ARB_explicit_attrib_location : enable
 
 layout(location = 0) in vec3 position;
 
@@ -110,7 +108,6 @@ void main() {
 
 const char* Sky::VertexShader = R"(
 #version 330
-#extension GL_ARB_explicit_attrib_location : enable
 
 layout(std140) uniform SceneData {
 	mat4 projection;
@@ -146,7 +143,6 @@ void main() {
 
 const char* WorldObject::VertexShader = R"(
 #version 330
-#extension GL_ARB_explicit_attrib_location : enable
 
 layout(location = 0) in vec3 position;
 layout(location = 1) in vec3 normal;
@@ -285,7 +281,6 @@ void main()
 
 const char* ScreenSpaceRect::VertexShader = R"(
 #version 330
-#extension GL_ARB_explicit_attrib_location : enable
 
 layout(location = 0) in vec2 position;
 out vec2 TexCoords;
@@ -317,7 +312,6 @@ void main()
 
 const char* DefaultPostProcess::VertexShader = R"(
 #version 330
-#extension GL_ARB_explicit_attrib_location : enable
 
 layout(location = 0) in vec2 position;
 out vec2 TexCoords;

--- a/rwengine/src/render/MapRenderer.cpp
+++ b/rwengine/src/render/MapRenderer.cpp
@@ -8,7 +8,6 @@
 
 const char* MapVertexShader = R"(
 #version 330
-#extension GL_ARB_explicit_attrib_location : enable
 
 layout(location = 0) in vec2 position;
 out vec2 TexCoord;

--- a/rwengine/src/render/MapRenderer.cpp
+++ b/rwengine/src/render/MapRenderer.cpp
@@ -9,7 +9,6 @@
 const char* MapVertexShader = R"(
 #version 330
 #extension GL_ARB_explicit_attrib_location : enable
-#extension GL_ARB_uniform_buffer_object : enable
 
 layout(location = 0) in vec2 position;
 out vec2 TexCoord;

--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -58,7 +58,6 @@ glm::vec4 indexToCoord(int font, int index)
 
 const char* TextVertexShader = R"(
 #version 330
-#extension GL_ARB_explicit_attrib_location : enable
 
 layout(location = 0) in vec2 position;
 layout(location = 3) in vec2 texcoord;

--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -59,7 +59,6 @@ glm::vec4 indexToCoord(int font, int index)
 const char* TextVertexShader = R"(
 #version 330
 #extension GL_ARB_explicit_attrib_location : enable
-#extension GL_ARB_uniform_buffer_object : enable
 
 layout(location = 0) in vec2 position;
 layout(location = 3) in vec2 texcoord;


### PR DESCRIPTION
Uniform buffer objects have been [in core since 3.1](https://www.opengl.org/wiki/Uniform_Buffer_Object), and as we're currently on 3.3 there's no reason to keep these around. More importantly this extension isn't supported on Mac and will generate shader warnings.

I'm not sure whether we also need _GL_ARB_explicit_attrib_location_ -- I'm unable to find any information about its core status. It's not generating any warnings, and it does work fine without it on the Mac running Intel 4.1.