### PR TITLE
Load textures into separate groups

### DIFF
--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -5,7 +5,6 @@
 #include <engine/GameState.hpp>
 #include <engine/GameWorld.hpp>
 #include <loaders/LoaderCOL.hpp>
-#include <loaders/LoaderDFF.hpp>
 #include <loaders/LoaderIDE.hpp>
 #include <loaders/LoaderIPL.hpp>
 #include <script/SCMFile.hpp>
@@ -23,6 +22,10 @@
 
 GameData::GameData(Logger* log, const std::string& path)
     : datpath(path), logger(log), engine(nullptr) {
+    dffLoader.setTextureLookupCallback(
+        [&](const std::string& texture, const std::string&) {
+            return findSlotTexture(currenttextureslot, texture);
+        });
 }
 
 GameData::~GameData() {
@@ -353,13 +356,7 @@ Model* GameData::loadClump(const std::string& name) {
         logger->error("Data", "Failed to load model " + name);
         return nullptr;
     }
-    LoaderDFF l;
-    l.setTextureLookupCallback(
-        [&](const std::string& texture, const std::string&) {
-            // Lookup the texture in the current texture slot
-            return findSlotTexture(currenttextureslot, texture);
-        });
-    auto m = l.loadFromMemory(file);
+    auto m = dffLoader.loadFromMemory(file);
     if (!m) {
         logger->error("Data", "Error loading model file " + name);
         return nullptr;
@@ -373,14 +370,7 @@ void GameData::loadModelFile(const std::string& name) {
         logger->log("Data", Logger::Error, "Failed to load model file " + name);
         return;
     }
-    LoaderDFF l;
-    l.setTextureLookupCallback(
-        [&](const std::string& texture, const std::string&) {
-            // Lookup the texture in the current texture slot
-            return findSlotTexture(currenttextureslot, texture);
-        });
-
-    auto m = l.loadFromMemory(file);
+    auto m = dffLoader.loadFromMemory(file);
     if (!m) {
         logger->log("Data", Logger::Error, "Error loading model file " + name);
         return;
@@ -444,13 +434,7 @@ void GameData::loadModel(ModelID model) {
                                   std::to_string(model) + " [" + name + "]");
         return;
     }
-    LoaderDFF l;
-    l.setTextureLookupCallback(
-        [&](const std::string& texture, const std::string&) {
-            // Lookup the texture in the current texture slot
-            return findSlotTexture(currenttextureslot, texture);
-        });
-    auto m = l.loadFromMemory(file);
+    auto m = dffLoader.loadFromMemory(file);
     if (!m) {
         logger->error("Data",
                       "Error loading model file for " + std::to_string(model));

--- a/rwengine/src/engine/GameData.hpp
+++ b/rwengine/src/engine/GameData.hpp
@@ -39,6 +39,7 @@ class GameData {
 private:
     std::string datpath;
     std::string splash;
+    std::string currenttextureslot;
 
     Logger* logger;
 public:
@@ -111,9 +112,15 @@ public:
     void loadLevelFile(const std::string& path);
 
     /**
-     * Attempts to load a TXD, or does nothing if it has already been loaded
+     * Loads the txt slot if it is not already loaded and sets
+     * the current TXD slot
      */
     void loadTXD(const std::string& name);
+
+    /**
+     * Loads a named texture archive from the game data
+     */
+    TextureArchive loadTextureArchive(const std::string& name);
 
     /**
      * Converts combined {name}_l{LOD} into name and lod.
@@ -155,9 +162,17 @@ public:
 
     void loadSplash(const std::string& name);
 
-    TextureData::Handle findTexture(const std::string& name,
-                                    const std::string& alpha = "") {
-        return textures[{name, alpha}];
+    TextureData::Handle findSlotTexture(const std::string& slot,
+                                        const std::string& texture) const {
+        auto slotit = textureslots.find(slot);
+        if (slotit == textureslots.end()) {
+            return nullptr;
+        }
+        auto textureit = slotit->second.find(texture);
+        if (textureit == slotit->second.end()) {
+            return nullptr;
+        }
+        return textureit->second;
     }
 
     FileIndex index;
@@ -222,9 +237,9 @@ public:
     WeatherLoader weatherLoader;
 
     /**
-     * Loaded textures (Textures are ID by name and alpha pairs)
+     * Texture slots, containing loaded textures.
      */
-    std::map<std::pair<std::string, std::string>, TextureData::Handle> textures;
+    std::map<std::string, TextureArchive> textureslots;
 
     /**
      * Texture atlases.

--- a/rwengine/src/engine/GameData.hpp
+++ b/rwengine/src/engine/GameData.hpp
@@ -42,6 +42,7 @@ private:
     std::string currenttextureslot;
 
     Logger* logger;
+    LoaderDFF dffLoader;
 public:
     /**
      * ctor

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -158,18 +158,6 @@ InstanceObject* GameWorld::createInstance(const uint16_t id,
             data->loadModel(oi->id());
         }
 
-        std::string modelname = oi->name;
-        std::string texturename = oi->textureslot;
-
-        std::transform(std::begin(modelname), std::end(modelname),
-                       std::begin(modelname), tolower);
-        std::transform(std::begin(texturename), std::end(texturename),
-                       std::begin(texturename), tolower);
-
-        if (!texturename.empty()) {
-            data->loadTXD(texturename + ".txd");
-        }
-
         // Check for dynamic data.
         auto dyit = data->dynamicObjectData.find(oi->name);
         std::shared_ptr<DynamicObjectData> dydata;
@@ -177,7 +165,7 @@ InstanceObject* GameWorld::createInstance(const uint16_t id,
             dydata = dyit->second;
         }
 
-        if (modelname.empty()) {
+        if (oi->name.empty()) {
             logger->warning(
                 "World", "Instance with missing model: " + std::to_string(id));
         }
@@ -243,24 +231,17 @@ CutsceneObject* GameWorld::createCutsceneObject(const uint16_t id,
     }
 
     auto clumpmodel = static_cast<ClumpModelInfo*>(modelinfo);
-    std::string texturename;
 
     if (!clumpmodel->isLoaded()) {
         data->loadModel(id);
     }
     auto model = clumpmodel->getModel();
 
-    texturename = modelinfo->textureslot;
-
     if (id == 0) {
         auto playerobj = pedestrianPool.find(state->playerObject);
         if (playerobj) {
             model = playerobj->getModel();
         }
-    }
-
-    if (!texturename.empty()) {
-        data->loadTXD(texturename + ".txd");
     }
 
     auto instance = new CutsceneObject(this, pos, rot, model, modelinfo);
@@ -283,10 +264,6 @@ VehicleObject* GameWorld::createVehicle(const uint16_t id, const glm::vec3& pos,
 
     if (!vti->isLoaded()) {
         data->loadModel(id);
-    }
-
-    if (!vti->textureslot.empty()) {
-        data->loadTXD(vti->textureslot + ".txd");
     }
 
     glm::u8vec3 prim(255), sec(128);
@@ -361,12 +338,6 @@ CharacterObject* GameWorld::createPedestrian(const uint16_t id,
         data->loadModel(id);
     }
 
-    std::string texturename = pt->textureslot;
-
-    if (!texturename.empty()) {
-        data->loadTXD(texturename + ".txd");
-    }
-
     auto ped = new CharacterObject(this, pos, rot, pt);
     ped->setGameObjectID(gid);
     new DefaultAIController(ped);
@@ -388,12 +359,11 @@ CharacterObject* GameWorld::createPlayer(const glm::vec3& pos,
     std::string modelname = "player";
     std::string texturename = "player";
 
+    data->loadTXD(texturename + ".txd");
     if (!pt->isLoaded()) {
         auto model = data->loadClump(modelname + ".dff");
         pt->setModel(model);
     }
-
-    data->loadTXD(texturename + ".txd");
 
     auto ped = new CharacterObject(this, pos, rot, pt);
     ped->setGameObjectID(gid);
@@ -415,8 +385,6 @@ PickupObject* GameWorld::createPickup(const glm::vec3& pos, int id, int type) {
     if (!modelInfo->isLoaded()) {
         data->loadModel(id);
     }
-
-    data->loadTXD(modelInfo->textureslot + ".txd");
 
     PickupObject* pickup = nullptr;
     auto pickuptype = (PickupObject::PickupType)type;

--- a/rwengine/src/objects/PickupObject.cpp
+++ b/rwengine/src/objects/PickupObject.cpp
@@ -83,7 +83,7 @@ PickupObject::PickupObject(GameWorld* world, const glm::vec3& position,
     m_corona->particle.direction = glm::vec3(0.f, 0.f, 1.f);
     m_corona->particle.orientation = VisualFX::ParticleData::Camera;
     m_corona->particle.colour = glm::vec4(1.0f, 0.3f, 0.3f, 0.3f);
-    m_corona->particle.texture = engine->data->findTexture("coronacircle");
+    m_corona->particle.texture = engine->data->findSlotTexture("particle", "coronacircle");
 
     auto flags = behaviourFlags(m_type);
     RW_UNUSED(flags);

--- a/rwengine/src/objects/ProjectileObject.cpp
+++ b/rwengine/src/objects/ProjectileObject.cpp
@@ -71,7 +71,7 @@ void ProjectileObject::explode() {
                            0.f});
         }
 
-        auto tex = engine->data->findTexture("explo02");
+        auto tex = engine->data->findSlotTexture("particle", "explo02");
 
         auto explosion = engine->createEffect(VisualFX::Particle);
         explosion->particle.size = glm::vec2(exp_size);

--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -404,7 +404,7 @@ void GameRenderer::renderWorld(GameWorld* world, const ViewCamera& camera,
     GLuint splashTexName = 0;
     auto fc = world->state->fadeColour;
     if ((fc.r + fc.g + fc.b) == 0 && world->state->currentSplash.size() > 0) {
-        auto splash = world->data->findTexture(world->state->currentSplash);
+        auto splash = world->data->findSlotTexture("generic", world->state->currentSplash);
         if (splash) {
             splashTexName = splash->getName();
         }
@@ -494,16 +494,6 @@ void GameRenderer::renderGeometry(Model* model, size_t g,
 
             if (mat.textures.size() > 0) {
                 auto tex = mat.textures[0].texture;
-                if (!tex) {
-                    auto& tC = mat.textures[0].name;
-                    auto& tA = mat.textures[0].alphaName;
-                    tex = data->findTexture(tC, tA);
-                    if (!tex) {
-                        // logger->warning("Renderer", "Missing texture: " + tC
-                        // + " " + tA);
-                    }
-                    mat.textures[0].texture = tex;
-                }
                 if (tex) {
                     dp.textures = {tex->getName()};
                 }

--- a/rwengine/src/render/MapRenderer.cpp
+++ b/rwengine/src/render/MapRenderer.cpp
@@ -115,7 +115,7 @@ void MapRenderer::draw(GameWorld* world, const MapInfo& mi) {
     for (int m = 0; m < MAP_BLOCK_SIZE; ++m) {
         std::string num = (m < 10 ? "0" : "");
         std::string name = "radar" + num + std::to_string(m);
-        auto texture = world->data->textures[{name, ""}];
+        auto texture = world->data->findSlotTexture(name, name);
 
         glBindTexture(GL_TEXTURE_2D, texture->getName());
 
@@ -140,7 +140,8 @@ void MapRenderer::draw(GameWorld* world, const MapInfo& mi) {
         glDisable(GL_STENCIL_TEST);
         // We only need the outer ring if we're clipping.
         glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_ONE, GL_ZERO);
-        TextureData::Handle radarDisc = data->findTexture("radardisc");
+        TextureData::Handle radarDisc =
+            data->findSlotTexture("hud", "radardisc");
 
         glm::mat4 model;
         model = glm::translate(model, glm::vec3(mi.screenPosition, 0.0f));
@@ -257,7 +258,7 @@ void MapRenderer::prepareBlip(const glm::vec2& coord, const glm::mat4& view,
 
     GLuint tex = 0;
     if (!texture.empty()) {
-        auto sprite = data->findTexture(texture);
+        auto sprite = data->findSlotTexture("hud", texture);
         tex = sprite->getName();
     }
     renderer->setUniform(rectProg, "colour", colour);

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -61,17 +61,6 @@ void ObjectRenderer::renderGeometry(Model* model, size_t g,
 
             if (mat.textures.size() > 0) {
                 auto tex = mat.textures[0].texture;
-                if (!tex) {
-                    auto& tC = mat.textures[0].name;
-                    auto& tA = mat.textures[0].alphaName;
-                    tex = m_world->data->findTexture(tC, tA);
-                    if (!tex) {
-                        // logger->warning("Renderer", "Missing texture: " + tC
-                        // + " " + tA);
-                        dp.textures = {m_errorTexture};
-                    }
-                    mat.textures[0].texture = tex;
-                }
                 if (tex) {
                     if (tex->isTransparent()) {
                         isTransparent = true;

--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -284,7 +284,7 @@ void TextRenderer::renderText(const TextRenderer::TextInfo& ti,
     Renderer::DrawParameters dp;
     dp.start = 0;
     dp.count = gb.getCount();
-    auto ftexture = renderer->getData()->findTexture(fonts[ti.font]);
+    auto ftexture = renderer->getData()->findSlotTexture("fonts", fonts[ti.font]);
     dp.textures = {ftexture->getName()};
     dp.depthWrite = false;
 

--- a/rwengine/src/render/WaterRenderer.cpp
+++ b/rwengine/src/render/WaterRenderer.cpp
@@ -98,7 +98,7 @@ void WaterRenderer::setDataTexture(GLuint fbBinding, GLuint dataTex) {
 void WaterRenderer::render(GameRenderer* renderer, GameWorld* world) {
     auto r = renderer->getRenderer();
 
-    auto waterTex = world->data->findTexture("water_old");
+    auto waterTex = world->data->findSlotTexture("particle", "water_old");
     RW_CHECK(waterTex != nullptr, "Water texture is null");
     if (waterTex == nullptr) {
         // Can't render water if we don't have a texture.

--- a/rwgame/DrawUI.cpp
+++ b/rwgame/DrawUI.cpp
@@ -168,7 +168,7 @@ void drawPlayerInfo(PlayerController* player, GameWorld* world,
     }
 
     TextureData::Handle itemTexture =
-        render->getData()->findTexture(itemTextureName);
+        render->getData()->findSlotTexture("hud", itemTextureName);
     RW_CHECK(itemTexture != nullptr, "Item has 0 texture");
     if (itemTexture != nullptr) {
         RW_CHECK(itemTexture->getName() != 0, "Item has 0 texture");

--- a/rwlib/source/gl/TextureData.hpp
+++ b/rwlib/source/gl/TextureData.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <gl/gl_core_3_3.h>
 #include <glm/glm.hpp>
+#include <map>
 
 #include <memory>
 
@@ -37,3 +38,4 @@ private:
     glm::ivec2 size;
     bool hasAlpha;
 };
+using TextureArchive = std::map<std::string, TextureData::Handle>;

--- a/rwlib/source/loaders/LoaderDFF.cpp
+++ b/rwlib/source/loaders/LoaderDFF.cpp
@@ -341,8 +341,10 @@ void LoaderDFF::readTexture(Model *model, const RWBStream &stream) {
     std::transform(name.begin(), name.end(), name.begin(), ::tolower);
     std::transform(alpha.begin(), alpha.end(), alpha.begin(), ::tolower);
 
+    TextureData::Handle textureinst =
+        texturelookup ? texturelookup(name, alpha) : nullptr;
     model->geometries.back()->materials.back().textures.push_back(
-        {name, alpha, nullptr});
+        {name, alpha, textureinst});
 }
 
 void LoaderDFF::readGeometryExtension(Model *model, const RWBStream &stream) {

--- a/rwlib/source/loaders/LoaderDFF.hpp
+++ b/rwlib/source/loaders/LoaderDFF.hpp
@@ -2,14 +2,14 @@
 #ifndef _LOADERDFF_HPP_
 #define _LOADERDFF_HPP_
 
+#include <gl/TextureData.hpp>
 #include <loaders/RWBinaryStream.hpp>
-
 #include <platform/FileHandle.hpp>
+
+#include <functional>
 #include <string>
-#include <vector>
 
 class Model;
-class GameData;
 
 class DFFLoaderException {
     std::string _message;
@@ -48,7 +48,16 @@ class LoaderDFF {
     void readAtomic(Model* model, const RWBStream& stream);
 
 public:
+    using TextureLookupCallback = std::function<TextureData::Handle(
+        const std::string&, const std::string&)>;
+
     Model* loadFromMemory(FileHandle file);
+
+    void setTextureLookupCallback(TextureLookupCallback tlc) {
+        texturelookup = tlc;
+    }
+private:
+    TextureLookupCallback texturelookup;
 };
 
 #endif

--- a/rwlib/source/loaders/LoaderTXD.cpp
+++ b/rwlib/source/loaders/LoaderTXD.cpp
@@ -182,11 +182,7 @@ bool TextureLoader::loadFromMemory(FileHandle file,
 
         auto texture = createTexture(texNative, rootSection);
 
-        inTextures[{name, alpha}] = texture;
-
-        if (!alpha.empty()) {
-            inTextures[{name, ""}] = texture;
-        }
+        inTextures[name] = texture;
     }
 
     return true;

--- a/rwlib/source/loaders/LoaderTXD.hpp
+++ b/rwlib/source/loaders/LoaderTXD.hpp
@@ -11,8 +11,6 @@
 
 // This might suffice
 #include <gl/TextureData.hpp>
-typedef std::map<std::pair<std::string, std::string>, TextureData::Handle>
-    TextureArchive;
 
 class FileIndex;
 


### PR DESCRIPTION
This collects textures by slot name, which keeps the textures from each TXD from conflicting.