### PR TITLE
Parse command line arguments with Boost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
       - libsndfile-dev
       - libopenal-dev
       - libboost-filesystem-dev
+      - libboost-program-options-dev
       # Dependencies for BUILD_TESTS
       - libboost-test-dev
       # Dependencies for BUILD_VIEWER

--- a/rwgame/CMakeLists.txt
+++ b/rwgame/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost REQUIRED)
+find_package(Boost COMPONENTS program_options REQUIRED)
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/GitSHA1.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/GitSHA1.cpp" @ONLY)
 
@@ -45,6 +45,7 @@ include_directories(
 target_link_libraries(rwgame
 	rwengine
 	inih
+	${Boost_LIBRARIES}
 	${OPENGL_LIBRARIES}
 	${BULLET_LIBRARIES}
 	${SDL2_LIBRARY}

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -62,7 +62,7 @@ RWGame::RWGame(int argc, char* argv[])
 		("height,h",     po::value<size_t>(),      "Game resolution height in pixel")
 		("fullscreen,f",                           "Enable fullscreen mode")
 		("newgame,n",                              "Directly start a new game")
-		("test,t",                                 "To be used with -n, starts in a test location instead")
+		("test,t",                                 "Starts a new game in a test location")
 		("load,l",       po::value<std::string>(), "Load save file")
 		("benchmark,b",  po::value<std::string>(), "Run benchmark and store results in file")
 	;
@@ -162,20 +162,17 @@ RWGame::RWGame(int argc, char* argv[])
 	{
 		loading->setNextState(new BenchmarkState(this, benchFile));
 	}
+	else if( test)
+	{
+		loading->setNextState(new IngameState(this, true, "test"));
+	}
 	else if( newgame )
 	{
-		if( test )
-		{
-			loading->setNextState(new IngameState(this,true, "test"));
-		}
-		else
-		{
-			loading->setNextState(new IngameState(this,true));
-		}
+		loading->setNextState(new IngameState(this, true));
 	}
 	else if( ! startSave.empty() )
 	{
-		loading->setNextState(new IngameState(this,true, startSave));
+		loading->setNextState(new IngameState(this, true, startSave));
 	}
 	else
 	{

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -50,6 +50,7 @@ RWGame::RWGame(int argc, char* argv[])
 	bool fullscreen = false;
 	bool newgame = false;
 	bool test = false;
+	bool help = false;
 	std::string startSave;
 	std::string benchFile;
 
@@ -64,18 +65,25 @@ RWGame::RWGame(int argc, char* argv[])
 		("newgame,n",                              "Directly start a new game")
 		("test,t",                                 "Starts a new game in a test location")
 		("load,l",       po::value<std::string>(), "Load save file")
-		("benchmark,b",  po::value<std::string>(), "Run benchmark and store results in file")
+		("benchmark,b",  po::value<std::string>(), "Run benchmark from file")
 	;
 
 	po::variables_map vm;
-	po::store(po::parse_command_line(argc, argv, desc), vm);
-	po::notify(vm);
-
-	if( vm.count("help") )
+	try
 	{
-		// TODO: This is a hack
-		std::cout << desc << std::endl;
-		throw std::runtime_error("Terminate");
+		po::store(po::parse_command_line(argc, argv, desc), vm);
+		po::notify(vm);
+	}
+	catch (po::error& ex)
+	{
+		help = true;
+		std::cout << "Error parsing arguments: " << ex.what() << std::endl;
+	}
+
+	if( help || vm.count("help") )
+	{
+		std::cout << desc;
+		throw std::invalid_argument("");
 	}
 	if( vm.count("width") )
 	{
@@ -178,7 +186,7 @@ RWGame::RWGame(int argc, char* argv[])
 	{
 		loading->setNextState(new MenuState(this));
 	}
-	
+
 	StateManager::get().enter(loading);
 
 	log.info("Game", "Started");

--- a/rwgame/main.cpp
+++ b/rwgame/main.cpp
@@ -8,6 +8,11 @@ int main(int argc, char* argv[])
 		RWGame game(argc, argv);
 
 		return game.run();
+	} catch (std::invalid_argument& ex) {
+		// This exception is thrown when either an invalid command line option
+		// or a --help is found. The RWGame constructor prints a usage message
+		// in this case and then throws this exception.
+		return -2;
 	} catch (std::runtime_error& ex) {
 		// Catch runtime_error as these are fatal issues the user may want to
 		// know about like corrupted files or GL initialisation failure.


### PR DESCRIPTION
I've had a go at issue #177. It's a simple change, but there are still some points that are up for discussion.

For example, I don't fully understand each available option yet - maybe you could provide some accurate descriptions for the options with a TODO.

The most important point is how to exit when `--help` is used. In the short term an exception can be used, however it's not very clean.

In the longer term command line parsing should probably be decoupled from the SDL/engine initialization and maybe even merged with config file parsing (btw. Boost has support for that, but might not work together with the current config setup). This would require more rewriting though.

