### PR TITLE
General Game cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 sudo: required
 dist: trusty
-language: cpp
+language: generic
+env:
+  - CXX=g++-5 CC=gcc-5
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
+      - g++-5
       - libbullet-dev
       - libsdl2-dev
       - libmad0-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(OpenRW)
 
 # Global Build Configuration
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DRW_DEBUG=1")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -pthread -Wextra -Wpedantic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -pthread -Wextra -Wpedantic")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules")
 
 set(RW_VERBOSE_DEBUG_MESSAGES 1 CACHE BOOL "Print verbose debugging messages")

--- a/rwengine/src/core/Logger.hpp
+++ b/rwengine/src/core/Logger.hpp
@@ -35,6 +35,10 @@ public:
         virtual void messageRecieved(const LogMessage&) = 0;
     };
 
+    Logger(std::initializer_list<MessageReciever*> initial = {})
+        : recievers(initial) {
+    }
+
     void addReciever(MessageReciever* out);
     void removeReciever(MessageReciever* out);
 

--- a/rwengine/src/data/GameTexts.hpp
+++ b/rwengine/src/data/GameTexts.hpp
@@ -50,7 +50,7 @@ public:
         m_strings.emplace(id, text);
     }
 
-    GameString text(const GameStringKey& id) {
+    GameString text(const GameStringKey& id) const {
         auto a = m_strings.find(id);
         if (a != m_strings.end()) {
             return a->second;

--- a/rwengine/src/dynamics/CollisionInstance.cpp
+++ b/rwengine/src/dynamics/CollisionInstance.cpp
@@ -154,7 +154,7 @@ bool CollisionInstance::createPhysicsBody(GameObject* object,
 
 void CollisionInstance::changeMass(float newMass) {
     GameObject* object = static_cast<GameObject*>(m_body->getUserPointer());
-    auto dynamicsWorld = object->engine->dynamicsWorld;
+    auto& dynamicsWorld = object->engine->dynamicsWorld;
     dynamicsWorld->removeRigidBody(m_body);
     btVector3 inert;
     m_body->getCollisionShape()->calculateLocalInertia(newMass, inert);

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -87,12 +87,15 @@ GameWorld::GameWorld(Logger* log, WorkContext* work, GameData* dat)
     : logger(log), data(dat), randomEngine(rand()), _work(work), paused(false) {
     data->engine = this;
 
-    collisionConfig = new btDefaultCollisionConfiguration;
-    collisionDispatcher = new WorldCollisionDispatcher(collisionConfig);
-    broadphase = new btDbvtBroadphase();
-    solver = new btSequentialImpulseConstraintSolver;
-    dynamicsWorld = new btDiscreteDynamicsWorld(collisionDispatcher, broadphase,
-                                                solver, collisionConfig);
+    collisionConfig = std::make_unique<btDefaultCollisionConfiguration>();
+    collisionDispatcher =
+        std::make_unique<WorldCollisionDispatcher>(collisionConfig.get());
+    broadphase = std::make_unique<btDbvtBroadphase>();
+    solver = std::make_unique<btSequentialImpulseConstraintSolver>();
+    dynamicsWorld = std::make_unique<btDiscreteDynamicsWorld>(
+        collisionDispatcher.get(), broadphase.get(), solver.get(),
+        collisionConfig.get());
+
     dynamicsWorld->setGravity(btVector3(0.f, 0.f, -9.81f));
     broadphase->getOverlappingPairCache()->setInternalGhostPairCallback(
         new btGhostPairCallback());
@@ -104,14 +107,6 @@ GameWorld::~GameWorld() {
     for (auto& p : allObjects) {
         delete p;
     }
-
-    delete dynamicsWorld;
-    delete solver;
-    delete broadphase;
-    delete collisionDispatcher;
-    delete collisionConfig;
-
-    /// @todo delete other things.
 }
 
 bool GameWorld::placeItems(const std::string& name) {

--- a/rwengine/src/engine/GameWorld.hpp
+++ b/rwengine/src/engine/GameWorld.hpp
@@ -269,11 +269,11 @@ public:
     /**
      * Bullet
      */
-    btDefaultCollisionConfiguration* collisionConfig;
-    btCollisionDispatcher* collisionDispatcher;
-    btBroadphaseInterface* broadphase;
-    btSequentialImpulseConstraintSolver* solver;
-    btDiscreteDynamicsWorld* dynamicsWorld;
+    std::unique_ptr<btDefaultCollisionConfiguration> collisionConfig;
+    std::unique_ptr<btCollisionDispatcher> collisionDispatcher;
+    std::unique_ptr<btDbvtBroadphase> broadphase;
+    std::unique_ptr<btSequentialImpulseConstraintSolver> solver;
+    std::unique_ptr<btDiscreteDynamicsWorld> dynamicsWorld;
 
     /**
      * @brief physicsNearCallback

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -100,7 +100,7 @@ VehicleObject::VehicleObject(GameWorld* engine, const glm::vec3& pos,
     collision = new CollisionInstance;
     if (collision->createPhysicsBody(this, modelinfo->name, nullptr,
                                      &info->handling)) {
-        physRaycaster = new VehicleRaycaster(this, engine->dynamicsWorld);
+        physRaycaster = new VehicleRaycaster(this, engine->dynamicsWorld.get());
         btRaycastVehicle::btVehicleTuning tuning;
 
         float travel = fabs(info->handling.suspensionUpperLimit -

--- a/rwengine/src/script/ScriptDisassembly.cpp
+++ b/rwengine/src/script/ScriptDisassembly.cpp
@@ -1,8 +1,9 @@
 #include <script/SCMFile.hpp>
 #include <script/ScriptDisassembly.hpp>
 #include <script/ScriptMachine.hpp>
+#include <script/ScriptModule.hpp>
 
-ScriptDisassembly::ScriptDisassembly(SCMOpcodes* _codes, SCMFile* _scm)
+ScriptDisassembly::ScriptDisassembly(ScriptModule* _codes, SCMFile* _scm)
     : codes(_codes), scm(_scm) {
 }
 

--- a/rwengine/src/script/ScriptDisassembly.hpp
+++ b/rwengine/src/script/ScriptDisassembly.hpp
@@ -27,7 +27,7 @@ public:
         uint8_t flags;
     };
 
-    ScriptDisassembly(SCMOpcodes* codes, SCMFile* scm);
+    ScriptDisassembly(ScriptModule* codes, SCMFile* scm);
 
     /**
      * Execute the disassembly routine.
@@ -42,7 +42,7 @@ public:
     }
 
 private:
-    SCMOpcodes* codes;
+    ScriptModule* codes;
     SCMFile* scm;
 
     std::map<SCMAddress, InstructionInfo> instructions;

--- a/rwengine/src/script/ScriptMachine.hpp
+++ b/rwengine/src/script/ScriptMachine.hpp
@@ -120,15 +120,11 @@ struct SCMThread {
  */
 class ScriptMachine {
 public:
-    ScriptMachine(GameState* state, SCMFile* file, SCMOpcodes* ops);
-    ~ScriptMachine();
+    ScriptMachine(GameState* state, SCMFile* file, ScriptModule* ops);
+    ~ScriptMachine() { }
 
     SCMFile* getFile() const {
-        return _file;
-    }
-
-    SCMOpcodes* getOpcodes() const {
-        return _ops;
+        return file;
     }
 
     void startThread(SCMThread::pc_t start, bool mission = false);
@@ -152,8 +148,8 @@ public:
     void execute(float dt);
 
 private:
-    SCMFile* _file;
-    SCMOpcodes* _ops;
+    SCMFile* file;
+    ScriptModule* module;
     GameState* state;
 
     std::list<SCMThread> _activeThreads;

--- a/rwengine/src/script/ScriptTypes.hpp
+++ b/rwengine/src/script/ScriptTypes.hpp
@@ -376,12 +376,4 @@ struct SCMMicrocode {
 
 typedef std::map<SCMOpcode, SCMMicrocode> SCMMicrocodeTable;
 
-struct SCMOpcodes {
-    std::vector<ScriptModule*> modules;
-
-    ~SCMOpcodes();
-
-    bool findOpcode(ScriptFunctionID id, ScriptFunctionMeta** out);
-};
-
 #endif

--- a/rwgame/CMakeLists.txt
+++ b/rwgame/CMakeLists.txt
@@ -19,6 +19,9 @@ set(RWGAME_SOURCES
 	StateManager.cpp
 	State.cpp
 
+	MenuSystem.hpp
+	MenuSystem.cpp
+
 	states/LoadingState.hpp
 	states/LoadingState.cpp
 	states/IngameState.hpp

--- a/rwgame/CMakeLists.txt
+++ b/rwgame/CMakeLists.txt
@@ -8,6 +8,8 @@ set(RWGAME_SOURCES
 
 	main.cpp
 
+	GameBase.hpp
+	GameBase.cpp
 	RWGame.cpp
 
 	GameConfig.cpp

--- a/rwgame/CMakeLists.txt
+++ b/rwgame/CMakeLists.txt
@@ -15,6 +15,8 @@ set(RWGAME_SOURCES
 	GameConfig.cpp
 	GameWindow.cpp
 
+	StateManager.hpp
+	StateManager.cpp
 	State.cpp
 
 	states/LoadingState.hpp

--- a/rwgame/GameBase.cpp
+++ b/rwgame/GameBase.cpp
@@ -1,0 +1,69 @@
+#include "GameBase.hpp"
+#include "GitSHA1.h"
+
+#include "SDL.h"
+
+// Use first 8 chars of git hash as the build string
+const std::string kBuildStr(kGitSHA1Hash, 8);
+const std::string kWindowTitle = "RWGame";
+constexpr int kWindowWidth = 800;
+constexpr int kWindowHeight = 600;
+
+GameBase::GameBase(Logger &inlog, int argc, char *argv[]) : log(inlog) {
+    log.info("Game", "Build: " + kBuildStr);
+
+    if (!config.isValid()) {
+        throw std::runtime_error("Invalid configuration file at: " +
+                                 config.getConfigFile());
+    }
+
+    size_t w = kWindowWidth, h = kWindowHeight;
+    bool fullscreen = false;
+    bool help = false;
+
+    // Define and parse command line options
+    namespace po = boost::program_options;
+    po::options_description desc("Available options");
+    desc.add_options()("help", "Show this help message")(
+        "width,w", po::value<size_t>(), "Game resolution width in pixel")(
+        "height,h", po::value<size_t>(), "Game resolution height in pixel")(
+        "fullscreen,f", "Enable fullscreen mode")("newgame,n",
+                                                  "Directly start a new game")(
+        "test,t", "Starts a new game in a test location")(
+        "load,l", po::value<std::string>(), "Load save file")(
+        "benchmark,b", po::value<std::string>(), "Run benchmark from file");
+
+    po::variables_map &vm = options;
+    try {
+        po::store(po::parse_command_line(argc, argv, desc), vm);
+        po::notify(vm);
+    } catch (po::error &ex) {
+        help = true;
+        std::cout << "Error parsing arguments: " << ex.what() << std::endl;
+    }
+
+    if (help || vm.count("help")) {
+        std::cout << desc;
+        throw std::invalid_argument("");
+    }
+    if (vm.count("width")) {
+        w = vm["width"].as<size_t>();
+    }
+    if (vm.count("height")) {
+        h = vm["height"].as<size_t>();
+    }
+    if (vm.count("fullscreen")) {
+        fullscreen = true;
+    }
+
+    if (SDL_Init(SDL_INIT_VIDEO) < 0)
+        throw std::runtime_error("Failed to initialize SDL2!");
+
+    window.create(kWindowTitle + " [" + kBuildStr + "]", w, h, fullscreen);
+}
+
+GameBase::~GameBase() {
+    SDL_Quit();
+
+    log.info("Game", "Done cleaning up");
+}

--- a/rwgame/GameBase.hpp
+++ b/rwgame/GameBase.hpp
@@ -1,0 +1,33 @@
+#ifndef RWGAME_GAMEBASE_HPP
+#define RWGAME_GAMEBASE_HPP
+#include "GameConfig.hpp"
+#include "GameWindow.hpp"
+
+#include <core/Logger.hpp>
+
+#include <boost/program_options.hpp>
+
+/**
+ * @brief Handles basic window and setup
+ */
+class GameBase {
+public:
+    GameBase(Logger& inlog, int argc, char* argv[]);
+    ~GameBase();
+
+    GameWindow& getWindow() {
+        return window;
+    }
+
+    const GameConfig& getConfig() const {
+        return config;
+    }
+
+protected:
+    Logger& log;
+    GameConfig config{"openrw.ini"};
+    GameWindow window;
+    boost::program_options::variables_map options;
+};
+
+#endif

--- a/rwgame/MenuSystem.hpp
+++ b/rwgame/MenuSystem.hpp
@@ -21,27 +21,35 @@ constexpr const char* kOptionsId = "FET_OPT";
 constexpr const char* kQuitGameId = "FET_QG";
 }
 
+/**
+ * @brief Implements user navigable menus
+ *
+ * This is a temporary implementation
+ */
 class Menu {
-    int font;
-
 public:
-    Menu(int font = MenuDefaults::kFont) : font(font), activeEntry(-1) {
-    }
-
-    struct MenuEntry {
+    /**
+     * @brief Handles rendering and dispatch of menu items
+     */
+    class MenuEntry {
         GameString text;
-        float _size;
+        float size;
+        std::function<void(void)> callback;
 
-        MenuEntry(const GameString& n, float size = 30.f)
-            : text(n), _size(size) {
+    public:
+        MenuEntry(const std::string& n, std::function<void(void)> cb)
+            : text(GameStringUtil::fromString(n)), size(30.f), callback(cb) {
+        }
+        MenuEntry(const GameString& n, std::function<void(void)> cb,
+                  float size = 30.f)
+            : text(n), size(size), callback(cb) {
         }
 
-        float getHeight() {
-            return _size;
+        float getHeight() const {
+            return size;
         }
 
-        virtual void draw(int font, bool active, GameRenderer* r,
-                          glm::vec2& basis) {
+        void draw(int font, bool active, GameRenderer* r, glm::vec2& basis) {
             TextRenderer::TextInfo ti;
             ti.font = font;
             ti.screenPosition = basis;
@@ -56,16 +64,6 @@ public:
             basis.y += getHeight();
         }
 
-        virtual void activate(float clickX, float clickY) = 0;
-    };
-
-    struct Entry : public MenuEntry {
-        std::function<void(void)> callback;
-
-        Entry(const GameString& title, std::function<void(void)> cb, float size)
-            : MenuEntry(title, size), callback(cb) {
-        }
-
         void activate(float clickX, float clickY) {
             RW_UNUSED(clickX);
             RW_UNUSED(clickY);
@@ -73,19 +71,28 @@ public:
         }
     };
 
-    static std::shared_ptr<MenuEntry> lambda(const GameString& n,
-                                             std::function<void(void)> callback,
-                                             float size = 30.f) {
-        return std::shared_ptr<MenuEntry>(new Entry(n, callback, size));
+    Menu(std::vector<MenuEntry> initial, int font = MenuDefaults::kFont)
+        : activeEntry(-1), font(font), entries(std::move(initial)) {
     }
 
-    static std::shared_ptr<MenuEntry> lambda(const std::string& n,
-                                             std::function<void(void)> callback,
-                                             float size = 30.f) {
-        return lambda(GameStringUtil::fromString(n), callback, size);
+    /**
+     * @brief creates a menu from the given menu items
+     * @return a shared pointer to the menu with the items
+     */
+    static std::shared_ptr<Menu> create(std::vector<MenuEntry> items,
+                                        int font = MenuDefaults::kFont) {
+        return std::make_shared<Menu>(std::move(items), font);
     }
 
-    std::vector<std::shared_ptr<MenuEntry>> entries;
+    Menu& lambda(const GameString& n, std::function<void()> callback) {
+        entries.emplace_back(n, callback, 30.f);
+        return *this;
+    }
+
+    Menu& lambda(const std::string& n, std::function<void(void)> callback) {
+        entries.emplace_back(GameStringUtil::fromString(n), callback, 30.f);
+        return *this;
+    }
 
     /**
      * Active Entry index
@@ -94,10 +101,6 @@ public:
 
     glm::vec2 offset;
 
-    void addEntry(std::shared_ptr<MenuEntry> entry) {
-        entries.push_back(entry);
-    }
-
     void draw(GameRenderer* r) {
         glm::vec2 basis(offset);
         for (size_t i = 0; i < entries.size(); ++i) {
@@ -105,18 +108,18 @@ public:
             if (activeEntry >= 0 && i == (unsigned)activeEntry) {
                 active = true;
             }
-            entries[i]->draw(font, active, r, basis);
+            entries[i].draw(font, active, r, basis);
         }
     }
 
     void hover(const float x, const float y) {
         glm::vec2 c(x - offset.x, y - offset.y);
         for (size_t i = 0; i < entries.size(); ++i) {
-            if (c.y > 0.f && c.y < entries[i]->getHeight()) {
+            if (c.y > 0.f && c.y < entries[i].getHeight()) {
                 activeEntry = i;
                 return;
             } else {
-                c.y -= entries[i]->getHeight();
+                c.y -= entries[i].getHeight();
             }
         }
     }
@@ -124,11 +127,11 @@ public:
     void click(const float x, const float y) {
         glm::vec2 c(x - offset.x, y - offset.y);
         for (auto it = entries.begin(); it != entries.end(); ++it) {
-            if (c.y > 0.f && c.y < (*it)->getHeight()) {
-                (*it)->activate(c.x, c.y);
+            if (c.y > 0.f && c.y < (*it).getHeight()) {
+                (*it).activate(c.x, c.y);
                 return;
             } else {
-                c.y -= (*it)->getHeight();
+                c.y -= (*it).getHeight();
             }
         }
     }
@@ -136,7 +139,7 @@ public:
     // Activates the menu entry at the current active index.
     void activate() {
         if (activeEntry >= 0 && (unsigned)activeEntry < entries.size()) {
-            entries[activeEntry]->activate(0.f, 0.f);
+            entries[activeEntry].activate(0.f, 0.f);
         }
     }
 
@@ -148,6 +151,14 @@ public:
             activeEntry = entries.size() - 1;
         }
     }
+
+    const std::vector<MenuEntry>& getEntries() const {
+        return entries;
+    }
+
+private:
+    int font;
+    std::vector<MenuEntry> entries;
 };
 
 #endif

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -7,6 +7,7 @@
 #include "states/MenuState.hpp"
 
 #include <core/Profiler.hpp>
+#include <core/Logger.hpp>
 
 #include <engine/GameState.hpp>
 #include <engine/GameWorld.hpp>
@@ -42,9 +43,7 @@ std::map<GameRenderer::SpecialModel, std::string> kSpecialModels = {
 
 DebugDraw* debug = nullptr;
 
-StdOutReciever logPrinter;
-
-RWGame::RWGame(int argc, char* argv[]) {
+RWGame::RWGame(Logger& log, int argc, char* argv[]) : log(log) {
     if (!config.isValid()) {
         throw std::runtime_error("Invalid configuration file at: " +
                                  config.getConfigFile());
@@ -113,7 +112,6 @@ RWGame::RWGame(int argc, char* argv[]) {
 
     work = new WorkContext();
 
-    log.addReciever(&logPrinter);
     log.info("Game", "Game directory: " + config.getGameDataPath());
     log.info("Game", "Build: " + kBuildStr);
 

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -2,7 +2,6 @@
 #define _RWGAME_HPP_
 
 #include <chrono>
-#include <core/Logger.hpp>
 #include <engine/GameData.hpp>
 #include <engine/GameWorld.hpp>
 #include <render/GameRenderer.hpp>
@@ -15,9 +14,10 @@
 #include "SDL.h"
 
 class PlayerController;
+class Logger;
 
 class RWGame {
-    Logger log;
+    Logger& log;
     GameConfig config{"openrw.ini"};
     GameState* state = nullptr;
     GameData* data = nullptr;
@@ -51,7 +51,7 @@ class RWGame {
     float timescale = 1.f;
 
 public:
-    RWGame(int argc, char* argv[]);
+    RWGame(Logger& log, int argc, char* argv[]);
     ~RWGame();
 
     int run();

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -8,6 +8,7 @@
 #include <render/DebugDraw.hpp>
 #include <render/GameRenderer.hpp>
 #include <script/ScriptMachine.hpp>
+#include <script/modules/GTA3Module.hpp>
 #include "game.hpp"
 
 #include "GameBase.hpp"
@@ -22,7 +23,11 @@ class RWGame : public GameBase {
     GameState state;
 
     std::unique_ptr<GameWorld> world;
-    ScriptMachine* script = nullptr;
+
+    GTA3Module opcodes;
+    std::unique_ptr<ScriptMachine> vm;
+    std::unique_ptr<SCMFile> script;
+
     std::chrono::steady_clock clock;
     std::chrono::steady_clock::time_point last_clock_time;
 
@@ -72,8 +77,8 @@ public:
         return renderer;
     }
 
-    ScriptMachine* getScript() const {
-        return script;
+    ScriptMachine *getScriptVM() const {
+        return vm.get();
     }
 
     bool hitWorldRay(glm::vec3& hit, glm::vec3& normal,

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -1,5 +1,5 @@
-#ifndef _RWGAME_HPP_
-#define _RWGAME_HPP_
+#ifndef RWGAME_RWGAME_HPP
+#define RWGAME_RWGAME_HPP
 
 #include <chrono>
 #include <engine/GameData.hpp>

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -3,9 +3,10 @@
 
 #include <chrono>
 #include <engine/GameData.hpp>
+#include <engine/GameState.hpp>
 #include <engine/GameWorld.hpp>
-#include <render/GameRenderer.hpp>
 #include <render/DebugDraw.hpp>
+#include <render/GameRenderer.hpp>
 #include <script/ScriptMachine.hpp>
 #include "game.hpp"
 
@@ -18,8 +19,8 @@ class RWGame : public GameBase {
     GameData data;
     GameRenderer renderer;
     DebugDraw debug;
+    GameState state;
 
-    GameState* state = nullptr;
     GameWorld* world = nullptr;
     ScriptMachine* script = nullptr;
     std::chrono::steady_clock clock;
@@ -55,8 +56,8 @@ public:
      */
     void newGame();
 
-    GameState* getState() const {
-        return state;
+    GameState* getState() {
+        return &state;
     }
 
     GameWorld* getWorld() const {

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -21,7 +21,7 @@ class RWGame : public GameBase {
     DebugDraw debug;
     GameState state;
 
-    GameWorld* world = nullptr;
+    std::unique_ptr<GameWorld> world;
     ScriptMachine* script = nullptr;
     std::chrono::steady_clock clock;
     std::chrono::steady_clock::time_point last_clock_time;
@@ -60,8 +60,8 @@ public:
         return &state;
     }
 
-    GameWorld* getWorld() const {
-        return world;
+    GameWorld* getWorld() {
+        return world.get();
     }
 
     const GameData& getGameData() const {

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -8,24 +8,17 @@
 #include <script/ScriptMachine.hpp>
 #include "game.hpp"
 
-#include "GameConfig.hpp"
-#include "GameWindow.hpp"
-
-#include "SDL.h"
+#include "GameBase.hpp"
 
 class PlayerController;
-class Logger;
 
-class RWGame {
-    Logger& log;
-    GameConfig config{"openrw.ini"};
+class RWGame : public GameBase {
     GameState* state = nullptr;
     GameData* data = nullptr;
     GameWorld* world = nullptr;
     // must be allocated after Logger setup.
     GameRenderer* renderer = nullptr;
     ScriptMachine* script = nullptr;
-    GameWindow* window = nullptr;
     // Background worker
     WorkContext* work = nullptr;
     std::chrono::steady_clock clock;
@@ -77,16 +70,8 @@ public:
         return renderer;
     }
 
-    GameWindow& getWindow() {
-        return *window;
-    }
-
     ScriptMachine* getScript() const {
         return script;
-    }
-
-    const GameConfig& getConfig() const {
-        return config;
     }
 
     bool hitWorldRay(glm::vec3& hit, glm::vec3& normal,

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -5,6 +5,7 @@
 #include <engine/GameData.hpp>
 #include <engine/GameWorld.hpp>
 #include <render/GameRenderer.hpp>
+#include <render/DebugDraw.hpp>
 #include <script/ScriptMachine.hpp>
 #include "game.hpp"
 
@@ -13,14 +14,14 @@
 class PlayerController;
 
 class RWGame : public GameBase {
+    WorkContext work;
+    GameData data;
+    GameRenderer renderer;
+    DebugDraw debug;
+
     GameState* state = nullptr;
-    GameData* data = nullptr;
     GameWorld* world = nullptr;
-    // must be allocated after Logger setup.
-    GameRenderer* renderer = nullptr;
     ScriptMachine* script = nullptr;
-    // Background worker
-    WorkContext* work = nullptr;
     std::chrono::steady_clock clock;
     std::chrono::steady_clock::time_point last_clock_time;
 
@@ -62,11 +63,11 @@ public:
         return world;
     }
 
-    GameData* getGameData() const {
+    const GameData& getGameData() const {
         return data;
     }
 
-    GameRenderer* getRenderer() const {
+    GameRenderer& getRenderer() {
         return renderer;
     }
 

--- a/rwgame/State.hpp
+++ b/rwgame/State.hpp
@@ -1,8 +1,5 @@
-#ifndef _GAME_STATE_HPP_
-#define _GAME_STATE_HPP_
-#include <functional>
-#include <glm/gtc/quaternion.hpp>
-#include <queue>
+#ifndef RWGAME_STATE_HPP
+#define RWGAME_STATE_HPP
 #include <render/ViewCamera.hpp>
 #include "GameWindow.hpp"
 #include "MenuSystem.hpp"
@@ -11,8 +8,10 @@
 
 class RWGame;
 class GameWorld;
+class StateManager;
 
-struct State {
+class State {
+public:
     // Helper for global menu behaviour
     Menu* currentMenu;
     Menu* nextMenu;
@@ -66,46 +65,15 @@ struct State {
 
     GameWorld* getWorld();
     GameWindow& getWindow();
-};
 
-struct StateManager {
-    static StateManager& get() {
-        static StateManager m;
-        return m;
+    bool hasExited() const {
+        return hasexited_;
     }
 
-    std::deque<State*> states;
-
-    void clear() {
-        states.clear();
-    }
-
-    void enter(State* state) {
-        states.push_back(state);
-        state->enter();
-    }
-
-    void exec(State* state) {
-        exit();
-        enter(state);
-    }
-
-    void tick(float dt) {
-        states.back()->tick(dt);
-    }
-
-    void draw(GameRenderer* r) {
-        states.back()->draw(r);
-    }
-
-    void exit() {
-        // TODO: Resole states being leaked.
-        states.back()->exit();
-        states.pop_back();
-        if (states.size() > 0) {
-            states.back()->enter();
-        }
-    }
+private:
+    bool hasexited_ = false;
+protected:
+    void done() { hasexited_ = true; }
 };
 
 #endif

--- a/rwgame/State.hpp
+++ b/rwgame/State.hpp
@@ -12,13 +12,12 @@ class StateManager;
 
 class State {
 public:
-    // Helper for global menu behaviour
-    Menu* currentMenu;
-    Menu* nextMenu;
+    std::shared_ptr<Menu> menu;
+    std::shared_ptr<Menu> nextMenu;
 
     RWGame* game;
 
-    State(RWGame* game) : currentMenu(nullptr), nextMenu(nullptr), game(game) {
+    State(RWGame* game) : game(game) {
     }
 
     virtual void enter() = 0;
@@ -33,24 +32,18 @@ public:
     }
 
     virtual ~State() {
-        if (getCurrentMenu()) {
-            delete getCurrentMenu();
-        }
     }
 
-    void enterMenu(Menu* menu) {
+    void enterMenu(const std::shared_ptr<Menu>& menu) {
         nextMenu = menu;
     }
 
     Menu* getCurrentMenu() {
         if (nextMenu) {
-            if (currentMenu) {
-                delete currentMenu;
-            }
-            currentMenu = nextMenu;
+            menu = nextMenu;
             nextMenu = nullptr;
         }
-        return currentMenu;
+        return menu.get();
     }
 
     virtual void handleEvent(const SDL_Event& e);
@@ -72,8 +65,11 @@ public:
 
 private:
     bool hasexited_ = false;
+
 protected:
-    void done() { hasexited_ = true; }
+    void done() {
+        hasexited_ = true;
+    }
 };
 
 #endif

--- a/rwgame/StateManager.hpp
+++ b/rwgame/StateManager.hpp
@@ -1,0 +1,70 @@
+#ifndef RWGAME_STATEMANAGER_HPP
+#define RWGAME_STATEMANAGER_HPP
+#include "State.hpp"
+
+#include <memory>
+#include <queue>
+
+/**
+ * @brief Handles current state focus and transitions
+ *
+ * Possible states:
+ * 	Foreground (topmost state)
+ *  Background (any other position)
+ *
+ * Transitions:
+ *  New State (at the top)
+ *  Suspended (a state was created above us)
+ *  Resumed   (blocking state was removed)
+ */
+class StateManager {
+public:
+    static StateManager& get() {
+        static StateManager m;
+        return m;
+    }
+
+    std::deque<std::unique_ptr<State>> states;
+
+    void clear() {
+        cleared = true;
+    }
+
+    template <class T, class... Targs>
+    void enter(Targs&&... args) {
+        // Notify the previous state it has been suspended
+        if (!states.empty()) {
+            states.back()->exit();
+        }
+        states.emplace_back(std::move(std::make_unique<T>(args...)));
+        states.back()->enter();
+    }
+
+    void updateStack() {
+        if (cleared) {
+            states.clear();
+            cleared = false;
+        }
+
+        while (!states.empty() && states.back()->hasExited()) {
+            states.back()->exit();
+            states.pop_back();
+            if (!states.empty()) {
+                states.back()->enter();
+            }
+        }
+    }
+
+    void tick(float dt) {
+        states.back()->tick(dt);
+    }
+
+    void draw(GameRenderer* r) {
+        states.back()->draw(r);
+    }
+
+private:
+    bool cleared = false;
+};
+
+#endif

--- a/rwgame/game.hpp
+++ b/rwgame/game.hpp
@@ -15,7 +15,5 @@ bool hitWorldRay(const glm::vec3& start, const glm::vec3& direction,
                  GameObject** object = nullptr);
 
 #define GAME_TIMESTEP (1.f / 30.f)
-#define GAME_WINDOW_WIDTH 800
-#define GAME_WINDOW_HEIGHT 600
 
 #endif  // GAME_HPP

--- a/rwgame/main.cpp
+++ b/rwgame/main.cpp
@@ -2,9 +2,15 @@
 #include "RWGame.hpp"
 #include "SDL.h"
 
+#include <core/Logger.hpp>
+
 int main(int argc, char* argv[]) {
+    // Initialise Logging before anything else happens
+    StdOutReciever logstdout;
+    Logger logger({ &logstdout });
+
     try {
-        RWGame game(argc, argv);
+        RWGame game(logger, argc, argv);
 
         return game.run();
     } catch (std::invalid_argument& ex) {
@@ -20,7 +26,7 @@ int main(int argc, char* argv[]) {
 
         const char* kErrorTitle = "Fatal Error";
 
-        std::cerr << kErrorTitle << "\n" << ex.what() << std::endl;
+        logger.error("exception", ex.what());
 
         if (SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, kErrorTitle,
                                      ex.what(), NULL) < 0) {

--- a/rwgame/states/BenchmarkState.cpp
+++ b/rwgame/states/BenchmarkState.cpp
@@ -77,7 +77,7 @@ void BenchmarkState::tick(float dt) {
             a = p;
         }
         if (benchmarkTime > duration) {
-            StateManager::get().exit();
+            done();
         }
         if (b.time != a.time) {
             float alpha = (benchmarkTime - a.time) / (b.time - a.time);

--- a/rwgame/states/DebugState.cpp
+++ b/rwgame/states/DebugState.cpp
@@ -219,35 +219,6 @@ void DebugState::exit() {
 }
 
 void DebugState::tick(float dt) {
-    /*if(debugObject) {
-        auto p = debugObject->getPosition();
-        ss << "Position: " << p.x << " " << p.y << " " << p.z << std::endl;
-        ss << "Health: " << debugObject->mHealth << std::endl;
-        if(debugObject->model) {
-            auto m = debugObject->model;
-            ss << "Textures: " << std::endl;
-            for(auto it = m->geometries.begin(); it != m->geometries.end();
-                ++it )
-            {
-                auto g = *it;
-                for(auto itt = g->materials.begin(); itt != g->materials.end();
-                    ++itt)
-                {
-                    for(auto tit = itt->textures.begin(); tit !=
-    itt->textures.end();
-                        ++tit)
-                    {
-                        ss << " " << tit->name << std::endl;
-                    }
-                }
-            }
-        }
-        if(debugObject->type() == GameObject::Vehicle) {
-            GTAVehicle* vehicle = static_cast<GTAVehicle*>(debugObject);
-            ss << "ID: " << vehicle->info->handling.ID << std::endl;
-        }
-    }*/
-
     if (_freeLook) {
         _debugCam.rotation =
             glm::angleAxis(_debugLook.x, glm::vec3(0.f, 0.f, 1.f)) *

--- a/rwgame/states/DebugState.cpp
+++ b/rwgame/states/DebugState.cpp
@@ -115,7 +115,7 @@ Menu* DebugState::createDebugMenu() {
                              kDebugEntryHeight));
     m->addEntry(Menu::lambda(
         "Cull Here",
-        [=] { game->getRenderer()->setCullOverride(true, _debugCam); },
+        [=] { game->getRenderer().setCullOverride(true, _debugCam); },
         kDebugEntryHeight));
 
     // Optional block if the player is in a vehicle

--- a/rwgame/states/DebugState.cpp
+++ b/rwgame/states/DebugState.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<Menu> DebugState::createDebugMenu() {
          {"Full Armour", [=] { player->getCurrentState().armour = 100.f; }},
          {"Cull Here",
           [=] { game->getRenderer().setCullOverride(true, _debugCam); }}},
-        kDebugFont);
+        kDebugFont, kDebugEntryHeight);
 
     menu->offset = kDebugMenuOffset;
 
@@ -134,7 +134,7 @@ std::shared_ptr<Menu> DebugState::createMapMenu() {
                   }
               }
           }}},
-        kDebugFont);
+        kDebugFont, kDebugEntryHeight);
 
     menu->offset = kDebugMenuOffset;
     return menu;
@@ -142,7 +142,7 @@ std::shared_ptr<Menu> DebugState::createMapMenu() {
 
 std::shared_ptr<Menu> DebugState::createVehicleMenu() {
     auto menu = Menu::create({{"Back", [=] { enterMenu(createDebugMenu()); }}},
-                             kDebugFont);
+                             kDebugFont, kDebugEntryHeight);
 
     const std::map<std::string, int> kVehicleTypes = {
         {"Landstalker", 90}, {"Taxi", 110},      {"Firetruck", 97},
@@ -161,8 +161,9 @@ std::shared_ptr<Menu> DebugState::createVehicleMenu() {
 }
 
 std::shared_ptr<Menu> DebugState::createAIMenu() {
-    auto menu = Menu::create(
-        {{"Back", [=] { this->enterMenu(createDebugMenu()); }}}, kDebugFont);
+    auto menu =
+        Menu::create({{"Back", [=] { this->enterMenu(createDebugMenu()); }}},
+                     kDebugFont, kDebugEntryHeight);
 
     const std::map<std::string, int> kPedTypes = {
         {"Triad", 12}, {"Cop", 1},     {"SWAT", 2},
@@ -189,8 +190,9 @@ std::shared_ptr<Menu> DebugState::createAIMenu() {
 }
 
 std::shared_ptr<Menu> DebugState::createWeaponMenu() {
-    auto menu = Menu::create(
-        {{"Back", [=] { this->enterMenu(createDebugMenu()); }}}, kDebugFont);
+    auto menu =
+        Menu::create({{"Back", [=] { this->enterMenu(createDebugMenu()); }}},
+                     kDebugFont, kDebugEntryHeight);
 
     for (int i = 1; i < kMaxInventorySlots; ++i) {
         auto& name = getWorld()->data->weaponData[i]->name;

--- a/rwgame/states/DebugState.cpp
+++ b/rwgame/states/DebugState.cpp
@@ -11,6 +11,7 @@
 #include "RWGame.hpp"
 
 constexpr float kDebugEntryHeight = 14.f;
+constexpr int kDebugFont = 2;
 const glm::vec2 kDebugMenuOffset = glm::vec2(10.f, 50.f);
 
 static void jumpCharacter(RWGame* game, CharacterObject* player,
@@ -29,195 +30,119 @@ static void jumpCharacter(RWGame* game, CharacterObject* player,
     }
 }
 
-Menu* DebugState::createDebugMenu() {
+std::shared_ptr<Menu> DebugState::createDebugMenu() {
     CharacterObject* player = nullptr;
     if (game->getPlayer()) {
         player = game->getPlayer()->getCharacter();
     }
 
-    Menu* m = new Menu(2);
-    m->offset = kDebugMenuOffset;
-#if 0
-	m->addEntry(Menu::lambda("Random Vehicle", [this] {
-		auto it = getWorld()->vehicleTypes.begin();
-		std::uniform_int_distribution<int> uniform(0, 3);
-		for(size_t i = 0, n = uniform(getWorld()->randomEngine); i != n; i++) {
-			it++;
-		}
-		spawnVehicle(it->first);
-	}, entryHeight));
-	m->addEntry(Menu::lambda("Open All Doors/Flaps", [=] {
-		auto pc = getWorld()->state->player->getCharacter();
-		auto pv = pc->getCurrentVehicle();
-		if( pv ) {
-			for(auto& it : pv->_hingedObjects) {
-				pv->setHingeLocked(it.first, false);
-			}
-		}
-	}, entryHeight));
+    auto menu = Menu::create(
+        {{"Jump to Debug Camera",
+          [=] {
+              jumpCharacter(game, player,
+                            _debugCam.position +
+                                _debugCam.rotation * glm::vec3(3.f, 0.f, 0.f),
+                            false);
+          }},
+         {"-Map", [=] { this->enterMenu(createMapMenu()); }},
+         {"-Vehicles", [=] { this->enterMenu(createVehicleMenu()); }},
+         {"-AI", [=] { this->enterMenu(createAIMenu()); }},
+         {"-Weapons", [=] { this->enterMenu(createWeaponMenu()); }},
+         {"Set Super Jump", [=] { player->setJumpSpeed(20.f); }},
+         {"Set Normal Jump",
+          [=] { player->setJumpSpeed(CharacterObject::DefaultJumpSpeed); }},
+         {"Full Health", [=] { player->getCurrentState().health = 100.f; }},
+         {"Full Armour", [=] { player->getCurrentState().armour = 100.f; }},
+         {"Cull Here",
+          [=] { game->getRenderer().setCullOverride(true, _debugCam); }}},
+        kDebugFont);
 
-	m->addEntry(Menu::lambda("Spawn Pedestrians", [=] {
-		glm::vec3 hit, normal;
-		if(game->hitWorldRay(hit, normal)) {
-			glm::vec3 spawnPos = hit + glm::vec3(-5, 0.f, 0.0) + normal;
-			size_t k = 1;
-			// Spawn every pedestrian.
-			for(auto it = getWorld()->pedestrianTypes.begin();
-				it != getWorld()->pedestrianTypes.end(); ++it) {
-				getWorld()->createPedestrian(it->first, spawnPos);
-				spawnPos += glm::vec3(2.5, 0, 0);
-				if((k++ % 6) == 0) { spawnPos += glm::vec3(-15, -2.5, 0); }
-			}
-		}
-	}, entryHeight));
-
-	int vehiclesMax = 16, i = 0;
-	for( auto& v : getWorld()->vehicleTypes ) {
-		if( (i++) > vehiclesMax ) break;
-		m->addEntry(Menu::lambda(v.second->handlingID, [=] {
-			spawnVehicle(v.first);
-		}, entryHeight));
-	}
-#endif
-    m->addEntry(Menu::lambda("Jump to Debug Camera",
-                             [=] {
-                                 jumpCharacter(game, player,
-                                               _debugCam.position +
-                                                   _debugCam.rotation *
-                                                       glm::vec3(3.f, 0.f, 0.f),
-                                               false);
-                             },
-                             kDebugEntryHeight));
-
-    m->addEntry(Menu::lambda("-Map", [=] { this->enterMenu(createMapMenu()); },
-                             kDebugEntryHeight));
-    m->addEntry(Menu::lambda("-Vehicles",
-                             [=] { this->enterMenu(createVehicleMenu()); },
-                             kDebugEntryHeight));
-    m->addEntry(Menu::lambda("-AI", [=] { this->enterMenu(createAIMenu()); },
-                             kDebugEntryHeight));
-    m->addEntry(Menu::lambda("-Weapons",
-                             [=] { this->enterMenu(createWeaponMenu()); },
-                             kDebugEntryHeight));
-
-    m->addEntry(Menu::lambda("Set Super Jump",
-                             [=] { player->setJumpSpeed(20.f); },
-                             kDebugEntryHeight));
-    m->addEntry(Menu::lambda(
-        "Set Normal Jump",
-        [=] { player->setJumpSpeed(CharacterObject::DefaultJumpSpeed); },
-        kDebugEntryHeight));
-    m->addEntry(Menu::lambda("Full Health",
-                             [=] { player->getCurrentState().health = 100.f; },
-                             kDebugEntryHeight));
-    m->addEntry(Menu::lambda("Full Armour",
-                             [=] { player->getCurrentState().armour = 100.f; },
-                             kDebugEntryHeight));
-    m->addEntry(Menu::lambda(
-        "Cull Here",
-        [=] { game->getRenderer().setCullOverride(true, _debugCam); },
-        kDebugEntryHeight));
+    menu->offset = kDebugMenuOffset;
 
     // Optional block if the player is in a vehicle
     auto cv = player->getCurrentVehicle();
     if (cv) {
-        m->addEntry(Menu::lambda(
-            "Flip vehicle",
-            [=] {
-                cv->setRotation(
-                    cv->getRotation() *
-                    glm::quat(glm::vec3(0.f, glm::pi<float>(), 0.f)));
-            },
-            kDebugEntryHeight));
+        menu->lambda("Flip vehicle", [=] {
+            cv->setRotation(cv->getRotation() *
+                            glm::quat(glm::vec3(0.f, glm::pi<float>(), 0.f)));
+        });
     }
 
-    return m;
+    return menu;
 }
 
-Menu* DebugState::createMapMenu() {
+std::shared_ptr<Menu> DebugState::createMapMenu() {
     CharacterObject* player = nullptr;
     if (game->getPlayer()) {
         player = game->getPlayer()->getCharacter();
     }
 
-    Menu* m = new Menu(2);
-    m->offset = kDebugMenuOffset;
+    auto menu = Menu::create(
+        {{"Back", [=] { enterMenu(createDebugMenu()); }},
+         {"Jump to Docks",
+          [=] {
+              jumpCharacter(game, player, glm::vec3(1390.f, -837.f, 100.f));
+          }},
+         {"Jump to Garage",
+          [=] { jumpCharacter(game, player, glm::vec3(270.f, -605.f, 40.f)); }},
+         {"Jump to Airport",
+          [=] {
+              jumpCharacter(game, player, glm::vec3(-950.f, -980.f, 12.f));
+          }},
+         {"Jump to Hideout",
+          [=] {
+              jumpCharacter(game, player, glm::vec3(875.0, -309.0, 100.0));
+          }},
+         {"Jump to Luigi's",
+          [=] {
+              jumpCharacter(game, player, glm::vec3(902.75, -425.56, 100.0));
+          }},
+         {"Jump to Hospital",
+          [=] {
+              jumpCharacter(game, player, glm::vec3(1123.77, -569.15, 100.0));
+          }},
+         {"Unsolid garage doors",
+          [=] {
 
-    m->addEntry(Menu::lambda("Back",
-                             [=] { this->enterMenu(createDebugMenu()); },
-                             kDebugEntryHeight));
+              std::vector<std::string> garageDoorModels{
+                  "8ballsuburbandoor",  "amcogaragedoor",
+                  "bankjobdoor",        "bombdoor",
+                  "crushercrush",       "crushertop",
+                  "door2_garage",       "door3_garage",
+                  "door4_garage",       "door_bombshop",
+                  "door_col_compnd_01", "door_col_compnd_02",
+                  "door_col_compnd_03", "door_col_compnd_04",
+                  "door_col_compnd_05", "door_jmsgrage",
+                  "door_sfehousegrge",  "double_garage_dr",
+                  "impex_door",         "impexpsubgrgdoor",
+                  "ind_plyrwoor",       "ind_slidedoor",
+                  "jamesgrge_kb",       "leveldoor2",
+                  "oddjgaragdoor",      "plysve_gragedoor",
+                  "SalvGarage",         "shedgaragedoor",
+                  "Sub_sprayshopdoor",  "towergaragedoor1",
+                  "towergaragedoor2",   "towergaragedoor3",
+                  "vheistlocdoor"};
 
-    m->addEntry(Menu::lambda(
-        "Jump to Docks",
-        [=] { jumpCharacter(game, player, glm::vec3(1390.f, -837.f, 100.f)); },
-        kDebugEntryHeight));
-    m->addEntry(Menu::lambda(
-        "Jump to Garage",
-        [=] { jumpCharacter(game, player, glm::vec3(270.f, -605.f, 40.f)); },
-        kDebugEntryHeight));
-    m->addEntry(Menu::lambda(
-        "Jump to Airport",
-        [=] { jumpCharacter(game, player, glm::vec3(-950.f, -980.f, 12.f)); },
-        kDebugEntryHeight));
-    m->addEntry(Menu::lambda(
-        "Jump to Hideout",
-        [=] { jumpCharacter(game, player, glm::vec3(875.0, -309.0, 100.0)); },
-        kDebugEntryHeight));
-    m->addEntry(Menu::lambda(
-        "Jump to Luigi's",
-        [=] { jumpCharacter(game, player, glm::vec3(902.75, -425.56, 100.0)); },
-        kDebugEntryHeight));
-    m->addEntry(Menu::lambda(
-        "Jump to Hospital",
-        [=] {
-            jumpCharacter(game, player, glm::vec3(1123.77, -569.15, 100.0));
-        },
-        kDebugEntryHeight));
-    m->addEntry(Menu::lambda(
-        "Unsolid garage doors",
-        [=] {
+              auto gw = game->getWorld();
+              for (auto& i : gw->instancePool.objects) {
+                  auto obj = static_cast<InstanceObject*>(i.second);
+                  if (std::find(garageDoorModels.begin(),
+                                garageDoorModels.end(),
+                                obj->getModelInfo<BaseModelInfo>()->name) !=
+                      garageDoorModels.end()) {
+                      obj->setSolid(false);
+                  }
+              }
+          }}},
+        kDebugFont);
 
-            std::vector<std::string> garageDoorModels{
-                "8ballsuburbandoor",  "amcogaragedoor",
-                "bankjobdoor",        "bombdoor",
-                "crushercrush",       "crushertop",
-                "door2_garage",       "door3_garage",
-                "door4_garage",       "door_bombshop",
-                "door_col_compnd_01", "door_col_compnd_02",
-                "door_col_compnd_03", "door_col_compnd_04",
-                "door_col_compnd_05", "door_jmsgrage",
-                "door_sfehousegrge",  "double_garage_dr",
-                "impex_door",         "impexpsubgrgdoor",
-                "ind_plyrwoor",       "ind_slidedoor",
-                "jamesgrge_kb",       "leveldoor2",
-                "oddjgaragdoor",      "plysve_gragedoor",
-                "SalvGarage",         "shedgaragedoor",
-                "Sub_sprayshopdoor",  "towergaragedoor1",
-                "towergaragedoor2",   "towergaragedoor3",
-                "vheistlocdoor"};
-
-            auto gw = game->getWorld();
-            for (auto& i : gw->instancePool.objects) {
-                auto obj = static_cast<InstanceObject*>(i.second);
-                if (std::find(garageDoorModels.begin(), garageDoorModels.end(),
-                              obj->getModelInfo<BaseModelInfo>()->name) !=
-                    garageDoorModels.end()) {
-                    obj->setSolid(false);
-                }
-            }
-        },
-        kDebugEntryHeight));
-
-    return m;
+    menu->offset = kDebugMenuOffset;
+    return menu;
 }
 
-Menu* DebugState::createVehicleMenu() {
-    Menu* m = new Menu(2);
-    m->offset = kDebugMenuOffset;
-
-    m->addEntry(Menu::lambda("Back",
-                             [=] { this->enterMenu(createDebugMenu()); },
-                             kDebugEntryHeight));
+std::shared_ptr<Menu> DebugState::createVehicleMenu() {
+    auto menu = Menu::create({{"Back", [=] { enterMenu(createDebugMenu()); }}},
+                             kDebugFont);
 
     const std::map<std::string, int> kVehicleTypes = {
         {"Landstalker", 90}, {"Taxi", 110},      {"Firetruck", 97},
@@ -228,20 +153,16 @@ Menu* DebugState::createVehicleMenu() {
     };
 
     for (auto& e : kVehicleTypes) {
-        m->addEntry(Menu::lambda(e.first, [=] { spawnVehicle(e.second); },
-                                 kDebugEntryHeight));
+        menu->lambda(e.first, [=] { spawnVehicle(e.second); });
     }
 
-    return m;
+    menu->offset = kDebugMenuOffset;
+    return menu;
 }
 
-Menu* DebugState::createAIMenu() {
-    Menu* m = new Menu(2);
-    m->offset = kDebugMenuOffset;
-
-    m->addEntry(Menu::lambda("Back",
-                             [=] { this->enterMenu(createDebugMenu()); },
-                             kDebugEntryHeight));
+std::shared_ptr<Menu> DebugState::createAIMenu() {
+    auto menu = Menu::create(
+        {{"Back", [=] { this->enterMenu(createDebugMenu()); }}}, kDebugFont);
 
     const std::map<std::string, int> kPedTypes = {
         {"Triad", 12}, {"Cop", 1},     {"SWAT", 2},
@@ -249,42 +170,35 @@ Menu* DebugState::createAIMenu() {
     };
 
     for (auto& e : kPedTypes) {
-        m->addEntry(Menu::lambda(e.first + " Follower",
-                                 [=] { spawnFollower(e.second); },
-                                 kDebugEntryHeight));
+        menu->lambda(e.first + " Follower", [=] { spawnFollower(e.second); });
     }
 
-    m->addEntry(Menu::lambda(
-        "Kill All Peds",
-        [=] {
-            for (auto& p : game->getWorld()->pedestrianPool.objects) {
-                if (p.second->getLifetime() == GameObject::PlayerLifetime) {
-                    continue;
-                }
-                p.second->takeDamage({p.second->getPosition(),
-                                      p.second->getPosition(), 100.f,
-                                      GameObject::DamageInfo::Explosion, 0.f});
+    menu->lambda("Kill All Peds", [=] {
+        for (auto& p : game->getWorld()->pedestrianPool.objects) {
+            if (p.second->getLifetime() == GameObject::PlayerLifetime) {
+                continue;
             }
-        },
-        kDebugEntryHeight));
-    return m;
+            p.second->takeDamage({p.second->getPosition(),
+                                  p.second->getPosition(), 100.f,
+                                  GameObject::DamageInfo::Explosion, 0.f});
+        }
+    });
+
+    menu->offset = kDebugMenuOffset;
+    return menu;
 }
 
-Menu* DebugState::createWeaponMenu() {
-    Menu* m = new Menu(2);
-    m->offset = kDebugMenuOffset;
-
-    m->addEntry(Menu::lambda("Back",
-                             [=] { this->enterMenu(createDebugMenu()); },
-                             kDebugEntryHeight));
+std::shared_ptr<Menu> DebugState::createWeaponMenu() {
+    auto menu = Menu::create(
+        {{"Back", [=] { this->enterMenu(createDebugMenu()); }}}, kDebugFont);
 
     for (int i = 1; i < kMaxInventorySlots; ++i) {
         auto& name = getWorld()->data->weaponData[i]->name;
-        m->addEntry(
-            Menu::lambda(name, [=] { giveItem(i); }, kDebugEntryHeight));
+        menu->lambda(name, [=] { giveItem(i); });
     }
 
-    return m;
+    menu->offset = kDebugMenuOffset;
+    return menu;
 }
 
 DebugState::DebugState(RWGame* game, const glm::vec3& vp, const glm::quat& vd)

--- a/rwgame/states/DebugState.cpp
+++ b/rwgame/states/DebugState.cpp
@@ -363,7 +363,7 @@ void DebugState::handleEvent(const SDL_Event& event) {
         case SDL_KEYDOWN:
             switch (event.key.keysym.sym) {
                 case SDLK_ESCAPE:
-                    StateManager::get().exit();
+                    done();
                     break;
                 case SDLK_w:
                     _movement.x = 1.f;

--- a/rwgame/states/DebugState.hpp
+++ b/rwgame/states/DebugState.hpp
@@ -11,11 +11,11 @@ class DebugState : public State {
     bool _sonicMode = false;
     bool _invertedY;
 
-    Menu* createDebugMenu();
-    Menu* createMapMenu();
-    Menu* createVehicleMenu();
-    Menu* createAIMenu();
-    Menu* createWeaponMenu();
+    std::shared_ptr<Menu> createDebugMenu();
+    std::shared_ptr<Menu> createMapMenu();
+    std::shared_ptr<Menu> createVehicleMenu();
+    std::shared_ptr<Menu> createAIMenu();
+    std::shared_ptr<Menu> createWeaponMenu();
 
 public:
     DebugState(RWGame* game, const glm::vec3& vp = {},

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -412,11 +412,11 @@ void IngameState::handleEvent(const SDL_Event& event) {
         case SDL_KEYDOWN:
             switch (event.key.keysym.sym) {
                 case SDLK_ESCAPE:
-                    StateManager::get().enter(new PauseState(game));
+                    StateManager::get().enter<PauseState>(game);
                     break;
                 case SDLK_m:
-                    StateManager::get().enter(
-                        new DebugState(game, _look.position, _look.rotation));
+                    StateManager::get().enter<DebugState>(game, _look.position,
+                                                          _look.rotation);
                     break;
                 case SDLK_SPACE:
                     if (getWorld()->state->currentCutscene) {

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -124,7 +124,7 @@ void IngameState::startTest() {
 
 void IngameState::startGame() {
     game->startScript("data/main.scm");
-    game->getScript()->startThread(0);
+    game->getScriptVM()->startThread(0);
     getWorld()->sound.playBackground(getWorld()->data->getDataPath() +
                                      "/audio/City.wav");
 }

--- a/rwgame/states/IngameState.hpp
+++ b/rwgame/states/IngameState.hpp
@@ -1,7 +1,7 @@
 #ifndef INGAMESTATE_HPP
 #define INGAMESTATE_HPP
 
-#include "State.hpp"
+#include "StateManager.hpp"
 
 class PlayerController;
 

--- a/rwgame/states/LoadingState.cpp
+++ b/rwgame/states/LoadingState.cpp
@@ -1,8 +1,8 @@
 #include "LoadingState.hpp"
-#include <render/OpenGLRenderer.hpp>
 #include "RWGame.hpp"
 
-LoadingState::LoadingState(RWGame* game) : State(game), next(nullptr) {
+LoadingState::LoadingState(RWGame* game, std::function<void(void)> callback)
+    : State(game), complete(callback) {
 }
 
 void LoadingState::enter() {
@@ -15,18 +15,16 @@ void LoadingState::exit() {
 void LoadingState::tick(float dt) {
     RW_UNUSED(dt);
 
-    // If background work is completed, switch to the next state
+    // If background work is completed, do callback
     if (getWorld()->_work->isEmpty()) {
-        StateManager::get().exec(next);
+        // If we ever get back to this state it should be completed
+        done();
+        complete();
     }
 }
 
 bool LoadingState::shouldWorldUpdate() {
     return false;
-}
-
-void LoadingState::setNextState(State* nextState) {
-    next = nextState;
 }
 
 void LoadingState::handleEvent(const SDL_Event& e) {

--- a/rwgame/states/LoadingState.hpp
+++ b/rwgame/states/LoadingState.hpp
@@ -1,13 +1,14 @@
 #ifndef LOADINGSTATE_HPP
 #define LOADINGSTATE_HPP
+#include "StateManager.hpp"
 
-#include "State.hpp"
+#include <functional>
 
 class LoadingState : public State {
-    State* next;
+    std::function<void(void)> complete;
 
 public:
-    LoadingState(RWGame* game);
+    LoadingState(RWGame* game, std::function<void(void)> callback);
 
     virtual void enter();
     virtual void exit();
@@ -15,8 +16,6 @@ public:
     virtual void tick(float dt);
 
     virtual void draw(GameRenderer* r);
-
-    void setNextState(State* nextState);
 
     virtual bool shouldWorldUpdate();
 

--- a/rwgame/states/MenuState.cpp
+++ b/rwgame/states/MenuState.cpp
@@ -11,8 +11,7 @@ MenuState::MenuState(RWGame* game) : State(game) {
 }
 
 void MenuState::enterMainMenu() {
-    auto data = game->getGameData();
-    auto& t = data->texts;
+    auto& t = game->getGameData().texts;
 
     Menu* m = new Menu;
     m->offset = glm::vec2(200.f, 200.f);

--- a/rwgame/states/MenuState.cpp
+++ b/rwgame/states/MenuState.cpp
@@ -16,12 +16,12 @@ void MenuState::enterMainMenu() {
     Menu* m = new Menu;
     m->offset = glm::vec2(200.f, 200.f);
     m->addEntry(Menu::lambda(t.text(MenuDefaults::kStartGameId), [=] {
-        StateManager::get().enter(new IngameState(game));
+        StateManager::get().enter<IngameState>(game);
     }));
     m->addEntry(Menu::lambda(t.text(MenuDefaults::kLoadGameId),
                              [=] { enterLoadMenu(); }));
     m->addEntry(Menu::lambda(t.text(MenuDefaults::kDebugId), [=] {
-        StateManager::get().enter(new IngameState(game, true, "test"));
+        StateManager::get().enter<IngameState>(game, true, "test");
     }));
     m->addEntry(Menu::lambda(t.text(MenuDefaults::kOptionsId),
                              [] { RW_UNIMPLEMENTED("Options Menu"); }));
@@ -45,13 +45,11 @@ void MenuState::enterLoadMenu() {
                << save.basicState.saveTime.minute << "    ";
             auto name = GameStringUtil::fromString(ss.str());
             name += save.basicState.saveName;
-            m->addEntry(Menu::lambda(name,
-                                     [=] {
-                                         StateManager::get().enter(
-                                             new IngameState(game, false));
-                                         game->loadGame(save.savePath);
-                                     },
-                                     20.f));
+            auto loadsave = [=] {
+                StateManager::get().enter<IngameState>(game, false);
+                game->loadGame(save.savePath);
+            };
+            m->addEntry(Menu::lambda(name, loadsave, 20.f));
         } else {
             m->addEntry(Menu::lambda("CORRUPT", [=] {}));
         }
@@ -75,7 +73,7 @@ void MenuState::handleEvent(const SDL_Event& e) {
         case SDL_KEYUP:
             switch (e.key.keysym.sym) {
                 case SDLK_ESCAPE:
-                    StateManager::get().exit();
+                    done();
                 default:
                     break;
             }

--- a/rwgame/states/MenuState.cpp
+++ b/rwgame/states/MenuState.cpp
@@ -13,27 +13,24 @@ MenuState::MenuState(RWGame* game) : State(game) {
 void MenuState::enterMainMenu() {
     auto& t = game->getGameData().texts;
 
-    Menu* m = new Menu;
-    m->offset = glm::vec2(200.f, 200.f);
-    m->addEntry(Menu::lambda(t.text(MenuDefaults::kStartGameId), [=] {
-        StateManager::get().enter<IngameState>(game);
-    }));
-    m->addEntry(Menu::lambda(t.text(MenuDefaults::kLoadGameId),
-                             [=] { enterLoadMenu(); }));
-    m->addEntry(Menu::lambda(t.text(MenuDefaults::kDebugId), [=] {
-        StateManager::get().enter<IngameState>(game, true, "test");
-    }));
-    m->addEntry(Menu::lambda(t.text(MenuDefaults::kOptionsId),
-                             [] { RW_UNIMPLEMENTED("Options Menu"); }));
-    m->addEntry(Menu::lambda(t.text(MenuDefaults::kQuitGameId),
-                             [] { StateManager::get().clear(); }));
-    this->enterMenu(m);
+    auto menu = Menu::create(
+        {{t.text(MenuDefaults::kStartGameId),
+          [=] { StateManager::get().enter<IngameState>(game); }},
+         {t.text(MenuDefaults::kLoadGameId), [=] { enterLoadMenu(); }},
+         {t.text(MenuDefaults::kDebugId),
+          [=] { StateManager::get().enter<IngameState>(game, true, "test"); }},
+         {t.text(MenuDefaults::kOptionsId),
+          [] { RW_UNIMPLEMENTED("Options Menu"); }},
+         {t.text(MenuDefaults::kQuitGameId),
+          [] { StateManager::get().clear(); }}});
+    menu->offset = glm::vec2(200.f, 200.f);
+
+    enterMenu(menu);
 }
 
 void MenuState::enterLoadMenu() {
-    Menu* m = new Menu;
-    m->offset = glm::vec2(20.f, 30.f);
-    m->addEntry(Menu::lambda("BACK", [=] { enterMainMenu(); }));
+    auto menu = Menu::create({{"BACK", [=] { enterMainMenu(); }}});
+
     auto saves = SaveGame::getAllSaveGameInfo();
     for (SaveGameInfo& save : saves) {
         if (save.valid) {
@@ -49,12 +46,14 @@ void MenuState::enterLoadMenu() {
                 StateManager::get().enter<IngameState>(game, false);
                 game->loadGame(save.savePath);
             };
-            m->addEntry(Menu::lambda(name, loadsave, 20.f));
+            menu->lambda(name, loadsave);
         } else {
-            m->addEntry(Menu::lambda("CORRUPT", [=] {}));
+            menu->lambda("CORRUPT", [=] {});
         }
     }
-    this->enterMenu(m);
+    menu->offset = glm::vec2(20.f, 30.f);
+
+    enterMenu(menu);
 }
 
 void MenuState::enter() {

--- a/rwgame/states/MenuState.hpp
+++ b/rwgame/states/MenuState.hpp
@@ -1,7 +1,7 @@
 #ifndef MENUSTATE_HPP
 #define MENUSTATE_HPP
 
-#include "State.hpp"
+#include "StateManager.hpp"
 
 class MenuState : public State {
 public:

--- a/rwgame/states/PauseState.cpp
+++ b/rwgame/states/PauseState.cpp
@@ -4,15 +4,14 @@
 PauseState::PauseState(RWGame* game) : State(game) {
     auto& t = game->getGameData().texts;
 
-    Menu* m = new Menu;
-    m->offset = glm::vec2(200.f, 200.f);
-    m->addEntry(Menu::lambda(t.text(MenuDefaults::kResumeGameId),
-                             [&] { done(); }));
-    m->addEntry(Menu::lambda(t.text(MenuDefaults::kOptionsId),
-                             [] { std::cout << "Options" << std::endl; }));
-    m->addEntry(Menu::lambda(t.text(MenuDefaults::kQuitGameId),
-                             [] { StateManager::get().clear(); }));
-    this->enterMenu(m);
+    auto menu = Menu::create(
+        {{t.text(MenuDefaults::kResumeGameId), [&] { done(); }},
+         {t.text(MenuDefaults::kOptionsId),
+          [] { std::cout << "Options" << std::endl; }},
+         {t.text(MenuDefaults::kQuitGameId),
+          [] { StateManager::get().clear(); }}});
+    menu->offset = glm::vec2(200.f, 200.f);
+    enterMenu(menu);
 }
 
 void PauseState::enter() {

--- a/rwgame/states/PauseState.cpp
+++ b/rwgame/states/PauseState.cpp
@@ -4,8 +4,7 @@
 #include "RWGame.hpp"
 
 PauseState::PauseState(RWGame* game) : State(game) {
-    auto data = game->getGameData();
-    auto& t = data->texts;
+    auto& t = game->getGameData().texts;
 
     Menu* m = new Menu;
     m->offset = glm::vec2(200.f, 200.f);
@@ -42,7 +41,7 @@ void PauseState::draw(GameRenderer* r) {
     map.screenPosition = glm::vec2(vp.x / 2, vp.y / 2);
     map.screenSize = std::max(vp.x, vp.y);
 
-    game->getRenderer()->map.draw(getWorld(), map);
+    game->getRenderer().map.draw(getWorld(), map);
 
     State::draw(r);
 }

--- a/rwgame/states/PauseState.cpp
+++ b/rwgame/states/PauseState.cpp
@@ -1,6 +1,4 @@
 #include "PauseState.hpp"
-#include <ai/PlayerController.hpp>
-#include <objects/CharacterObject.hpp>
 #include "RWGame.hpp"
 
 PauseState::PauseState(RWGame* game) : State(game) {
@@ -9,7 +7,7 @@ PauseState::PauseState(RWGame* game) : State(game) {
     Menu* m = new Menu;
     m->offset = glm::vec2(200.f, 200.f);
     m->addEntry(Menu::lambda(t.text(MenuDefaults::kResumeGameId),
-                             [] { StateManager::get().exit(); }));
+                             [&] { done(); }));
     m->addEntry(Menu::lambda(t.text(MenuDefaults::kOptionsId),
                              [] { std::cout << "Options" << std::endl; }));
     m->addEntry(Menu::lambda(t.text(MenuDefaults::kQuitGameId),
@@ -51,7 +49,7 @@ void PauseState::handleEvent(const SDL_Event& e) {
         case SDL_KEYDOWN:
             switch (e.key.keysym.sym) {
                 case SDLK_ESCAPE:
-                    StateManager::get().exit();
+                    done();
                     break;
                 default:
                     break;

--- a/rwgame/states/PauseState.hpp
+++ b/rwgame/states/PauseState.hpp
@@ -1,7 +1,7 @@
 #ifndef PAUSESTATE_HPP
 #define PAUSESTATE_HPP
 
-#include "State.hpp"
+#include "StateManager.hpp"
 
 class PauseState : public State {
 public:

--- a/tests/test_menu.cpp
+++ b/tests/test_menu.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(menu_test_click) {
 
     BOOST_CHECK(!clickered);
 
-    float h = test.getEntries().at(0).getHeight();
+    float h = 30.f;
 
     test.click(0.f, h + 1.f);
 
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(menu_test_click_offset) {
 
     BOOST_CHECK(!clickered);
 
-    float h = test.getEntries().at(0).getHeight();
+    float h = 30.f;
 
     test.click(201.f, 200.f + h + 1.f);
 
@@ -79,10 +79,10 @@ BOOST_AUTO_TEST_CASE(menu_test_hover_index) {
     Menu test({{"Test1", [&] { clickindex = 0; }},
                {"Test2", [&] { clickindex = 1; }}});
 
-    test.hover(0.f, test.getEntries()[0].getHeight() - 0.1f);
+    test.hover(0.f, 30.f - 0.1f);
     BOOST_CHECK(test.activeEntry == 0);
 
-    test.hover(0.f, test.getEntries()[0].getHeight() + 0.1f);
+    test.hover(0.f, 30.f + 0.1f);
     BOOST_CHECK(test.activeEntry == 1);
 }
 

--- a/tests/test_menu.cpp
+++ b/tests/test_menu.cpp
@@ -6,8 +6,7 @@ BOOST_AUTO_TEST_SUITE(MenuUnitTests)
 
 BOOST_AUTO_TEST_CASE(menu_test_click) {
     bool clickered = false;
-    Menu test(0);
-    test.addEntry(Menu::lambda("Test", [&] { clickered = true; }));
+    Menu test({{"Test", [&] { clickered = true; }}});
 
     BOOST_CHECK(!clickered);
 
@@ -16,7 +15,7 @@ BOOST_AUTO_TEST_CASE(menu_test_click) {
 
     BOOST_CHECK(!clickered);
 
-    float h = test.entries.at(0)->getHeight();
+    float h = test.getEntries().at(0).getHeight();
 
     test.click(0.f, h + 1.f);
 
@@ -29,9 +28,8 @@ BOOST_AUTO_TEST_CASE(menu_test_click) {
 
 BOOST_AUTO_TEST_CASE(menu_test_click_offset) {
     bool clickered = false;
-    Menu test(0);
+    Menu test({{"Test", [&] { clickered = true; }}});
     test.offset = glm::vec2(200.f, 200.f);
-    test.addEntry(Menu::lambda("Test", [&] { clickered = true; }));
 
     BOOST_CHECK(!clickered);
 
@@ -40,7 +38,7 @@ BOOST_AUTO_TEST_CASE(menu_test_click_offset) {
 
     BOOST_CHECK(!clickered);
 
-    float h = test.entries.at(0)->getHeight();
+    float h = test.getEntries().at(0).getHeight();
 
     test.click(201.f, 200.f + h + 1.f);
 
@@ -53,9 +51,8 @@ BOOST_AUTO_TEST_CASE(menu_test_click_offset) {
 
 BOOST_AUTO_TEST_CASE(menu_test_active_index) {
     int clickindex = -1;
-    Menu test(0);
-    test.addEntry(Menu::lambda("Test1", [&] { clickindex = 0; }));
-    test.addEntry(Menu::lambda("Test2", [&] { clickindex = 1; }));
+    Menu test({{"Test1", [&] { clickindex = 0; }},
+               {"Test2", [&] { clickindex = 1; }}});
 
     test.activate();
 
@@ -79,14 +76,13 @@ BOOST_AUTO_TEST_CASE(menu_test_active_index) {
 
 BOOST_AUTO_TEST_CASE(menu_test_hover_index) {
     int clickindex = -1;
-    Menu test(0);
-    test.addEntry(Menu::lambda("Test1", [&] { clickindex = 0; }));
-    test.addEntry(Menu::lambda("Test2", [&] { clickindex = 1; }));
+    Menu test({{"Test1", [&] { clickindex = 0; }},
+               {"Test2", [&] { clickindex = 1; }}});
 
-    test.hover(0.f, test.entries[0]->getHeight() - 0.1f);
+    test.hover(0.f, test.getEntries()[0].getHeight() - 0.1f);
     BOOST_CHECK(test.activeEntry == 0);
 
-    test.hover(0.f, test.entries[0]->getHeight() + 0.1f);
+    test.hover(0.f, test.getEntries()[0].getHeight() + 0.1f);
     BOOST_CHECK(test.activeEntry == 1);
 }
 


### PR DESCRIPTION
You know what sucks? raw pointers. So lets' get rid of them.

- Split RWGame code that has nothing to do with the game into GameBase
- Use logger to print runtime exceptions so we can remove std::cerr usage
- Avoid dynamically allocating some of RWGame's members that don't need to be
- Switch to C++14 so we can use make_unique
- Use unique_ptr where appropriate to avoid manual memory management
- Kill SCMOpcodes since it wasn't needed anymore