### PR TITLE
Fix debug-camera

### DIFF
--- a/rwgame/states/DebugState.cpp
+++ b/rwgame/states/DebugState.cpp
@@ -356,7 +356,7 @@ void DebugState::tick(float dt)
 		_debugCam.rotation = glm::angleAxis(_debugLook.x, glm::vec3(0.f, 0.f, 1.f))
 			* glm::angleAxis(_debugLook.y, glm::vec3(0.f, 1.f, 0.f));
 
-		_debugCam.position += _debugCam.rotation * _movement * dt * (_sonicMode ? 1000.f : 100.f);
+		_debugCam.position += _debugCam.rotation * _movement * dt * (_sonicMode ? 500.f : 50.f);
 	}
 }
 

--- a/rwgame/states/DebugState.cpp
+++ b/rwgame/states/DebugState.cpp
@@ -304,8 +304,7 @@ Menu*DebugState::createWeaponMenu()
 
 DebugState::DebugState(RWGame* game, const glm::vec3& vp, const glm::quat& vd)
 	: State(game)
-	, _freeLook( false )
-	, _sonicMode( false )
+	, _invertedY(game->getConfig().getInputInvertY())
 {
 	this->enterMenu(createDebugMenu());
 

--- a/rwgame/states/DebugState.cpp
+++ b/rwgame/states/DebugState.cpp
@@ -382,7 +382,6 @@ void DebugState::handleEvent(const SDL_Event& event)
 	switch(event.type) {
 	case SDL_KEYDOWN:
 		switch(event.key.keysym.sym) {
-		default: break;
 		case SDLK_ESCAPE:
 			StateManager::get().exit();
 			break;
@@ -408,10 +407,7 @@ void DebugState::handleEvent(const SDL_Event& event)
 		case SDLK_p:
 			printCameraDetails();
 			break;
-		}
-
-		switch (event.key.keysym.mod) {
-		case KMOD_LSHIFT:
+		case SDLK_LSHIFT:
 			_sonicMode = true;
 			break;
 		default: break;
@@ -429,10 +425,7 @@ void DebugState::handleEvent(const SDL_Event& event)
 		case SDLK_d:
 			_movement.y = 0.f;
 			break;
-		}
-
-		switch (event.key.keysym.mod) {
-		case KMOD_LSHIFT:
+		case SDLK_LSHIFT:
 			_sonicMode = false;
 			break;
 		default: break;

--- a/rwgame/states/DebugState.hpp
+++ b/rwgame/states/DebugState.hpp
@@ -8,8 +8,8 @@ class DebugState : public State
 	ViewCamera _debugCam;
 	glm::vec3 _movement;
 	glm::vec2 _debugLook;
-	bool _freeLook;
-	bool _sonicMode;
+	bool _freeLook = false;
+	bool _sonicMode = false;
 	bool _invertedY;
 
 	Menu* createDebugMenu();


### PR DESCRIPTION
This fixes 3 seperate issues:

- Undefined behaviour as `_invertedY` was not initialized and caused random camera inversion. This new implementation uses the user-configuration like `IngameState` does.
- Speed-modifier (`sonicSpeed`) was broken because the modifier flag was checked in key-up / down instead of checking for shift directly (which didn't work for unknown reasons?). Ideally we should check the key state instead. However, this is an okay workaround.
- The camera speed was adjusted as it was often too fast for accurate placement (it's still fast).


(I don't feel like looking into why the speed modifier didn't work. It might be a result from more than one modifier being active on XFCE. The original code should have simply AND'ed for the shift press instead or sticked to the working solution which is already used for all other keys in `DebugState` - as implemented here)