### PR TITLE
Fix weapon scrollback

### DIFF
--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -586,7 +586,8 @@ void CharacterObject::cycleInventory(bool up) {
         currentState.currentWeapon = 0;
     } else {
         for (int j = currentState.currentWeapon - 1; j >= 0; --j) {
-            if (currentState.weapons[j].weaponId != 0) {
+            bool isFist = j == 0;
+            if (currentState.weapons[j].weaponId != 0 || isFist) {
                 currentState.currentWeapon = j;
                 return;
             }
@@ -594,7 +595,8 @@ void CharacterObject::cycleInventory(bool up) {
 
         // Nothing? set the highest
         for (int j = kMaxInventorySlots - 1; j >= 0; --j) {
-            if (currentState.weapons[j].weaponId != 0 || j == 0) {
+            bool isFist = j == 0;
+            if (currentState.weapons[j].weaponId != 0 || isFist) {
                 currentState.currentWeapon = j;
                 return;
             }

--- a/rwgame/DrawUI.cpp
+++ b/rwgame/DrawUI.cpp
@@ -184,9 +184,20 @@ void drawPlayerInfo(PlayerController* player, GameWorld* world,
     if (weapon->fireType != WeaponData::MELEE) {
         const CharacterState& cs = player->getCharacter()->getCurrentState();
         const CharacterWeaponSlot& slotInfo = cs.weapons[cs.currentWeapon];
-        ti.text = GameStringUtil::fromString(
-            std::to_string(slotInfo.bulletsClip) + "-" +
-            std::to_string(slotInfo.bulletsTotal));
+
+        bool isProjectile = weapon->fireType == WeaponData::PROJECTILE;
+        bool isShotgun = weapon->modelID == 176;
+        bool isSniper = weapon->modelID == 177;
+        bool noClip = isProjectile || isShotgun || isSniper;
+
+        if (noClip) {
+            ti.text = GameStringUtil::fromString(
+                std::to_string(slotInfo.bulletsTotal));
+        } else {
+            ti.text = GameStringUtil::fromString(
+                std::to_string(slotInfo.bulletsClip) + "-" +
+                std::to_string(slotInfo.bulletsTotal));
+        }
 
         ti.baseColour = ui_shadowColour;
         ti.font = 2;

--- a/rwgame/DrawUI.cpp
+++ b/rwgame/DrawUI.cpp
@@ -167,6 +167,8 @@ void drawPlayerInfo(PlayerController* player, GameWorld* world,
     // Urgh
     if (itemTextureName == "colt45") {
         itemTextureName = "pistol";
+    } else if (itemTextureName == "bomb") {
+        itemTextureName = "detonator";
     }
 
     TextureData::Handle itemTexture =

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -302,7 +302,9 @@ void IngameState::handlePlayerInput(const SDL_Event& event) {
             }
             break;
         case SDL_MOUSEWHEEL:
-            player->getCharacter()->cycleInventory(event.wheel.y > 0);
+            if (player->getCharacter()->getCurrentVehicle() == nullptr) {
+                player->getCharacter()->cycleInventory(event.wheel.y > 0);
+            }
             break;
         case SDL_MOUSEMOTION:
             if (game->hasFocus()) {


### PR DESCRIPTION
The order of the weapons in the inventory seems to be a bit off comparing to vanilla.
Couldn't find where to alter that quickly and it's probably enough commits for a single PR so next time Ü
