### PR TITLE
Improve Debug Views

### DIFF
--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -722,19 +722,24 @@ void RWGame::render(float alpha, float time) {
     auto rendertime = renderer->getRenderer()->popDebugGroup();
 
     RW_PROFILE_BEGIN("debug");
-    if (showDebugPaths) {
-        renderDebugPaths(time);
-    }
-
-    if (showDebugStats) {
-        renderDebugStats(time, rendertime);
-    }
-
-    if (showDebugPhysics) {
-        if (world) {
-            world->dynamicsWorld->debugDrawWorld();
-            debug->flush(renderer);
-        }
+    switch (debugview_) {
+        case DebugViewMode::General:
+            renderDebugStats(time, rendertime);
+            break;
+        case DebugViewMode::Physics:
+            if (world) {
+                world->dynamicsWorld->debugDrawWorld();
+                debug->flush(renderer);
+            }
+            break;
+        case DebugViewMode::Navigation:
+            renderDebugPaths(time);
+            break;
+        case DebugViewMode::Objects:
+            /// @todo
+            break;
+        default:
+            break;
     }
     RW_PROFILE_END();
 
@@ -960,6 +965,10 @@ void RWGame::renderProfile() {
 }
 
 void RWGame::globalKeyEvent(const SDL_Event& event) {
+    const auto toggle_debug = [&](DebugViewMode m) {
+        debugview_ = debugview_ == m ? DebugViewMode::Disabled : m;
+    };
+
     switch (event.key.keysym.sym) {
         case SDLK_LEFTBRACKET:
             world->offsetGameTime(-30);
@@ -974,13 +983,16 @@ void RWGame::globalKeyEvent(const SDL_Event& event) {
             timescale *= 2.0f;
             break;
         case SDLK_F1:
-            showDebugStats = !showDebugStats;
+            toggle_debug(DebugViewMode::General);
             break;
         case SDLK_F2:
-            showDebugPaths = !showDebugPaths;
+            toggle_debug(DebugViewMode::Navigation);
             break;
         case SDLK_F3:
-            showDebugPhysics = !showDebugPhysics;
+            toggle_debug(DebugViewMode::Physics);
+            break;
+        case SDLK_F4:
+            toggle_debug(DebugViewMode::Objects);
             break;
         default:
             break;

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -765,15 +765,11 @@ void RWGame::renderDebugStats(float time) {
     }
 
     std::stringstream ss;
-    ss << "Frametime: " << time_ms << " (FPS " << (1.f / time) << ")\n";
-    ss << "Average (per " << average_every_frame
-       << " frames); Frametime: " << time_average << " (FPS "
-       << (1000.f / time_average) << ")\n";
-    ss << "Draws: " << lastDraws << " (" << renderer->culled << " Culls)\n";
-    ss << " Texture binds: " << renderer->getRenderer()->getTextureCount()
-       << "\n";
-    ss << " Buffer binds: " << renderer->getRenderer()->getBufferCount()
-       << "\n";
+    ss << "FPS: " << (1000.f / time_average) << " (" << time_average << "ms)\n"
+       << "Frame: " << time_ms << "ms\n"
+       << "Draws/Textures/Buffers: " << lastDraws << "/"
+       << renderer->getRenderer()->getTextureCount() << "/"
+       << renderer->getRenderer()->getBufferCount() << "\n";
 
     TextRenderer::TextInfo ti;
     ti.text = GameStringUtil::fromString(ss.str());

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -736,7 +736,7 @@ void RWGame::render(float alpha, float time) {
             renderDebugPaths(time);
             break;
         case DebugViewMode::Objects:
-            /// @todo
+            renderDebugObjects(time);
             break;
         default:
             break;
@@ -867,6 +867,25 @@ void RWGame::renderDebugPaths(float time) {
     }
 
     debug->flush(renderer);
+}
+
+void RWGame::renderDebugObjects(float time) {
+    RW_UNUSED(time);
+
+    std::stringstream ss;
+
+    ss << "Models: " << data->modelinfo.size() << "\n"
+       << "Dynamic Objects:\n"
+       << " Vehicles: " << world->vehiclePool.objects.size() << "\n"
+       << " Peds: " << world->pedestrianPool.objects.size() << "\n";
+
+    TextRenderer::TextInfo ti;
+    ti.text = GameStringUtil::fromString(ss.str());
+    ti.font = 2;
+    ti.screenPosition = glm::vec2(10.f, 10.f);
+    ti.size = 15.f;
+    ti.baseColour = glm::u8vec3(255);
+    renderer->text.renderText(ti);
 }
 
 void RWGame::renderProfile() {

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -140,7 +140,7 @@ private:
 
     void renderDebugStats(float time);
     void renderDebugPaths(float time);
-    void renderDebugObjects(float time);
+    void renderDebugObjects(float time, ViewCamera& camera);
     void renderProfile();
 
     void handleCheatInput(char symbol);

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -138,7 +138,7 @@ private:
     void tick(float dt);
     void render(float alpha, float dt);
 
-    void renderDebugStats(float time, Renderer::ProfileInfo& worldRenderTime);
+    void renderDebugStats(float time);
     void renderDebugPaths(float time);
     void renderProfile();
 

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -33,9 +33,16 @@ class RWGame {
 
     bool inFocus = true;
     ViewCamera lastCam, nextCam;
-    bool showDebugStats = false;
-    bool showDebugPaths = false;
-    bool showDebugPhysics = false;
+
+    enum class DebugViewMode {
+        Disabled,
+        General,
+        Physics,
+        Navigation,
+        Objects
+    };
+
+    DebugViewMode debugview_ = DebugViewMode::Disabled;
     int lastDraws;  /// Number of draws issued for the last frame.
 
     std::string cheatInputWindow = std::string(32, ' ');

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -140,6 +140,7 @@ private:
 
     void renderDebugStats(float time);
     void renderDebugPaths(float time);
+    void renderDebugObjects(float time);
     void renderProfile();
 
     void handleCheatInput(char symbol);


### PR DESCRIPTION
There was quite a bit of cruft in the <keyboard>F1</keyboard> debug view.

- Remove not-even working values
- Move object data into its own view on F4
- Show object state for nearby objects (might be useful to check objects are in the state scripts expect)