### PR TITLE
Refactor seat storage, fixes entering wrong seat

### DIFF
--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -382,12 +382,24 @@ VehicleObject *GameWorld::createVehicle(const uint16_t id, const glm::vec3& pos,
 						auto frameTrans = f->getMatrix();
 						info->second->wheels.push_back({glm::vec3(frameTrans[3])});
 					}
-					if(name.size() > 3 && name.substr(0, 3) == "ped" && name.substr(name.size()-4) == "seat") {
+					if(name == "ped_frontseat") {
 						auto p = f->getDefaultTranslation();
-						p.x = p.x * -1.f;
-						info->second->seats.push_back({p});
-						p.x = p.x * -1.f;
-						info->second->seats.push_back({p});
+						// Left seat
+						p.x = -p.x;
+						info->second->seats.front.push_back({p});
+						// Right seat
+						p.x = -p.x;
+						info->second->seats.front.push_back({p});
+					}
+					if(name == "ped_backseat") {
+						// @todo how does this work for the barracks, ambulance or coach?
+						auto p = f->getDefaultTranslation();
+						// Left seat
+						p.x = -p.x;
+						info->second->seats.back.push_back({p});
+						// Right seat
+						p.x = -p.x;
+						info->second->seats.back.push_back({p});
 					}
 				}
 			}

--- a/rwengine/src/objects/VehicleInfo.hpp
+++ b/rwengine/src/objects/VehicleInfo.hpp
@@ -92,8 +92,25 @@ struct VehicleInfo {
 
 	/** Value for caching wheel information */
 	std::vector<WheelInfo> wheels;
-	/** Value for caching seat information */
-	std::vector<SeatInfo> seats;
+	/** Struct for caching seat information */
+	struct {
+		std::vector<SeatInfo> front;
+		std::vector<SeatInfo> back;
+
+		SeatInfo operator[](size_t index) const {
+			// Try front seats first
+			if (index < front.size()) {
+				return front[index];
+			}
+			index -= front.size();
+
+			// Get back seat
+			return back[index];
+		}
+		size_t size() const {
+			return front.size() + back.size();
+		}
+	} seats;
 };
 
 typedef std::shared_ptr<VehicleInfo> VehicleInfoHandle;

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -533,7 +533,7 @@ bool VehicleObject::isOccupantDriver(size_t seat) const
 
 VehicleObject::Part* VehicleObject::getSeatEntryDoor(size_t seat)
 {
-	auto pos = info->seats.at(seat).offset + glm::vec3(0.f, 0.5f, 0.f);
+	auto pos = info->seats[seat].offset + glm::vec3(0.f, 0.5f, 0.f);
 	Part* nearestDoor = nullptr;
 	float d = std::numeric_limits<float>::max();
 	for(auto& p : dynamicParts)


### PR DESCRIPTION
I've tested this on all cars in testmode and it worked fine.
I've only tested entering the driver seat (front left).

The motivation for storing data like this has been that we are able to find front and backseats without iterating over all available seats, while still being able to get any seat easily.

The code replaces one `at()` by `[]` and overloads an `operator[]` elsewhere without bounds checking.
This is written under the assumption that we fix those kind of issues at a later point (lint etc.) or do bounds checking elsewhere.

Fixes #73 