### PR TITLE
Script: Implement opcode_0363 (Object visibility)

### DIFF
--- a/rwengine/src/objects/InstanceObject.hpp
+++ b/rwengine/src/objects/InstanceObject.hpp
@@ -13,6 +13,7 @@ class CollisionInstance;
 class InstanceObject : public GameObject
 {
 	float health;
+	bool visible = true;
 public:
 	glm::vec3 scale;
 	CollisionInstance* body;
@@ -36,6 +37,11 @@ public:
 	virtual bool takeDamage(const DamageInfo& damage);
 
 	void setSolid(bool solid);
+
+	void setVisible(bool visible) {
+		this->visible = visible;
+	}
+	float getVisible() const { return visible; }
 
 	float getHealth() const { return health; }
 };

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -191,8 +191,12 @@ void ObjectRenderer::renderItem(InventoryItem *item,
 void ObjectRenderer::renderInstance(InstanceObject *instance,
 									RenderList& outList)
 {
-	if(!instance->model->resource)
-	{
+	if(!instance->model->resource) {
+		return;
+	}
+
+	// Only draw visible objects
+	if(!instance->getVisible()) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #51. Only implements 0363. No known issues.

---

Style wise it's debatable wether `setVisible` should be part  of GameObject instead. It might deserve a comment about being entirely script controlled (and not something like TOBJ) but I wasn't sure what kind of doc format I should use.

I'd also prefer `args.getModel()` or an overload for `ScriptModel`, but it's beyond the scope of this PR.

---

Probably conflicts with #220 (I'll happily rebase after #220 is merged).