### PR TITLE
Rework how exiting and cleanup is handled.

### DIFF
--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -28,11 +28,11 @@ class RWGame
 	GameRenderer* renderer;
     ScriptMachine* script;
 	// Background worker
-	WorkContext work;
+	WorkContext *work;
 	bool debugScript;
     HttpServer* httpserver = nullptr;
     std::thread* httpserver_thread = nullptr;
-	GameWindow window;
+	GameWindow *window;
 	std::chrono::steady_clock clock;
 	std::chrono::steady_clock::time_point last_clock_time;
 
@@ -79,7 +79,7 @@ public:
 
 	GameWindow& getWindow()
 	{
-		return window;
+		return *window;
 	}
 
 	ScriptMachine* getScript() const

--- a/rwgame/State.hpp
+++ b/rwgame/State.hpp
@@ -80,6 +80,11 @@ struct StateManager
 	}
 	
 	std::deque<State*> states;
+
+	void clear()
+	{
+		states.clear();
+	}
 	
 	void enter(State* state)
 	{

--- a/rwgame/menustate.cpp
+++ b/rwgame/menustate.cpp
@@ -20,7 +20,7 @@ void MenuState::enterMainMenu()
 	m->addEntry(Menu::lambda("Load Game", [=] { enterLoadMenu(); }));
 	m->addEntry(Menu::lambda("Test", [=] { StateManager::get().enter(new IngameState(game, true, "test")); }));
 	m->addEntry(Menu::lambda("Options", [] { RW_UNIMPLEMENTED("Options Menu"); }));
-	m->addEntry(Menu::lambda("Exit", [=] { getWindow().close(); }));
+	m->addEntry(Menu::lambda("Exit", [] { StateManager::get().clear(); }));
 	this->enterMenu(m);
 }
 

--- a/rwgame/pausestate.cpp
+++ b/rwgame/pausestate.cpp
@@ -10,7 +10,7 @@ PauseState::PauseState(RWGame* game)
 	m->offset = glm::vec2( 200.f, 200.f );
 	m->addEntry(Menu::lambda("Continue", [] { StateManager::get().exit(); }));
 	m->addEntry(Menu::lambda("Options", [] { std::cout << "Options" << std::endl; }));
-	m->addEntry(Menu::lambda("Exit", [&] { getWindow().close(); }));
+	m->addEntry(Menu::lambda("Exit", [] { StateManager::get().clear(); }));
 	this->enterMenu(m);
 }
 

--- a/rwlib/source/job/WorkContext.cpp
+++ b/rwlib/source/job/WorkContext.cpp
@@ -12,20 +12,21 @@ void WorkContext::workNext()
 {
 	WorkJob* j = nullptr;
 
-	_inMutex.lock();
-	if( ! _workQueue.empty() ) {
-		j = _workQueue.front();
-		_workQueue.pop();
+	{
+		std::lock_guard<std::mutex> guard( _inMutex );
+
+		if( ! _workQueue.empty() ) {
+			j = _workQueue.front();
+			_workQueue.pop();
+		}
 	}
-	_inMutex.unlock();
 
 	if( j == nullptr ) return;
 
 	j->work();
-
-	_outMutex.lock();
+	
+	std::lock_guard<std::mutex> guard( _outMutex );
 	_completeQueue.push(j);
-	_outMutex.unlock();
 }
 
 void WorkContext::update()


### PR DESCRIPTION
This involves a few changes. The first changes involve
allocating GameWindow and WorkContext on the heap, so that
RWGame still owns them but chooses when they're freed.

The work queue is given a method to stop the worker thread
without destroying the work context, so that subsystems
relying on the work context may still function to shut down.

Then RWGame is rearranged to cleanup separate subsystems
in an order that does not conflict (i.e., stop the work queue,
shut down other subsystems, then the renderer, *then* the window.)

The window needs to be cleaned up *after* the renderer because it
owns the OpenGL context.

In addition, exiting is now performed by emptying the state queue, instead of
RWGame relying on polling the GameWindow.