### PR TITLE
Make sure SDL_Quit() is called on exit

### DIFF
--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -189,6 +189,8 @@ RWGame::~RWGame()
 	log.info("Game", "Cleaning up work queue");
 	delete work;
 
+	SDL_Quit();
+
 	log.info("Game", "Done cleaning up");
 }
 

--- a/rwgame/main.cpp
+++ b/rwgame/main.cpp
@@ -23,6 +23,8 @@ int main(int argc, char* argv[])
 			SDL_Log("Failed to show message box\n");
 		}
 
+		SDL_Quit();
+
 		return -1;
 	}
 }


### PR DESCRIPTION
On my Fedora using the fullscreen mode permamently changes the display resolution. Obviously this is extremely inconvenient. The fix is making sure `SDL_Quit` is called before exit. This function is safe to call - even if SDL init fails.