### PR TITLE
Fix the construction of WorkContext

### DIFF
--- a/rwgame/benchmarkstate.cpp
+++ b/rwgame/benchmarkstate.cpp
@@ -1,6 +1,7 @@
 #include "benchmarkstate.hpp"
 #include "RWGame.hpp"
 #include <engine/GameState.hpp>
+#include <fstream>
 
 BenchmarkState::BenchmarkState(RWGame* game, const std::string& benchfile)
 	: State(game)

--- a/rwviewer/views/ModelViewer.cpp
+++ b/rwviewer/views/ModelViewer.cpp
@@ -5,6 +5,7 @@
 #include <engine/Animator.hpp>
 #include <objects/GameObject.hpp>
 #include "ViewerWidget.hpp"
+#include <fstream>
 
 ModelViewer::ModelViewer(ViewerWidget* viewer, QWidget* parent, Qt::WindowFlags f)
 : ViewerInterface(parent, f), viewing(nullptr), skeleton(nullptr)


### PR DESCRIPTION
Previously the worker thread was constructed before the queue was, leading to
unfortunate race conditions. This fixes that, along with unrelated minor cleanup.