### PR TITLE
OpenAL headers, fix for OSX compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ include_directories(
 	${GLM_INCLUDE_DIRS}
 	${OPENGL_INCLUDE_DIR}
 	${BULLET_INCLUDE_DIRS}
+	${OPENAL_INCLUDE_DIR}
 )
 
 # External-internal dependencies

--- a/rwengine/src/audio/MADStream.hpp
+++ b/rwengine/src/audio/MADStream.hpp
@@ -1,8 +1,9 @@
 #pragma once
 #ifndef _MADSTREAM_HPP_
 #define _MADSTREAM_HPP_
-#include <AL/al.h>
-#include <AL/alc.h>
+
+#include "al.h"
+#include "alc.h"
 #include <fcntl.h>
 #include <mad.h>
 #include <stdint.h>

--- a/rwengine/src/audio/SoundManager.hpp
+++ b/rwengine/src/audio/SoundManager.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <AL/al.h>
-#include <AL/alc.h>
+#include "al.h"
+#include "alc.h"
 #include <sndfile.h>
 
 #include <map>

--- a/rwengine/src/audio/alCheck.cpp
+++ b/rwengine/src/audio/alCheck.cpp
@@ -1,7 +1,7 @@
 #include "audio/alCheck.hpp"
 
-#include <AL/al.h>
-#include <AL/alc.h>
+#include "al.h"
+#include "alc.h"
 
 #include <iostream>
 


### PR DESCRIPTION
This PR changes how the OpenAL headers are imported, fixing a compile error on OSX. Only tested on OSX.