### PR TITLE
Input fixup

### DIFF
--- a/rwengine/src/engine/GameInputState.hpp
+++ b/rwengine/src/engine/GameInputState.hpp
@@ -10,9 +10,7 @@ struct GameInputState {
         /* On Foot */
         FireWeapon = 0,
         NextWeapon,
-        NextTarget = NextWeapon,
         LastWeapon,
-        LastTarget = LastWeapon,
         GoForward,
         GoBackwards,
         GoLeft,
@@ -29,11 +27,8 @@ struct GameInputState {
         LookBehind,
 
         /* In Vehicle */
-        VehicleFireWeapon = FireWeapon,
         VehicleAccelerate,
         VehicleBrake,
-        VehicleLeft = GoLeft,
-        VehicleRight = GoRight,
         VehicleDown,
         VehicleUp,
         ChangeRadio,
@@ -47,7 +42,13 @@ struct GameInputState {
         VehicleAimUp,
         VehicleAimDown,
 
-        _MaxControls
+        _MaxControls,
+
+        NextTarget = NextWeapon,
+        LastTarget = LastWeapon,
+        VehicleLeft = GoLeft,
+        VehicleRight = GoRight,
+        VehicleFireWeapon = FireWeapon,
     };
 
     /**

--- a/rwengine/src/engine/GameInputState.hpp
+++ b/rwengine/src/engine/GameInputState.hpp
@@ -55,14 +55,17 @@ struct GameInputState {
      *
      * For buttons, this will result in either 0 or 1.
      */
-    float currentLevels[_MaxControls] = {};
+    float levels[_MaxControls] = {};
 
     float operator[](Control c) const {
-        return currentLevels[c];
+        return levels[c];
     }
 
+    /**
+     * @return if cotrol is held down
+     */
     bool pressed(Control c) const {
-        return currentLevels[c] > kButtonOnThreshold;
+        return levels[c] > kButtonOnThreshold;
     }
 };
 

--- a/rwengine/src/engine/GameState.hpp
+++ b/rwengine/src/engine/GameState.hpp
@@ -337,9 +337,9 @@ public:
     std::bitset<32> importExportUnused;
 
     /**
-     * State of the game input
+     * State of the game input for the last 2 frames
      */
-    GameInputState input;
+    GameInputState input[2];
 
     /**
      * World to use for this state, this isn't saved, just used at runtime
@@ -362,6 +362,13 @@ public:
      * Removes a blip
      */
     void removeBlip(int blip);
+
+    /**
+     * Swaps input state
+     */
+    void swapInputState() {
+        input[1] = input[0];
+    }
 };
 
 #endif

--- a/rwengine/src/script/modules/GTA3ModuleImpl.inl
+++ b/rwengine/src/script/modules/GTA3ModuleImpl.inl
@@ -2459,7 +2459,7 @@ bool opcode_00e1(const ScriptArguments& args, const ScriptPad player, const Scri
 	// Hack: not implemented correctly.
 	if (player == 0) {
 		if (buttonID == 19) { // Look behind / sub mission
-			return args.getState()->input.pressed(GameInputState::Submission);
+			return args.getState()->input[0].pressed(GameInputState::Submission);
 		}
 	}
 	return false;

--- a/rwgame/CMakeLists.txt
+++ b/rwgame/CMakeLists.txt
@@ -22,6 +22,9 @@ set(RWGAME_SOURCES
 	MenuSystem.hpp
 	MenuSystem.cpp
 
+	GameInput.hpp
+	GameInput.cpp
+
 	states/LoadingState.hpp
 	states/LoadingState.cpp
 	states/IngameState.hpp

--- a/rwgame/GameInput.cpp
+++ b/rwgame/GameInput.cpp
@@ -1,0 +1,80 @@
+#include "GameInput.hpp"
+#include <unordered_map>
+
+// Hardcoded Controls SDLK_* -> GameInputState::Control
+const std::unordered_multimap<int, GameInputState::Control> kDefaultControls = {
+    /* On Foot */
+    {SDLK_LCTRL, GameInputState::FireWeapon},
+    {SDLK_KP_0, GameInputState::FireWeapon},
+    {SDLK_KP_ENTER, GameInputState::NextWeapon},
+    {SDLK_KP_PERIOD, GameInputState::LastWeapon},
+    {SDLK_w, GameInputState::GoForward},
+    {SDLK_UP, GameInputState::GoForward},
+    {SDLK_s, GameInputState::GoBackwards},
+    {SDLK_DOWN, GameInputState::GoBackwards},
+    {SDLK_a, GameInputState::GoLeft},
+    {SDLK_LEFT, GameInputState::GoLeft},
+    {SDLK_d, GameInputState::GoRight},
+    {SDLK_RIGHT, GameInputState::GoRight},
+    {SDLK_PAGEUP, GameInputState::ZoomIn},
+    {SDLK_z, GameInputState::ZoomIn},
+    {SDLK_PAGEDOWN, GameInputState::ZoomOut},
+    {SDLK_x, GameInputState::ZoomOut},
+    {SDLK_f, GameInputState::EnterExitVehicle},
+    {SDLK_RETURN, GameInputState::EnterExitVehicle},
+    {SDLK_c, GameInputState::ChangeCamera},
+    {SDLK_HOME, GameInputState::ChangeCamera},
+    {SDLK_RCTRL, GameInputState::Jump},
+    {SDLK_SPACE, GameInputState::Jump},
+    {SDLK_LSHIFT, GameInputState::Sprint},
+    {SDLK_RSHIFT, GameInputState::Sprint},
+    {SDLK_LALT, GameInputState::Walk},
+    {SDLK_DELETE, GameInputState::AimWeapon},
+    {SDLK_CAPSLOCK, GameInputState::LookBehind},
+
+    /* In Vehicle */
+    {SDLK_LCTRL, GameInputState::VehicleFireWeapon},
+    {SDLK_a, GameInputState::VehicleLeft},
+    {SDLK_LEFT, GameInputState::VehicleLeft},
+    {SDLK_d, GameInputState::VehicleRight},
+    {SDLK_RIGHT, GameInputState::VehicleRight},
+    {SDLK_w, GameInputState::VehicleAccelerate},
+    {SDLK_UP, GameInputState::VehicleAccelerate},
+    {SDLK_d, GameInputState::VehicleBrake},
+    {SDLK_DOWN, GameInputState::VehicleBrake},
+    {SDLK_INSERT, GameInputState::ChangeRadio},
+    {SDLK_r, GameInputState::ChangeRadio},
+    {SDLK_LSHIFT, GameInputState::Horn},
+    {SDLK_RSHIFT, GameInputState::Horn},
+    {SDLK_KP_PLUS, GameInputState::Submission},
+    {SDLK_CAPSLOCK, GameInputState::Submission},
+    {SDLK_RCTRL, GameInputState::Handbrake},
+    {SDLK_SPACE, GameInputState::Handbrake},
+    {SDLK_KP_9, GameInputState::VehicleAimUp},
+    {SDLK_KP_2, GameInputState::VehicleAimDown},
+    {SDLK_KP_4, GameInputState::VehicleAimLeft},
+    {SDLK_KP_6, GameInputState::VehicleAimRight},
+    {SDLK_KP_9, GameInputState::VehicleDown},
+    {SDLK_KP_2, GameInputState::VehicleUp},
+    {SDLK_KP_1, GameInputState::LookLeft},
+    {SDLK_q, GameInputState::LookLeft},
+    {SDLK_KP_2, GameInputState::LookRight},
+    {SDLK_e, GameInputState::LookRight},
+};
+
+void GameInput::updateGameInputState(GameInputState *state,
+                                     const SDL_Event &event) {
+    switch (event.type) {
+        case SDL_KEYDOWN:
+        case SDL_KEYUP: {
+            auto sym = event.key.keysym.sym;
+            auto level = event.type == SDL_KEYDOWN ? 1.f : 0.f;
+            auto& levels = state->levels;
+
+            auto range = kDefaultControls.equal_range(sym);
+            for (auto it = range.first; it != range.second; ++it) {
+                levels[it->second] = level;
+            }
+        } break;
+    }
+}

--- a/rwgame/GameInput.hpp
+++ b/rwgame/GameInput.hpp
@@ -1,0 +1,10 @@
+#ifndef RWGAME_GAMEINPUT_HPP
+#define RWGAME_GAMEINPUT_HPP
+#include "engine/GameState.hpp"
+#include "SDL2/SDL.h"
+
+namespace GameInput {
+void updateGameInputState(GameInputState* state, const SDL_Event& event);
+}
+
+#endif

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -1,5 +1,6 @@
 #include "RWGame.hpp"
 #include "DrawUI.hpp"
+#include "GameInput.hpp"
 #include "State.hpp"
 #include "states/BenchmarkState.hpp"
 #include "states/IngameState.hpp"
@@ -393,6 +394,8 @@ int RWGame::run() {
                     event.motion.yrel *= MOUSE_SENSITIVITY_SCALE;
                     break;
             }
+
+            GameInput::updateGameInputState(&getState()->input[0], event);
 
             RW_PROFILE_BEGIN("State");
             state->handleEvent(event);

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -420,6 +420,8 @@ int RWGame::run() {
             tick(GAME_TIMESTEP);
             RW_PROFILE_END();
 
+            getState()->swapInputState();
+
             accum -= GAME_TIMESTEP;
 
             // Throw away time if the accumulator reaches too high.

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -17,7 +17,6 @@
 #include <script/ScriptMachine.hpp>
 
 #include <glm/gtc/constants.hpp>
-#include <unordered_map>
 
 constexpr float kAutoLookTime = 2.f;
 constexpr float kAutolookMinVelocity = 0.2f;
@@ -25,67 +24,6 @@ const float kMaxRotationRate = glm::half_pi<float>();
 const float kCameraPitchLimit = glm::quarter_pi<float>() * 0.5f;
 const float kVehicleCameraPitch =
     glm::half_pi<float>() - glm::quarter_pi<float>() * 0.25f;
-
-// Hardcoded Controls SDLK_* -> GameInputState::Control
-const std::unordered_multimap<int, GameInputState::Control> kDefaultControls = {
-    /* On Foot */
-    {SDLK_LCTRL, GameInputState::FireWeapon},
-    {SDLK_KP_0, GameInputState::FireWeapon},
-    {SDLK_KP_ENTER, GameInputState::NextWeapon},
-    {SDLK_KP_PERIOD, GameInputState::LastWeapon},
-    {SDLK_w, GameInputState::GoForward},
-    {SDLK_UP, GameInputState::GoForward},
-    {SDLK_s, GameInputState::GoBackwards},
-    {SDLK_DOWN, GameInputState::GoBackwards},
-    {SDLK_a, GameInputState::GoLeft},
-    {SDLK_LEFT, GameInputState::GoLeft},
-    {SDLK_d, GameInputState::GoRight},
-    {SDLK_RIGHT, GameInputState::GoRight},
-    {SDLK_PAGEUP, GameInputState::ZoomIn},
-    {SDLK_z, GameInputState::ZoomIn},
-    {SDLK_PAGEDOWN, GameInputState::ZoomOut},
-    {SDLK_x, GameInputState::ZoomOut},
-    {SDLK_f, GameInputState::EnterExitVehicle},
-    {SDLK_RETURN, GameInputState::EnterExitVehicle},
-    {SDLK_c, GameInputState::ChangeCamera},
-    {SDLK_HOME, GameInputState::ChangeCamera},
-    {SDLK_RCTRL, GameInputState::Jump},
-    {SDLK_SPACE, GameInputState::Jump},
-    {SDLK_LSHIFT, GameInputState::Sprint},
-    {SDLK_RSHIFT, GameInputState::Sprint},
-    {SDLK_LALT, GameInputState::Walk},
-    {SDLK_DELETE, GameInputState::AimWeapon},
-    {SDLK_CAPSLOCK, GameInputState::LookBehind},
-
-    /* In Vehicle */
-    {SDLK_LCTRL, GameInputState::VehicleFireWeapon},
-    {SDLK_a, GameInputState::VehicleLeft},
-    {SDLK_LEFT, GameInputState::VehicleLeft},
-    {SDLK_d, GameInputState::VehicleRight},
-    {SDLK_RIGHT, GameInputState::VehicleRight},
-    {SDLK_w, GameInputState::VehicleAccelerate},
-    {SDLK_UP, GameInputState::VehicleAccelerate},
-    {SDLK_d, GameInputState::VehicleBrake},
-    {SDLK_DOWN, GameInputState::VehicleBrake},
-    {SDLK_INSERT, GameInputState::ChangeRadio},
-    {SDLK_r, GameInputState::ChangeRadio},
-    {SDLK_LSHIFT, GameInputState::Horn},
-    {SDLK_RSHIFT, GameInputState::Horn},
-    {SDLK_KP_PLUS, GameInputState::Submission},
-    {SDLK_CAPSLOCK, GameInputState::Submission},
-    {SDLK_RCTRL, GameInputState::Handbrake},
-    {SDLK_SPACE, GameInputState::Handbrake},
-    {SDLK_KP_9, GameInputState::VehicleAimUp},
-    {SDLK_KP_2, GameInputState::VehicleAimDown},
-    {SDLK_KP_4, GameInputState::VehicleAimLeft},
-    {SDLK_KP_6, GameInputState::VehicleAimRight},
-    {SDLK_KP_9, GameInputState::VehicleDown},
-    {SDLK_KP_2, GameInputState::VehicleUp},
-    {SDLK_KP_1, GameInputState::LookLeft},
-    {SDLK_q, GameInputState::LookLeft},
-    {SDLK_KP_2, GameInputState::LookRight},
-    {SDLK_e, GameInputState::LookRight},
-};
 
 IngameState::IngameState(RWGame* game, bool newgame, const std::string& save)
     : State(game)
@@ -445,8 +383,6 @@ void IngameState::handleEvent(const SDL_Event& event) {
             break;
     }
 
-    updateInputState(event);
-
     if (player && player->isInputEnabled()) {
         handlePlayerInput(event);
     }
@@ -496,22 +432,6 @@ void IngameState::handlePlayerInput(const SDL_Event& event) {
             break;
         default:
             break;
-    }
-}
-
-void IngameState::updateInputState(const SDL_Event& event) {
-    switch (event.type) {
-        case SDL_KEYDOWN:
-        case SDL_KEYUP: {
-            auto sym = event.key.keysym.sym;
-            auto level = event.type == SDL_KEYDOWN ? 1.f : 0.f;
-            auto& levels = getWorld()->state->input[0].levels;
-
-            auto range = kDefaultControls.equal_range(sym);
-            for (auto it = range.first; it != range.second; ++it) {
-                levels[it->second] = level;
-            }
-        } break;
     }
 }
 

--- a/rwgame/states/IngameState.hpp
+++ b/rwgame/states/IngameState.hpp
@@ -53,7 +53,6 @@ public:
 
     virtual void handleEvent(const SDL_Event& event);
     virtual void handlePlayerInput(const SDL_Event& event);
-    void updateInputState(const SDL_Event& event);
 
     virtual bool shouldWorldUpdate();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TEST_SOURCES
 	"test_GameWorld.cpp"
 	"test_globals.hpp"
 	"test_items.cpp"
+	"test_Input.cpp"
 	"test_lifetime.cpp"
 	"test_loaderdff.cpp"
 	"test_Logger.cpp"
@@ -49,6 +50,7 @@ set(TEST_SOURCES
 	# Hack in rwgame sources until there's a per-target test suite
 	"${CMAKE_SOURCE_DIR}/rwgame/GameConfig.cpp"
 	"${CMAKE_SOURCE_DIR}/rwgame/GameWindow.cpp"
+	"${CMAKE_SOURCE_DIR}/rwgame/GameInput.cpp"
 	)
 
 ADD_DEFINITIONS(-DBOOST_TEST_DYN_LINK)

--- a/tests/test_Input.cpp
+++ b/tests/test_Input.cpp
@@ -1,0 +1,35 @@
+#include <boost/test/unit_test.hpp>
+#include "GameInput.hpp"
+#include "test_globals.hpp"
+
+BOOST_AUTO_TEST_SUITE(InputTests)
+
+BOOST_AUTO_TEST_CASE(TestStateUpdate) {
+    BOOST_CHECK(GameInputState::Handbrake != GameInputState::Submission);
+    BOOST_CHECK(GameInputState::Jump != GameInputState::Sprint);
+    {
+        // Currently tests against hard-coded input
+        GameInputState state;
+
+        SDL_Event ev;
+        ev.type = SDL_KEYDOWN;
+        ev.key.keysym.sym = SDLK_SPACE;
+
+        GameInput::updateGameInputState(&state, ev);
+
+        // Check that the correct inputs report pressed
+        for (int c = 0; c < GameInputState::_MaxControls; ++c) {
+            switch ((GameInputState::Control)c) {
+                case GameInputState::Jump:
+                case GameInputState::Handbrake:
+                    BOOST_CHECK(state.pressed((GameInputState::Control)c));
+                    break;
+                default:
+                    BOOST_CHECK(!state.pressed((GameInputState::Control)c));
+                    break;
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Prevent actions like jumping or entering vehicles being requested twice by checking for keypresses 
- Zero player input while it is disabled, preventing jumping in cut-scenes
- Fix aliasing of input controls

Relates to #233,  #208, #224 