### PR TITLE
Improve SDL & GL initialisation failure handling

### DIFF
--- a/rwgame/GameWindow.cpp
+++ b/rwgame/GameWindow.cpp
@@ -10,7 +10,7 @@ GameWindow::GameWindow() :
 
 void GameWindow::create(const std::string& title, size_t w, size_t h, bool fullscreen)
 {
-	uint32_t style = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE;
+	Uint32 style = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIDDEN;
 	if (fullscreen)
 		style |= SDL_WINDOW_FULLSCREEN;
 
@@ -33,6 +33,8 @@ void GameWindow::create(const std::string& title, size_t w, size_t h, bool fulls
 		std::string sdlErrorStr = SDL_GetError();
 		throw std::runtime_error("SDL_GL_CreateContext failed: " + sdlErrorStr);
 	}
+
+	SDL_ShowWindow(window);
 }
 
 

--- a/rwgame/GameWindow.cpp
+++ b/rwgame/GameWindow.cpp
@@ -50,16 +50,12 @@ void GameWindow::close()
 void GameWindow::showCursor()
 {
 	SDL_SetRelativeMouseMode(SDL_FALSE);
-	SDL_ShowCursor(SDL_ENABLE);
-	SDL_SetWindowGrab(window, SDL_FALSE);
 }
 
 
 void GameWindow::hideCursor()
 {
 	SDL_SetRelativeMouseMode(SDL_TRUE);
-	SDL_ShowCursor(SDL_DISABLE);
-	SDL_SetWindowGrab(window, SDL_TRUE);
 }
 
 

--- a/rwgame/GameWindow.cpp
+++ b/rwgame/GameWindow.cpp
@@ -22,7 +22,17 @@ void GameWindow::create(const std::string& title, size_t w, size_t h, bool fulls
 	SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
 
 	window = SDL_CreateWindow(title.c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, w, h, style);
+	if (window == nullptr) {
+		// Window creation failure is fatal
+		std::string sdlErrorStr = SDL_GetError();
+		throw std::runtime_error("SDL_CreateWindow failed: " + sdlErrorStr);
+	}
 	glcontext = SDL_GL_CreateContext(window);
+	if (glcontext == nullptr) {
+		// context creation failure is fatal
+		std::string sdlErrorStr = SDL_GetError();
+		throw std::runtime_error("SDL_GL_CreateContext failed: " + sdlErrorStr);
+	}
 }
 
 

--- a/rwgame/main.cpp
+++ b/rwgame/main.cpp
@@ -1,9 +1,28 @@
 #include "RWGame.hpp"
+#include "SDL.h"
+#include <iostream>
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
+	try {
+		RWGame game(argc, argv);
 
-	RWGame game( argc, argv );
+		return game.run();
+	} catch (std::runtime_error& ex) {
+		// Catch runtime_error as these are fatal issues the user may want to
+		// know about like corrupted files or GL initialisation failure.
+		// Catching other types (out_of_range, bad_alloc) would just make
+		// debugging them more difficult.
 
-	return game.run();
+		const char* kErrorTitle = "Fatal Error";
+
+		std::cerr << kErrorTitle << "\n" << ex.what() << std::endl;
+
+		if (SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, kErrorTitle,
+		                             ex.what(), NULL) < 0) {
+			SDL_Log("Failed to show message box\n");
+		}
+
+		return -1;
+	}
 }


### PR DESCRIPTION
This adds some usability fixes:

- Check that we actually opened a window and get a gl context
- Don't show the window if we don't get an OpenGL context
- Show an error dialog for environments where stderr is not readily accessible 