### PR TITLE
Fixes #219: Take TOBJ data into account when building render lists

### DIFF
--- a/rwengine/src/loaders/LoaderIDE.cpp
+++ b/rwengine/src/loaders/LoaderIDE.cpp
@@ -81,7 +81,8 @@ bool LoaderIDE::load(const std::string &filename)
 					objs->timeOff = atoi(buff.c_str());
 				}
 				else {
-					objs->timeOff = objs->timeOn = 0;
+					objs->timeOn = 0;
+					objs->timeOff = 24;
 				}
 
 				// Put stuff in our struct

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -198,17 +198,14 @@ void ObjectRenderer::renderInstance(InstanceObject *instance,
 
 
 	// Handles times provided by TOBJ data
-	if (instance->object->timeOn != 0 || instance->object->timeOff != 0)
+	const auto currentHour = m_world->getHour();
+	if (instance->object->timeOff < instance->object->timeOn)
 	{
-		const auto currentHour = m_world->getHour();
-		if (instance->object->timeOff < instance->object->timeOn)
-		{
-			if ( currentHour >= instance->object->timeOff && currentHour < instance->object->timeOn )
-				return;
-		} else {
-			if ( currentHour >= instance->object->timeOff || currentHour < instance->object->timeOn )
-				return;
-		}
+		if ( currentHour >= instance->object->timeOff && currentHour < instance->object->timeOn )
+			return;
+	} else {
+		if ( currentHour >= instance->object->timeOff || currentHour < instance->object->timeOn )
+			return;
 	}
 
 	auto matrixModel = instance->getTimeAdjustedTransform(m_renderAlpha);

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -196,6 +196,21 @@ void ObjectRenderer::renderInstance(InstanceObject *instance,
 		return;
 	}
 
+
+	// Handles times provided by TOBJ data
+	if (instance->object->timeOn != 0 || instance->object->timeOff != 0)
+	{
+		const auto currentHour = m_world->getHour();
+		if (instance->object->timeOff < instance->object->timeOn)
+		{
+			if ( currentHour >= instance->object->timeOff && currentHour < instance->object->timeOn )
+				return;
+		} else {
+			if ( currentHour >= instance->object->timeOff || currentHour < instance->object->timeOn )
+				return;
+		}
+	}
+
 	auto matrixModel = instance->getTimeAdjustedTransform(m_renderAlpha);
 
 	float mindist = glm::length(instance->getPosition()-m_camera.position)


### PR DESCRIPTION
This is an implementation of TOBJ support for openrw, fixing issue #219. 

So far, I don't handle breakable TOBJ objects, as I can't find any in my GTA3 files and as such I don't think support for that would be required to play GTA3. I can look into it further if needed, however.

It also seems that for static meshes that have day/night variants, only one of the two has collision information, so it seems to be purely graphical for those. If we ever have breakable TOBJ, we need to look into how the physics for those should be handled.

As I pointed out in #219, the windows near the debug spawn area all seem to be offset from their respective buildings. I have no idea what the cause of this is.

