### PR TITLE
Cleanup MinGW build

### DIFF
--- a/cmake/external/mman-win32.cmake
+++ b/cmake/external/mman-win32.cmake
@@ -1,28 +1,18 @@
+###### External Project: mman-win32
 include(ExternalProject)
-SET(MMAN_W32_DIR ${PROJECT_SOURCE_DIR}/external/mman-win32)
 
-SET(MMAN_W32_SOURCES
-	${MMAN_W32_DIR}/mman.c)
-file(GLOB MMAN_W32_HEADERS
-	${MMAN_W32_DIR}/mman.h)
+SET(MMAN_WIN32_PREFIX_DIR ${PROJECT_SOURCE_DIR}/external/mman-win32)
 
+SET(MMAN_WIN32_SOURCES
+	${MMAN_WIN32_PREFIX_DIR}/mman.c)
 add_library(mman
-	${MMAN_W32_SOURCES})
-find_path(MINGWW64_ROOT NAMES include/sys/time.h PATH_SUFFIXES i686-w64-mingw32 mingw mingw32 )
-if (MINGWW64_ROOT)
-  message(STATUS "MINGWW64_ROOT found - ${MINGWW64_ROOT}")
-else()
-  message(FATAL_ERROR "MINGWW64_ROOT not found")
-endif()
+	${MMAN_WIN32_SOURCES})
 
-target_include_directories(mman INTERFACE SYSTEM ${MMAN_W32_DIR})
-set_target_properties( mman
-    PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY "${MINGWW64_ROOT}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${MINGWW64_ROOT}/lib"    
-)
+# The source folder for mman has mman.h, however, we require sys/mman.h
+# To get this, we copy it to the build directory.. This gives us a virtual sys/ folder.
 add_custom_command(
-      TARGET mman
-      COMMAND ${CMAKE_COMMAND} -E copy "${MMAN_W32_HEADERS}" "${MINGWW64_ROOT}/include/sys"
-	  COMMENT "Installing headers for libmman-win32..."
+	TARGET mman
+	COMMAND ${CMAKE_COMMAND} -E copy "${MMAN_WIN32_PREFIX_DIR}/mman.h" "${CMAKE_CURRENT_BINARY_DIR}/include/sys/mman.h"
 )
+
+target_include_directories(mman INTERFACE SYSTEM ${CMAKE_CURRENT_BINARY_DIR}/include)

--- a/rwengine/CMakeLists.txt
+++ b/rwengine/CMakeLists.txt
@@ -140,6 +140,11 @@ add_library(rwengine
     ${RWENGINE_SOURCES}
 )
 
+if(MINGW)
+	target_link_libraries(rwengine
+	mman)
+endif()
+
 target_link_libraries(rwengine
 	rwlib
 	${MAD_LIBRARY}

--- a/rwengine/CMakeLists.txt
+++ b/rwengine/CMakeLists.txt
@@ -140,10 +140,6 @@ add_library(rwengine
     ${RWENGINE_SOURCES}
 )
 
-if(MINGW)
-	add_definitions(-D _USE_MATH_DEFINES)	
-endif()
-
 target_link_libraries(rwengine
 	rwlib
 	${MAD_LIBRARY}

--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -1,6 +1,3 @@
-#define _USE_MATH_DEFINES
-#include <cmath>
-
 #include <render/GameRenderer.hpp>
 #include <engine/GameWorld.hpp>
 #include <engine/Animator.hpp>
@@ -26,7 +23,7 @@
 #include <core/Logger.hpp>
 
 #include <deque>
-#include <cmath>
+#include <glm/gtc/constants.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtx/string_cast.hpp>
 
@@ -163,9 +160,9 @@ GameRenderer::GameRenderer(Logger* log, GameData* _data)
     for( size_t r = 0, i = 0; r < rows; ++r) {
         for( size_t s = 0; s < segments; ++s) {
 			skydomeVerts[i++].position = glm::vec3(
-                        cos(2.f * M_PI * s * S) * cos(M_PI_2 * r * R),
-                        sin(2.f * M_PI * s * S) * cos(M_PI_2 * r * R),
-                        sin(M_PI_2 * r * R)
+                        cos(2.f * glm::pi<float>() * s * S) * cos(glm::half_pi<float>() * r * R),
+                        sin(2.f * glm::pi<float>() * s * S) * cos(glm::half_pi<float>() * r * R),
+                        sin(glm::half_pi<float>() * r * R)
                         );
 		}
 	}

--- a/rwgame/CMakeLists.txt
+++ b/rwgame/CMakeLists.txt
@@ -50,7 +50,6 @@ target_link_libraries(rwgame
 	${SDL2_LIBRARY}
 	)
 if(MINGW)
-	add_definitions(-D _USE_MATH_DEFINES)
 	target_link_libraries(rwgame
 	mman)
 endif()

--- a/rwgame/DrawUI.cpp
+++ b/rwgame/DrawUI.cpp
@@ -1,6 +1,3 @@
-#define _USE_MATH_DEFINES
-#include <cmath>
-
 #include "DrawUI.hpp"
 #include <render/GameRenderer.hpp>
 #include <ai/PlayerController.hpp>
@@ -8,6 +5,7 @@
 #include <engine/GameState.hpp>
 #include <items/WeaponItem.hpp>
 
+#include <glm/gtc/constants.hpp>
 #include <iomanip>
 
 constexpr size_t ui_textSize = 25;
@@ -34,7 +32,7 @@ void drawMap(ViewCamera& currentView,  PlayerController* player, GameWorld* worl
 	
 	glm::quat camRot = currentView.rotation;
 	
-	map.rotation = glm::roll(camRot) - M_PI/2.f;
+	map.rotation = glm::roll(camRot) - glm::half_pi<float>();
 	map.worldSize = ui_worldSizeMin;
 	map.worldSize = ui_worldSizeMax;
 	if( player )

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -16,6 +16,7 @@
 #include <script/ScriptMachine.hpp>
 #include <dynamics/RaycastCallbacks.hpp>
 
+#include <glm/gtc/constants.hpp>
 #include <unordered_map>
 
 constexpr float kAutoLookTime = 2.f;
@@ -343,7 +344,7 @@ void IngameState::tick(float dt)
 				}
 
 				float length = glm::length(movement);
-				float movementAngle = angleYaw - M_PI/2.f;
+				float movementAngle = angleYaw - glm::half_pi<float>();
 				if (length > 0.1f)
 				{
 					glm::vec3 direction = glm::normalize(movement);


### PR DESCRIPTION
This does some minor cleanup for MinGW to make the build process less error prone.

* I've replaced all uses of cmath as we can also use the glm constants.
* master wouldn't work when the system include path is read only as mman was installed into the system path which is a no-no anyway.
* rwengine itself depends on iconv (LoaderGXT) and mman (MADStream). While these are linked by rwgame they are also required for rwviewer (which uses rwengine, but doesn't link them = fail). This commit is a purely temporary measure (See notes below)

Ideally we'd also link to iconv from every platform, but @danhedron is working on removing iconv altogether, so it's really not that important.
I wasn't sure wether I can remove the link to mman from rwgame so I kept it for now (someone on IRC said they might try to get rid of mman / libmad anyway, too).