### PR TITLE
Fix RWViewer

### DIFF
--- a/rwviewer/ViewerWidget.cpp
+++ b/rwviewer/ViewerWidget.cpp
@@ -54,7 +54,7 @@ std::vector<WidgetVertex> widgetVerts = {
 void ViewerWidget::initializeGL()
 {
 	QGLWidget::initializeGL();
-	timer.setInterval(16);
+	timer.setInterval(25);
 	connect(&timer, SIGNAL(timeout()), SLOT(updateGL()));
 	timer.start();
 

--- a/rwviewer/ViewerWidget.cpp
+++ b/rwviewer/ViewerWidget.cpp
@@ -15,8 +15,8 @@
 #include <objects/VehicleObject.hpp>
 
 
-ViewerWidget::ViewerWidget(QWidget* parent, const QGLWidget* shareWidget, Qt::WindowFlags f)
-	: QGLWidget(parent, shareWidget, f)
+ViewerWidget::ViewerWidget(QGLFormat g, QWidget* parent, const QGLWidget* shareWidget, Qt::WindowFlags f)
+	: QGLWidget(g, parent, shareWidget, f)
 	, gworld(nullptr)
 	, activeModel(nullptr)
 	, selectedFrame(nullptr)

--- a/rwviewer/ViewerWidget.hpp
+++ b/rwviewer/ViewerWidget.hpp
@@ -52,7 +52,7 @@ class ViewerWidget : public QGLWidget
 	void drawFrameWidget(ModelFrame* f, const glm::mat4& = glm::mat4(1.f));
 public:
 
-	ViewerWidget(QWidget* parent = 0, const QGLWidget* shareWidget = 0, Qt::WindowFlags f = 0);
+	ViewerWidget(QGLFormat g, QWidget* parent = 0, const QGLWidget* shareWidget = 0, Qt::WindowFlags f = 0);
 
 	virtual void initializeGL();
 	

--- a/rwviewer/ViewerWindow.cpp
+++ b/rwviewer/ViewerWindow.cpp
@@ -169,7 +169,6 @@ void ViewerWindow::loadGame(const QString &path)
 
 		// Initalize all the archives.
 		gameWorld->data->loadIMG("/models/gta3");
-		gameWorld->data->loadIMG("/models/txd");
 		gameWorld->data->loadIMG("/anim/cuts");
 
 		loadedData(gameWorld);

--- a/rwviewer/ViewerWindow.cpp
+++ b/rwviewer/ViewerWindow.cpp
@@ -46,7 +46,12 @@ ViewerWindow::ViewerWindow(QWidget* parent, Qt::WindowFlags flags)
 	connect(ex, SIGNAL(triggered()), QApplication::instance(), SLOT(closeAllWindows()));
 
 	//----------------------- View Mode setup
-	viewerWidget = new ViewerWidget;
+
+	QGLFormat glFormat;
+	glFormat.setVersion( 3, 3 );
+	glFormat.setProfile( QGLFormat::CoreProfile );
+
+	viewerWidget = new ViewerWidget(glFormat);
 	viewerWidget->context()->makeCurrent();
 	connect(this, SIGNAL(loadedData(GameWorld*)), viewerWidget, SLOT(dataLoaded(GameWorld*)));
 


### PR DESCRIPTION
3 Simple changes to RWViewer:

- Init GL 3.3 core context (code stolen from Qt sample page; fixes error in GL code)
- Don't load models/txd as we might not have that file (fixes assert or crash, can't remember)
- And finally don't hog the CPU (My machine can't keep up with 16ms interval so events will stack up. When opening a file dialog this means a framerate of about 1 FPS for the entire process which makes it impossible to select files)

The last one is a bit hacky. Ideally we'd only redraw if necessary and sync to VSYNC somehow.
But: we can fix that later.