### PR TITLE
Implement basic Anim groups

### DIFF
--- a/rwengine/CMakeLists.txt
+++ b/rwengine/CMakeLists.txt
@@ -29,6 +29,8 @@ set(RWENGINE_SOURCES
 	src/core/Logger.hpp
 	src/core/Profiler.cpp
 	src/core/Profiler.hpp
+	src/data/AnimGroup.cpp
+	src/data/AnimGroup.hpp
 	src/data/Chase.cpp
 	src/data/Chase.hpp
 	src/data/CollisionModel.hpp

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -202,15 +202,19 @@ bool Activities::EnterVehicle::update(CharacterObject *character,
     auto entryPos = vehicle->getSeatEntryPositionWorld(seat);
     auto entryPosLocal = vehicle->getSeatEntryPosition(seat);
 
-    auto anm_open = character->animations->car_open_lhs;
-    auto anm_enter = character->animations->car_getin_lhs;
-    auto anm_pullout = character->animations->car_pullout_lhs;
+    auto cycle_open = AnimCycle::CarOpenLHS;
+    auto cycle_enter = AnimCycle::CarGetInLHS;
+    auto cycle_pullout = AnimCycle::CarPullOutLHS;
 
     if (entryPosLocal.x > 0.f) {
-        anm_open = character->animations->car_open_rhs;
-        anm_enter = character->animations->car_getin_rhs;
-        anm_pullout = character->animations->car_pullout_rhs;
+        cycle_open = AnimCycle::CarOpenRHS;
+        cycle_enter = AnimCycle::CarGetInRHS;
+        cycle_pullout = AnimCycle::CarPullOutRHS;
     }
+
+    auto anm_open = character->animations->animation(cycle_open);
+    auto anm_enter = character->animations->animation(cycle_enter);
+    auto anm_pullout = character->animations->animation(cycle_pullout);
 
     // If there's someone in this seat already, we may have to ask them to
     // leave.
@@ -298,8 +302,8 @@ bool Activities::ExitVehicle::update(CharacterObject *character,
     RW_UNUSED(controller);
 
     if (jacked) {
-        auto anm_jacked_lhs = character->animations->car_jacked_lhs;
-        auto anm_jacked_rhs = character->animations->car_jacked_lhs;
+        auto anm_jacked_lhs = character->animations->animation(AnimCycle::CarJackedLHS);
+        auto anm_jacked_rhs = character->animations->animation(AnimCycle::CarJackedRHS);
         auto anm_current = character->animator->getAnimation(AnimIndexAction);
 
         if (anm_current == anm_jacked_lhs || anm_current == anm_jacked_rhs) {
@@ -312,6 +316,7 @@ bool Activities::ExitVehicle::update(CharacterObject *character,
             auto vehicle = character->getCurrentVehicle();
             auto seat = character->getCurrentSeat();
             auto door = vehicle->getSeatEntryDoor(seat);
+            RW_UNUSED(door);
             auto exitPos = vehicle->getSeatEntryPositionWorld(seat);
             auto exitPosLocal = vehicle->getSeatEntryPosition(seat);
 
@@ -339,10 +344,10 @@ bool Activities::ExitVehicle::update(CharacterObject *character,
     auto exitPos = vehicle->getSeatEntryPositionWorld(seat);
     auto exitPosLocal = vehicle->getSeatEntryPosition(seat);
 
-    auto anm_exit = character->animations->car_getout_lhs;
+    auto anm_exit = character->animations->animation(AnimCycle::CarGetOutLHS);
 
     if (exitPosLocal.x > 0.f) {
-        anm_exit = character->animations->car_getout_rhs;
+        anm_exit = character->animations->animation(AnimCycle::CarGetOutRHS);
     }
 
     if (vehicle->getVehicle()->vehicletype_ == VehicleModelInfo::BOAT) {

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -202,14 +202,14 @@ bool Activities::EnterVehicle::update(CharacterObject *character,
     auto entryPos = vehicle->getSeatEntryPositionWorld(seat);
     auto entryPosLocal = vehicle->getSeatEntryPosition(seat);
 
-    auto anm_open = character->animations.car_open_lhs;
-    auto anm_enter = character->animations.car_getin_lhs;
-    auto anm_pullout = character->animations.car_pullout_lhs;
+    auto anm_open = character->animations->car_open_lhs;
+    auto anm_enter = character->animations->car_getin_lhs;
+    auto anm_pullout = character->animations->car_pullout_lhs;
 
     if (entryPosLocal.x > 0.f) {
-        anm_open = character->animations.car_open_rhs;
-        anm_enter = character->animations.car_getin_rhs;
-        anm_pullout = character->animations.car_pullout_rhs;
+        anm_open = character->animations->car_open_rhs;
+        anm_enter = character->animations->car_getin_rhs;
+        anm_pullout = character->animations->car_pullout_rhs;
     }
 
     // If there's someone in this seat already, we may have to ask them to
@@ -298,8 +298,8 @@ bool Activities::ExitVehicle::update(CharacterObject *character,
     RW_UNUSED(controller);
 
     if (jacked) {
-        auto anm_jacked_lhs = character->animations.car_jacked_lhs;
-        auto anm_jacked_rhs = character->animations.car_jacked_lhs;
+        auto anm_jacked_lhs = character->animations->car_jacked_lhs;
+        auto anm_jacked_rhs = character->animations->car_jacked_lhs;
         auto anm_current = character->animator->getAnimation(AnimIndexAction);
 
         if (anm_current == anm_jacked_lhs || anm_current == anm_jacked_rhs) {
@@ -339,10 +339,10 @@ bool Activities::ExitVehicle::update(CharacterObject *character,
     auto exitPos = vehicle->getSeatEntryPositionWorld(seat);
     auto exitPosLocal = vehicle->getSeatEntryPosition(seat);
 
-    auto anm_exit = character->animations.car_getout_lhs;
+    auto anm_exit = character->animations->car_getout_lhs;
 
     if (exitPosLocal.x > 0.f) {
-        anm_exit = character->animations.car_getout_rhs;
+        anm_exit = character->animations->car_getout_rhs;
     }
 
     if (vehicle->getVehicle()->vehicletype_ == VehicleModelInfo::BOAT) {

--- a/rwengine/src/data/AnimGroup.cpp
+++ b/rwengine/src/data/AnimGroup.cpp
@@ -1,39 +1,393 @@
 #include "AnimGroup.hpp"
+#include <algorithm>
+#include <vector>
 
-AnimGroup::AnimGroup(AnimationSet &animations, const std::string &name)
-    : idle(find(animations, name, "idle_stance"))
-    , walk(find(animations, name, "walk_player"))
-    , walk_start(find(animations, name, "walk_start"))
-    , run(find(animations, name, "run_player"))
-    , sprint(find(animations, name, "sprint_civi"))
-    , walk_right(find(animations, name, "walk_player_right"))
-    , walk_right_start(find(animations, name, "walk_start_right"))
-    , walk_left(find(animations, name, "walk_player_left"))
-    , walk_left_start(find(animations, name, "walk_start_left"))
-    , walk_back(find(animations, name, "walk_player_back"))
-    , walk_back_start(find(animations, name, "walk_start_back"))
-    , jump_start(find(animations, name, "jump_launch"))
-    , jump_glide(find(animations, name, "jump_glide"))
-    , jump_land(find(animations, name, "jump_land"))
-    , car_sit(find(animations, name, "car_sit"))
-    , car_sit_low(find(animations, name, "car_lsit"))
-    , car_open_lhs(find(animations, name, "car_open_lhs"))
-    , car_getin_lhs(find(animations, name, "car_getin_lhs"))
-    , car_getout_lhs(find(animations, name, "car_getout_lhs"))
-    , car_pullout_lhs(find(animations, name, "car_pullout_lhs"))
-    , car_jacked_lhs(find(animations, name, "car_jackedlhs"))
-    , car_open_rhs(find(animations, name, "car_open_rhs"))
-    , car_getin_rhs(find(animations, name, "car_getin_rhs"))
-    , car_getout_rhs(find(animations, name, "car_getout_rhs"))
-    , car_pullout_rhs(find(animations, name, "car_pullout_rhs"))
-    , car_jacked_rhs(find(animations, name, "car_jackedrhs"))
-    , kd_front(find(animations, name, "kd_front"))
-    , ko_shot_front(find(animations, name, "ko_shot_front")) {
-}
+// The default animations for every cycle
+const std::vector<AnimGroup> kBuiltInAnimGroups{
+    {"man",
+     {
+         {"walk_civi", 0xe2},
+         {"run_civi", 0xe2},
+         {"sprint_panic", 0xe2},
+         {"idle_stance", 0x2},
+         {"walk_start", 0x40},
+         {"run_stop", 0x44},
+         {"run_stopr", 0x44},
+         {"idle_cam", 0x12},
+         {"idle_hbhb", 0x12},
+         {"idle_tired", 0x2},
+         {"idle_armed", 0x12},
+         {"idle_chat", 0x12},
+         {"idle_taxi", 0x18},
+         {"ko_shot_front", 0x850},
+         {"ko_shot_front", 0x850},
+         {"ko_shot_front", 0x850},
+         {"ko_shot_front", 0x850},
+         {"ko_shot_face", 0x850},
+         {"ko_shot_stom", 0x50},
+         {"ko_shot_arml", 0x810},
+         {"ko_shot_armr", 0x810},
+         {"ko_shot_legl", 0x50},
+         {"ko_shot_legr", 0x50},
+         {"kd_left", 0x810},
+         {"kd_right", 0x810},
+         {"ko_skid_front", 0x10},
+         {"ko_spin_r", 0x10},
+         {"ko_skid_back", 0x810},
+         {"ko_spin_l", 0x10},
+         {"shot_partial", 0x218},
+         {"shot_leftp", 0x218},
+         {"shot_partial", 0x218},
+         {"shot_rightp", 0x218},
+         {"hit_front", 0x58},
+         {"hit_l", 0x18},
+         {"hit_back", 0x58},
+         {"hit_r", 0x18},
+         {"floor_hit", 0x14},
+         {"hit_bodyblow", 0x58},
+         {"hit_chest", 0x58},
+         {"hit_head", 0x58},
+         {"hit_walk", 0x58},
+         {"hit_wall", 0x58},
+         {"floor_hit_f", 0x814},
+         {"hit_behind", 0x18},
+         {"punchr", 0x18},
+         {"kick_floor", 0x18},
+         {"weapon_bat_h", 0x18},
+         {"weapon_bat_v", 0x18},
+         {"weapon_hgun_body", 0x218},
+         {"weapon_ak_body", 0x18},
+         {"weapon_pump", 0x18},
+         {"weapon_sniper", 0x18},
+         {"weapon_throw", 0x18},
+         {"weapon_throwu", 0x18},
+         {"weapon_start_throw", 0x18},
+         {"bomber", 0x218},
+         {"weapon_hgun_rload", 0x218},
+         {"weapon_ak_rload", 0x218},
+         {"fps_punch", 0x18},
+         {"fps_bat", 0x18},
+         {"fps_uzi", 0x18},
+         {"fps_pump", 0x18},
+         {"fps_ak", 0x18},
+         {"fps_m16", 0x18},
+         {"fps_rocket", 0x18},
+         {"fightidle", 0x2},
+         {"fight2idle", 0x18},
+         {"fightsh_f", 0x58},
+         {"fightbodyblow", 0x18},
+         {"fighthead", 0x18},
+         {"fightkick", 0x18},
+         {"fightknee", 0x18},
+         {"fightlhook", 0x18},
+         {"fightpunch", 0x18},
+         {"fightrndhse", 0x58},
+         {"fightlngkck", 0x58},
+         {"fightppunch", 0x214},
+         {"car_jackedrhs", 0x14},
+         {"car_ljackedrhs", 0x14},
+         {"car_jackedlhs", 0x14},
+         {"car_ljackedlhs", 0x14},
+         {"car_qjack", 0x18},
+         {"car_qjacked", 0x14},
+         {"car_align_lhs", 0x18},
+         {"car_alignhi_lhs", 0x18},
+         {"car_open_lhs", 0x18},
+         {"car_doorlocked_lhs", 0x18},
+         {"car_pullout_lhs", 0x18},
+         {"car_pulloutl_lhs", 0x18},
+         {"car_getin_lhs", 0x18},
+         {"car_getinl_lhs", 0x18},
+         {"car_closedoor_lhs", 0x18},
+         {"car_closedoorl_lhs", 0x18},
+         {"car_rolldoor", 0x18},
+         {"car_rolldoorlo", 0x18},
+         {"car_getout_lhs", 0x18},
+         {"car_getoutl_lhs", 0x18},
+         {"car_close_lhs", 0x18},
+         {"car_align_rhs", 0x18},
+         {"car_alignhi_rhs", 0x18},
+         {"car_open_rhs", 0x18},
+         {"car_doorlocked_rhs", 0x18},
+         {"car_pullout_rhs", 0x18},
+         {"car_pulloutl_rhs", 0x18},
+         {"car_getin_rhs", 0x18},
+         {"car_getinl_rhs", 0x18},
+         {"car_closedoor_rhs", 0x18},
+         {"car_closedoorl_rhs", 0x18},
+         {"car_shuffle_rhs", 0x18},
+         {"car_lshuffle_rhs", 0x18},
+         {"car_sit", 0x4},
+         {"car_lsit", 0x4},
+         {"car_sitp", 0x4},
+         {"car_sitplo", 0x4},
+         {"drive_l", 0x14},
+         {"drive_r", 0x14},
+         {"drive_lo_l", 0x14},
+         {"drive_lo_r", 0x14},
+         {"driveby_l", 0x14},
+         {"driveby_r", 0x14},
+         {"car_lb", 0x14},
+         {"drive_boat", 0x4},
+         {"car_getout_rhs", 0x18},
+         {"car_getoutl_rhs", 0x18},
+         {"car_close_rhs", 0x18},
+         {"car_hookertalk", 0x12},
+         {"coach_opnl", 0x18},
+         {"coach_opnr", 0x18},
+         {"coach_inl", 0x18},
+         {"coach_inr", 0x18},
+         {"coach_outl", 0x18},
+         {"train_getin", 0x10},
+         {"train_getout", 0x18},
+         {"car_crawloutrhs", 0x18},
+         {"car_crawloutrhs", 0x18},
+         {"van_openl", 0x18},
+         {"van_getinl", 0x18},
+         {"van_closel", 0x18},
+         {"van_getoutl", 0x18},
+         {"van_open", 0x18},
+         {"van_getin", 0x18},
+         {"van_close", 0x18},
+         {"van_getout", 0x18},
+         {"getup", 0x58},
+         {"getup", 0x58},
+         {"getup", 0x58},
+         {"getup_front", 0x58},
+         {"jump_launch", 0x18},
+         {"jump_glide", 0x14},
+         {"jump_land", 0x58},
+         {"fall_fall", 0x16},
+         {"fall_glide", 0x14},
+         {"fall_land", 0x58},
+         {"fall_collapse", 0x58},
+         {"ev_step", 0x58},
+         {"ev_dive", 0x850},
+         {"xpressscratch", 0x118},
+         {"roadcross", 0x12},
+         {"turn_180", 0x18},
+         {"arrestgun", 0x50},
+         {"drown", 0x10},
+         {"cpr", 0x18},
+         {"duck_down", 0x14},
+         {"duck_low", 0x14},
+         {"rblock_cshoot", 0x14},
+         {"weapon_throwu", 0x18},
+         {"handsup", 0x50},
+         {"handscower", 0x58},
+         {"fucku", 0x21c},
+         {"phone_in", 0x10},
+         {"phone_out", 0x18},
+         {"phone_talk", 0x16},
+     }},
+    {"player",
+     {
+         {"walk_player", 0xe2},
+         {"run_player", 0xe2},
+         {"sprint_civi", 0xe2},
+         {"idle_stance", 0x2},
+         {"walk_start", 0x40},
+     }},
+    {"playerrocket",
+     {
+         {"walk_rocket", 0xe2},
+         {"run_rocket", 0xe2},
+         {"run_rocket", 0xe2},
+         {"idle_rocket", 0x2},
+         {"walk_start_rocket", 0x40},
+     }},
+    {"player1armed",
+     {
+         {"walk_player", 0xe2},
+         {"run_1armed", 0xe2},
+         {"sprint_civi", 0xe2},
+         {"idle_stance", 0x2},
+         {"walk_start", 0x40},
+     }},
+    {"player2armed",
+     {
+         {"walk_player", 0xe2},
+         {"run_armed", 0xe2},
+         {"run_armed", 0xe2},
+         {"idle_stance", 0x2},
+         {"walk_start", 0x40},
+     }},
+    {"playerbbbat",
+     {
+         {"walk_player", 0xe2},
+         {"run_player", 0xe2},
+         {"run_player", 0xe2},
+         {"idle_stance", 0x2},
+         {"walk_start", 0x40},
+     }},
+    {"shuffle",
+     {
+         {"walk_shuffle", 0xe2},
+         {"run_civi", 0xe2},
+         {"sprint_civi", 0xe2},
+         {"idle_stance", 0x2},
+     }},
+    {"oldman",
+     {
+         {"walk_old", 0xe2},
+         {"run_civi", 0xe2},
+         {"sprint_civi", 0xe2},
+         {"idle_stance", 0x2},
+     }},
+    {"gang1",
+     {
+         {"walk_gang1", 0xe2},
+         {"run_gang1", 0xe2},
+         {"sprint_civi", 0xe2},
+         {"idle_stance", 0x2},
+     }},
+    {"gang2",
+     {
+         {"walk_gang2", 0xe2},
+         {"run_gang1", 0xe2},
+         {"sprint_civi", 0xe2},
+         {"idle_stance", 0x2},
+     }},
+    {"fatman",
+     {
+         {"walk_fat", 0xe2},
+         {"run_civi", 0xe2},
+         {"woman_runpanic", 0xe2},
+         {"idle_stance", 0x2},
+     }},
+    {"oldfatman",
+     {
+         {"walk_fatold", 0xe2},
+         {"run_fatold", 0xe2},
+         {"woman_runpanic", 0xe2},
+         {"idle_stance", 0x2},
+     }},
+    {"woman",
+     {
+         {"woman_walknorm", 0xe2},
+         {"woman_run", 0xe2},
+         {"woman_runpanic", 0xe2},
+         {"woman_idlestance", 0x2},
+     }},
+    {"shopping",
+     {
+         {"woman_walkshop", 0xe2},
+         {"woman_run", 0xe2},
+         {"woman_run", 0xe2},
+         {"woman_idlestance", 0x2},
+     }},
+    {"busywoman",
+     {
+         {"woman_walkbusy", 0xe2},
+         {"woman_run", 0xe2},
+         {"woman_runpanic", 0xe2},
+         {"woman_idlestance", 0x2},
+     }},
+    {"sexywoman",
+     {
+         {"woman_walksexy", 0xe2},
+         {"woman_run", 0xe2},
+         {"woman_runpanic", 0xe2},
+         {"woman_idlestance", 0x2},
+     }},
+    {"oldwoman",
+     {
+         {"woman_walkold", 0xe2},
+         {"woman_run", 0xe2},
+         {"woman_runpanic", 0xe2},
+         {"woman_idlestance", 0x2},
+     }},
+    {"fatwoman",
+     {
+         {"walk_fat", 0xe2},
+         {"woman_run", 0xe2},
+         {"woman_runpanic", 0xe2},
+         {"woman_idlestance", 0x2},
+     }},
+    {"panicchunky",
+     {
+         {"run_fatold", 0xe2},
+         {"woman_runpanic", 0xe2},
+         {"woman_runpanic", 0xe2},
+         {"idle_stance", 0x2},
+     }},
+    {"playerback",
+     {
+         {"walk_player_back", 0xe2},
+         {"run_player_back", 0xe2},
+         {"run_player_back", 0xe2},
+         {"idle_stance", 0x2},
+         {"walk_start_back", 0x40},
+     }},
+    {"playerleft",
+     {
+         {"walk_player_left", 0x10e2},
+         {"run_left", 0x10e2},
+         {"run_left", 0x10e2},
+         {"idle_stance", 0x2},
+         {"walk_start_left", 0x1040},
+     }},
+    {"playerright",
+     {
+         {"walk_player_right", 0x10e2},
+         {"run_right", 0x10e2},
+         {"run_right", 0x10e2},
+         {"idle_stance", 0x2},
+         {"walk_start_right", 0x1040},
+     }},
+    {"rocketback",
+     {
+         {"walk_rocket_back", 0xe2},
+         {"run_rocket_back", 0xe2},
+         {"run_rocket_back", 0xe2},
+         {"idle_rocket", 0x2},
+         {"walkst_rocket_back", 0x40},
+     }},
+    {"rocketleft",
+     {
+         {"walk_rocket_left", 0x10e2},
+         {"run_rocket_left", 0x10e2},
+         {"run_rocket_left", 0x10e2},
+         {"idle_rocket", 0x2},
+         {"walkst_rocket_left", 0x1040},
+     }},
+    {"rocketright",
+     {
+         {"walk_rocket_right", 0x10e2},
+         {"run_rocket_right", 0x10e2},
+         {"run_rocket_right", 0x10e2},
+         {"idle_rocket", 0x2},
+         {"walkst_rocket_right", 0x1040},
+     }}};
 
-Animation *AnimGroup::find(AnimationSet &animations, const std::string &group,
-                           const std::string &anim) {
-    // @todo actually find the correct animation
-    RW_UNUSED(group);
-    return animations[anim];
+AnimGroup AnimGroup::getBuiltInAnimGroup(AnimationSet &animations,
+                                         const std::string &name) {
+    auto findgroup = [&]() {
+        auto it =
+            std::find_if(kBuiltInAnimGroups.begin(), kBuiltInAnimGroups.end(),
+                         [&](const AnimGroup &g) { return g.name_ == name; });
+        if (it != kBuiltInAnimGroups.end()) {
+            return *it;
+        } else {
+            RW_MESSAGE("No such animation group: " + name +
+                       ". Returning first animation group");
+            return kBuiltInAnimGroups[0];
+        }
+    };
+
+    auto group = AnimGroup(findgroup());
+
+    uint32_t id = 0;
+    for (auto &a : group.animations_) {
+        // Copy from the first animgroup if this entry is empty
+        /// @todo check if this is realy how we should do this
+        if (a.name.empty()) {
+            a = kBuiltInAnimGroups[0].animations_[id];
+        }
+
+        a.id = static_cast<AnimCycle>(id++);
+        a.anim = animations[a.name];
+    }
+
+    return group;
 }

--- a/rwengine/src/data/AnimGroup.cpp
+++ b/rwengine/src/data/AnimGroup.cpp
@@ -1,0 +1,39 @@
+#include "AnimGroup.hpp"
+
+AnimGroup::AnimGroup(AnimationSet &animations, const std::string &name)
+    : idle(find(animations, name, "idle_stance"))
+    , walk(find(animations, name, "walk_player"))
+    , walk_start(find(animations, name, "walk_start"))
+    , run(find(animations, name, "run_player"))
+    , sprint(find(animations, name, "sprint_civi"))
+    , walk_right(find(animations, name, "walk_player_right"))
+    , walk_right_start(find(animations, name, "walk_start_right"))
+    , walk_left(find(animations, name, "walk_player_left"))
+    , walk_left_start(find(animations, name, "walk_start_left"))
+    , walk_back(find(animations, name, "walk_player_back"))
+    , walk_back_start(find(animations, name, "walk_start_back"))
+    , jump_start(find(animations, name, "jump_launch"))
+    , jump_glide(find(animations, name, "jump_glide"))
+    , jump_land(find(animations, name, "jump_land"))
+    , car_sit(find(animations, name, "car_sit"))
+    , car_sit_low(find(animations, name, "car_lsit"))
+    , car_open_lhs(find(animations, name, "car_open_lhs"))
+    , car_getin_lhs(find(animations, name, "car_getin_lhs"))
+    , car_getout_lhs(find(animations, name, "car_getout_lhs"))
+    , car_pullout_lhs(find(animations, name, "car_pullout_lhs"))
+    , car_jacked_lhs(find(animations, name, "car_jackedlhs"))
+    , car_open_rhs(find(animations, name, "car_open_rhs"))
+    , car_getin_rhs(find(animations, name, "car_getin_rhs"))
+    , car_getout_rhs(find(animations, name, "car_getout_rhs"))
+    , car_pullout_rhs(find(animations, name, "car_pullout_rhs"))
+    , car_jacked_rhs(find(animations, name, "car_jackedrhs"))
+    , kd_front(find(animations, name, "kd_front"))
+    , ko_shot_front(find(animations, name, "ko_shot_front")) {
+}
+
+Animation *AnimGroup::find(AnimationSet &animations, const std::string &group,
+                           const std::string &anim) {
+    // @todo actually find the correct animation
+    RW_UNUSED(group);
+    return animations[anim];
+}

--- a/rwengine/src/data/AnimGroup.hpp
+++ b/rwengine/src/data/AnimGroup.hpp
@@ -1,0 +1,55 @@
+#ifndef RWENGINE_DATA_ANIMGROUP_HPP
+#define RWENGINE_DATA_ANIMGROUP_HPP
+#include <memory>
+#include <unordered_map>
+#include "rw/types.hpp"
+
+struct Animation;
+
+struct AnimGroup {
+    /* Animations */
+    Animation* idle;
+    Animation* walk;
+    Animation* walk_start;
+    Animation* run;
+    Animation* sprint;
+
+    Animation* walk_right;
+    Animation* walk_right_start;
+    Animation* walk_left;
+    Animation* walk_left_start;
+
+    Animation* walk_back;
+    Animation* walk_back_start;
+
+    Animation* jump_start;
+    Animation* jump_glide;
+    Animation* jump_land;
+
+    Animation* car_sit;
+    Animation* car_sit_low;
+
+    Animation* car_open_lhs;
+    Animation* car_getin_lhs;
+    Animation* car_getout_lhs;
+    Animation* car_pullout_lhs;
+    Animation* car_jacked_lhs;
+
+    Animation* car_open_rhs;
+    Animation* car_getin_rhs;
+    Animation* car_getout_rhs;
+    Animation* car_pullout_rhs;
+    Animation* car_jacked_rhs;
+
+    Animation* kd_front;
+    Animation* ko_shot_front;
+
+    AnimGroup(AnimationSet& animations, const std::string&);
+
+    static Animation* find(AnimationSet&, const std::string& group,
+                           const std::string& anim);
+};
+
+using AnimGroups = std::unordered_map<std::string, std::unique_ptr<AnimGroup>>;
+
+#endif

--- a/rwengine/src/data/AnimGroup.hpp
+++ b/rwengine/src/data/AnimGroup.hpp
@@ -6,48 +6,227 @@
 
 struct Animation;
 
+/**
+ * The logical animations
+ */
+enum class AnimCycle {
+    Walk = 0,
+    Run,
+    Sprint,
+    Idle,
+    WalkStart,
+    RunStop,
+    RunStopR,
+    IdleCam,
+    IdleHbhb,
+    IdleTired,
+    IdleArmed,
+    IdleChat,
+    IdleTaxi,
+    KnockOutShotFront0,
+    KnockOutShotFront1,
+    KnockOutShotFront2,
+    KnockOutShotFront3,
+    KnockOutShotFace,
+    KnockOutShotStomach,
+    KnockOutShotArmL,
+    KnockOutShotArmR,
+    KnockOutShotLegL,
+    KnockOutShotLegR,
+    KnockDownLeft,
+    KnockDownRight,
+    KnockOutSkidFront,
+    KnockOutSpinR,
+    KnockOutSkidBack,
+    KnkockOutSpinL,
+    ShotPartial0,
+    ShotLeftP,
+    ShotPartial1,
+    ShotRightP,
+    HitFront,
+    HitLeft,
+    HitBack,
+    HitRight,
+    FloorHit,
+    HitBodyBlow,
+    HitChest,
+    HitHead,
+    HitWalk,
+    HitWall,
+    FloorHitF,
+    HitBehind,
+    PunchR,
+    KickFloor,
+    WeaponBatH,
+    WeaponBatV,
+    WeaponHgunBody,
+    WeaponAKBody,
+    WeaponPump,
+    WeaponSniper,
+    WeaponThrow,
+    WeaponThrowu,
+    WeaponStartThrow,
+    WeaponBomber,
+    WeaponHgunReload,
+    WeaponAKReload,
+    FPSPunch,
+    FPSBat,
+    FPSUzi,
+    FPSPump,
+    FPSAK,
+    FPSM16,
+    FPSRocket,
+    FightIdle0,
+    FightIdle1,
+    FightSh_F,
+    FightBodyBlow,
+    FightHead,
+    FightKick,
+    FightKnee,
+    FightLHook,
+    FightPunch,
+    FightRoundhouse,
+    FightLongKick,
+    FightPPunch,
+    CarJackedRHS,
+    CarLowJackedRHS,
+    CarJackedLHS,
+    CarLowJackedLHS,
+    CarQuickJack,
+    CarQuickJacked,
+    CarAlignLHS,
+    CarAlignHighLHS,
+    CarOpenLHS,
+    CarDoorLockedLHS,
+    CarPullOutLHS,
+    CarLowPullOutLHS,
+    CarGetInLHS,
+    CarLowGetInLHS,
+    CarCloseDoorLHS,
+    CarLowCloseDoorLHS,
+    CarRollDoor,
+    CarLowRollDoor,
+    CarGetOutLHS,
+    CarLowGetOutLHS,
+    CarCloseLHS,
+    CarAlignRHS,
+    CarAlignHighRHS,
+    CarOpenRHS,
+    CarDoorLockedRHS,
+    CarPullOutRHS,
+    CarLowPullOutRHS,
+    CarGetInRHS,
+    CarLowGetInRHS,
+    CarCloseDoorRHS,
+    CarLowCloseDoorRHS,
+    CarShuffleRHS,
+    CarLowShuffleRHS,
+    CarSit,
+    CarLowSit,
+    CarSitPassenger,
+    CarLowSitPassenger,
+    DriveLeft,
+    DriveRight,
+    LowDriveLeft,
+    LowDriveRight,
+    DriveByLeft,
+    DriveByRight,
+    CarLB,  // ?
+    DriveBoat,
+    CarGetOutRHS,
+    CarLowGetOutRHS,
+    CarCloseRHS,
+    CarHookerTalk,
+    CoachOpenLHS,
+    CoachOpenRHS,
+    CoachGetInLHS,
+    CoachGetInRHS,
+    CoachGetOutLHS,
+    TrainGetIn,
+    TrainGetOut,
+    CarCrawlOutLHS,
+    CarCrawlOutRHS,
+    VanOpenLHS,
+    VanGetInLHS,
+    VanCloseLHS,
+    VanGetOutLHS,
+    VanOpenRHS,
+    VanGetInRHS,
+    VanCloseRHS,
+    VanGetOutRHS,
+    GetUp0,
+    GetUp1,
+    GetUp2,
+    GetUpFront,
+    JumpLaunch,
+    JumpGlide,
+    JumpLand,
+    FallFall,
+    FallGlide,
+    FallLand,
+    FallCollapse,
+    EVStep,
+    EVDive,
+    XpressScratch,
+    RoadCross,
+    Turn180,
+    ArrestGun,
+    Drown,
+    CPR,
+    DuckDown,
+    DuckLow,
+    RBlockCShoot,
+    WeaponThrowu1,
+    HandsUp,
+    HandsCower,
+    FuckYou,
+    PhoneIn,
+    PhoneOut,
+    PhoneTalk,
+    _CycleCount
+};
+
+struct AnimCycleInfo {
+    enum Flags { Repeat = 0x02, Movement = 0x40, Movement_X = 0x1000 };
+
+    AnimCycle id = AnimCycle::Idle;
+    /// The name from animgrp.dat or hard-coded
+    std::string name;
+    /// Flags
+    uint32_t flags;
+    /// The actual animation
+    Animation* anim = nullptr;
+
+    AnimCycleInfo(const std::string& name = "", uint32_t flags = 0)
+        : name(name), flags(flags) {
+    }
+};
+
 struct AnimGroup {
+    std::string name_;
+
     /* Animations */
-    Animation* idle;
-    Animation* walk;
-    Animation* walk_start;
-    Animation* run;
-    Animation* sprint;
+    AnimCycleInfo animations_[static_cast<uint32_t>(AnimCycle::_CycleCount)];
 
-    Animation* walk_right;
-    Animation* walk_right_start;
-    Animation* walk_left;
-    Animation* walk_left_start;
+    Animation* animation(AnimCycle cycle) const {
+        return animations_[static_cast<uint32_t>(cycle)].anim;
+    }
 
-    Animation* walk_back;
-    Animation* walk_back_start;
+    uint32_t flags(AnimCycle cycle) const {
+        return animations_[static_cast<uint32_t>(cycle)].flags;
+    }
 
-    Animation* jump_start;
-    Animation* jump_glide;
-    Animation* jump_land;
+    static AnimGroup getBuiltInAnimGroup(AnimationSet&,
+                                         const std::string& name);
 
-    Animation* car_sit;
-    Animation* car_sit_low;
+    static uint32_t getAnimationFlags(const std::string& animation);
 
-    Animation* car_open_lhs;
-    Animation* car_getin_lhs;
-    Animation* car_getout_lhs;
-    Animation* car_pullout_lhs;
-    Animation* car_jacked_lhs;
-
-    Animation* car_open_rhs;
-    Animation* car_getin_rhs;
-    Animation* car_getout_rhs;
-    Animation* car_pullout_rhs;
-    Animation* car_jacked_rhs;
-
-    Animation* kd_front;
-    Animation* ko_shot_front;
-
-    AnimGroup(AnimationSet& animations, const std::string&);
-
-    static Animation* find(AnimationSet&, const std::string& group,
-                           const std::string& anim);
+    AnimGroup(const std::string& name,
+              const std::initializer_list<AnimCycleInfo>& cycles = {})
+        : name_(name) {
+        std::copy(std::begin(cycles), std::end(cycles),
+                  std::begin(animations_));
+    }
 };
 
 using AnimGroups = std::unordered_map<std::string, std::unique_ptr<AnimGroup>>;

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -149,6 +149,17 @@ uint16_t GameData::findModelObject(const std::string model) {
     return -1;
 }
 
+AnimGroup* GameData::getAnimGroup(const std::string& group) {
+    auto it = pedAnimGroups.find(group);
+    if (it != pedAnimGroups.end()) {
+        return it->second.get();
+    }
+
+    pedAnimGroups[group] = std::make_unique<AnimGroup>(
+        AnimGroup::getBuiltInAnimGroup(animations, group));
+    return pedAnimGroups[group].get();
+}
+
 void GameData::loadCOL(const size_t zone, const std::string& name) {
     RW_UNUSED(zone);
 

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -58,6 +58,9 @@ void GameData::load() {
 
     loadIFP("ped.ifp");
 
+    /// @todo load real data
+    pedAnimGroups["player"] = std::make_unique<AnimGroup>(animations, "player");
+
     // Clear existing zones
     gamezones = ZoneDataList{
         {"CITYZON", 0, {-4000.f, -4000.f, -500.f}, {4000.f, 4000.f, 500.f}, 0}};

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -59,7 +59,8 @@ void GameData::load() {
     loadIFP("ped.ifp");
 
     /// @todo load real data
-    pedAnimGroups["player"] = std::make_unique<AnimGroup>(animations, "player");
+    pedAnimGroups["player"] = std::make_unique<AnimGroup>(
+        AnimGroup::getBuiltInAnimGroup(animations, "player"));
 
     // Clear existing zones
     gamezones = ZoneDataList{
@@ -605,7 +606,7 @@ void GameData::loadPedGroups(const std::string& path) {
                 break;
             }
             if (line.back() == ',') {
-                line.resize(line.size()-1);
+                line.resize(line.size() - 1);
             }
             auto model = findModelObject(line);
             if (int16_t(model) == -1) {

--- a/rwengine/src/engine/GameData.hpp
+++ b/rwengine/src/engine/GameData.hpp
@@ -288,6 +288,13 @@ public:
     AnimGroups pedAnimGroups;
 
     /**
+     * Finds or loads the named animation group
+     *
+     * if the group can't be found, a default is returned.
+     */
+    AnimGroup* getAnimGroup(const std::string& group);
+
+    /**
      * DynamicObjectData
      */
     std::map<std::string, std::shared_ptr<DynamicObjectData>> dynamicObjectData;

--- a/rwengine/src/engine/GameData.hpp
+++ b/rwengine/src/engine/GameData.hpp
@@ -7,6 +7,7 @@ class Logger;
 #include <data/GameTexts.hpp>
 #include <data/PedData.hpp>
 #include <data/ZoneData.hpp>
+#include <data/AnimGroup.hpp>
 #include <loaders/LoaderDFF.hpp>
 #include <loaders/LoaderIDE.hpp>
 #include <loaders/LoaderIFP.hpp>
@@ -280,6 +281,11 @@ public:
      * Loaded Animations
      */
     AnimationSet animations;
+
+    /**
+     * Pedestrian Animation Groups
+     */
+    AnimGroups pedAnimGroups;
 
     /**
      * DynamicObjectData

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -28,6 +28,7 @@ CharacterObject::CharacterObject(GameWorld* engine, const glm::vec3& pos,
     , jumped(false)
     , jumpSpeed(DefaultJumpSpeed)
     , motionBlockedByActivity(false)
+    , cycle_(AnimCycle::Idle)
     , physCharacter(nullptr)
     , physObject(nullptr)
     , physShape(nullptr)
@@ -523,6 +524,23 @@ void CharacterObject::playActivityAnimation(Animation* animation, bool repeat,
 void CharacterObject::activityFinished() {
     animator->playAnimation(AnimIndexAction, nullptr, 1.f, false);
     motionBlockedByActivity = false;
+}
+
+void CharacterObject::playCycle(AnimCycle cycle) {
+    auto animation = animations->animation(cycle);
+    auto flags = animations->flags(cycle);
+
+    cycle_ = cycle;
+    animator->playAnimation(AnimIndexAction, animation, 1.f,
+                            flags & AnimCycleInfo::Repeat);
+}
+
+void CharacterObject::playCycleAnimOverride(AnimCycle cycle, Animation* anim) {
+    auto flags = animations->flags(cycle);
+
+    cycle_ = cycle;
+    animator->playAnimation(AnimIndexAction, anim, 1.f,
+                            flags & AnimCycleInfo::Repeat);
 }
 
 void CharacterObject::addToInventory(int slot, int ammo) {

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -116,11 +116,12 @@ glm::vec3 CharacterObject::updateMovementAnimation(float dt) {
 
     // Things are simpler if we're in a vehicle
     if (getCurrentVehicle()) {
-        animator->playAnimation(0, animations->car_sit, 1.f, true);
+        animator->playAnimation(0, animations->animation(AnimCycle::CarSit),
+                                1.f, true);
         return glm::vec3();
     }
 
-    Animation* movementAnimation = animations->idle;
+    Animation* movementAnimation = animations->animation(AnimCycle::Idle);
     Animation* currentAnim = animator->getAnimation(AnimIndexMovement);
     bool isActionHappening =
         (animator->getAnimation(AnimIndexAction) != nullptr);
@@ -130,46 +131,49 @@ glm::vec3 CharacterObject::updateMovementAnimation(float dt) {
 
     float movementLength = glm::length(movement);
     if (!isAlive()) {
-        movementAnimation = animations->ko_shot_front;
+        movementAnimation =
+            animations->animation(AnimCycle::KnockOutShotFront0);
         repeat = false;
     } else if (jumped) {
         repeat = false;
-        if (currentAnim == animations->jump_start &&
+        if (currentAnim == animations->animation(AnimCycle::JumpLaunch) &&
             animator->isCompleted(AnimIndexMovement)) {
-            movementAnimation = animations->jump_start;
+            movementAnimation = animations->animation(AnimCycle::JumpLaunch);
         }
         if (isOnGround()) {
-            if (currentAnim != animations->jump_land ||
+            if (currentAnim != animations->animation(AnimCycle::JumpLand) ||
                 !animator->isCompleted(AnimIndexMovement)) {
-                movementAnimation = animations->jump_land;
+                movementAnimation = animations->animation(AnimCycle::JumpLand);
             } else {
                 // We are done jumping
                 jumped = false;
             }
         } else {
-            movementAnimation = animations->jump_glide;
+            movementAnimation = animations->animation(AnimCycle::JumpGlide);
         }
     } else if (movementLength > movementEpsilon) {
         if (running && !isActionHappening) {
             if (movementLength > 1.f) {
-                movementAnimation = animations->sprint;
+                movementAnimation = animations->animation(AnimCycle::Sprint);
             } else {
-                movementAnimation = animations->run;
+                movementAnimation = animations->animation(AnimCycle::Run);
             }
             animationSpeed = 1.f;
         } else {
             animationSpeed = 1.f / movementLength;
             // Determine if we need to play the walk start animation
-            if (currentAnim != animations->walk) {
-                if (currentAnim != animations->walk_start ||
+            if (currentAnim != animations->animation(AnimCycle::Walk)) {
+                if (currentAnim !=
+                        animations->animation(AnimCycle::WalkStart) ||
                     !animator->isCompleted(AnimIndexMovement)) {
-                    movementAnimation = animations->walk_start;
+                    movementAnimation =
+                        animations->animation(AnimCycle::WalkStart);
                 } else {
-                    movementAnimation = animations->walk;
+                    movementAnimation = animations->animation(AnimCycle::Walk);
                 }
             } else {
                 // Keep walkin
-                movementAnimation = animations->walk;
+                movementAnimation = animations->animation(AnimCycle::Walk);
             }
         }
     }
@@ -184,7 +188,7 @@ glm::vec3 CharacterObject::updateMovementAnimation(float dt) {
 
     // If we have to, interrogate the movement animation
     const auto& modelroot = getClump()->getFrame();
-    if (movementAnimation != animations->idle &&
+    if (movementAnimation != animations->animation(AnimCycle::Idle) &&
         !modelroot->getChildren().empty()) {
         const auto& root = modelroot->getChildren()[0];
         auto it = movementAnimation->bones.find(root->getName());
@@ -404,8 +408,10 @@ bool CharacterObject::enterVehicle(VehicleObject* vehicle, size_t seat) {
 
 bool CharacterObject::isEnteringOrExitingVehicle() const {
     auto a = animator->getAnimation(AnimIndexAction);
-    return a == animations->car_getout_lhs || a == animations->car_getin_lhs ||
-           a == animations->car_getout_rhs || a == animations->car_getin_rhs;
+    return a == animations->animation(AnimCycle::CarGetOutLHS) ||
+           a == animations->animation(AnimCycle::CarGetInLHS) ||
+           a == animations->animation(AnimCycle::CarGetOutRHS) ||
+           a == animations->animation(AnimCycle::CarGetInRHS);
 }
 
 bool CharacterObject::isStopped() const {
@@ -452,8 +458,9 @@ void CharacterObject::jump() {
     if (physCharacter) {
         physCharacter->jump();
         jumped = true;
-        animator->playAnimation(AnimIndexMovement, animations->jump_start, 1.f,
-                                false);
+        animator->playAnimation(AnimIndexMovement,
+                                animations->animation(AnimCycle::JumpLaunch),
+                                1.f, false);
     }
 }
 

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -235,6 +235,11 @@ void CharacterObject::tick(float dt) {
         controller->update(dt);
     }
 
+    // Reset back to idle cycle when not in an activity
+    if (controller->getCurrentActivity() == nullptr) {
+        cycle_ = AnimCycle::Idle;
+    }
+
     animator->tick(dt);
     updateCharacter(dt);
 

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -33,7 +33,6 @@ CharacterObject::CharacterObject(GameWorld* engine, const glm::vec3& pos,
     , physObject(nullptr)
     , physShape(nullptr)
     , controller(nullptr) {
-    animations = engine->data->pedAnimGroups["player"].get();
 
     auto info = getModelInfo<PedModelInfo>();
     setClump(ClumpPtr(info->getModel()->clone()));
@@ -43,6 +42,8 @@ CharacterObject::CharacterObject(GameWorld* engine, const glm::vec3& pos,
 
         createActor();
     }
+
+    animations = engine->data->getAnimGroup(info->animgroup_);
 }
 
 CharacterObject::~CharacterObject() {

--- a/rwengine/src/objects/CharacterObject.hpp
+++ b/rwengine/src/objects/CharacterObject.hpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <glm/glm.hpp>
 #include <objects/GameObject.hpp>
+#include <data/AnimGroup.hpp>
 
 constexpr int kMaxInventorySlots = 13;
 
@@ -35,64 +36,6 @@ struct CharacterState {
 
 class VehicleObject;
 class GameWorld;
-
-struct AnimationGroup {
-    Animation* idle;
-    Animation* walk;
-    Animation* walk_start;
-    Animation* run;
-    Animation* sprint;
-
-    Animation* walk_right;
-    Animation* walk_right_start;
-    Animation* walk_left;
-    Animation* walk_left_start;
-
-    Animation* walk_back;
-    Animation* walk_back_start;
-
-    Animation* jump_start;
-    Animation* jump_glide;
-    Animation* jump_land;
-
-    Animation* car_sit;
-    Animation* car_sit_low;
-
-    Animation* car_open_lhs;
-    Animation* car_getin_lhs;
-    Animation* car_getout_lhs;
-    Animation* car_jacked_lhs;
-    Animation* car_pullout_lhs;
-
-    Animation* car_open_rhs;
-    Animation* car_getin_rhs;
-    Animation* car_getout_rhs;
-    Animation* car_jacked_rhs;
-    Animation* car_pullout_rhs;
-
-    Animation* kd_front;
-    Animation* ko_shot_front;
-
-    AnimationGroup()
-        : idle(nullptr)
-        , walk(nullptr)
-        , walk_start(nullptr)
-        , run(nullptr)
-        , jump_start(nullptr)
-        , jump_glide(nullptr)
-        , jump_land(nullptr)
-        , car_sit(nullptr)
-        , car_sit_low(nullptr)
-        , car_open_lhs(nullptr)
-        , car_getin_lhs(nullptr)
-        , car_getout_lhs(nullptr)
-        , car_open_rhs(nullptr)
-        , car_getin_rhs(nullptr)
-        , car_getout_rhs(nullptr)
-        , kd_front(nullptr)
-        , ko_shot_front(nullptr) {
-    }
-};
 
 /**
  * @brief The CharacterObject struct
@@ -128,7 +71,7 @@ public:
 
     CharacterController* controller;
 
-    AnimationGroup animations;
+    AnimGroup* animations;
 
     /**
      * @param pos

--- a/rwengine/src/objects/CharacterObject.hpp
+++ b/rwengine/src/objects/CharacterObject.hpp
@@ -5,9 +5,9 @@
 #include <BulletDynamics/Character/btKinematicCharacterController.h>
 #include <btBulletCollisionCommon.h>
 #include <array>
+#include <data/AnimGroup.hpp>
 #include <glm/glm.hpp>
 #include <objects/GameObject.hpp>
-#include <data/AnimGroup.hpp>
 
 constexpr int kMaxInventorySlots = 13;
 
@@ -61,6 +61,8 @@ private:
     bool motionBlockedByActivity;
 
     glm::vec3 updateMovementAnimation(float dt);
+
+    AnimCycle cycle_;
 
 public:
     static const float DefaultJumpSpeed;
@@ -188,6 +190,25 @@ public:
     void activityFinished();
 
     /**
+     * Play the animation from the ped's animation group
+     *
+     * Flags on the cycle in the anim group will control repeating etc.
+     */
+    void playCycle(AnimCycle cycle);
+
+    /**
+     * Play the given animation, with the flags of the given cycle
+     *
+     * This sets the same state as playCycle, but provides an alternate
+     * animation to play.
+     */
+    void playCycleAnimOverride(AnimCycle cycle, Animation* anim);
+
+    AnimCycle getCurrentCycle() const {
+        return cycle_;
+    }
+
+    /**
      * @brief addToInventory Adds ammo to the specified item slot
      * @param slot The slot to add ammo for
      * @param ammo The quanity of ammunition to add
@@ -197,7 +218,9 @@ public:
     void addToInventory(int slot, int ammo);
 
     void setActiveItem(int slot);
-    int getActiveItem() const { return currentState.currentWeapon; }
+    int getActiveItem() const {
+        return currentState.currentWeapon;
+    }
 
     /**
      * @brief removeFromInventory Removes item at slot from inventory

--- a/tests/test_character.cpp
+++ b/tests/test_character.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(test_death) {
         character->tick(0.16f);
 
         BOOST_CHECK_EQUAL(character->animator->getAnimation(0),
-                          character->animations.ko_shot_front);
+                          character->animations->ko_shot_front);
 
         Global::get().e->destroyObject(character);
         delete controller;

--- a/tests/test_character.cpp
+++ b/tests/test_character.cpp
@@ -139,8 +139,9 @@ BOOST_AUTO_TEST_CASE(test_death) {
 
         character->tick(0.16f);
 
-        BOOST_CHECK_EQUAL(character->animator->getAnimation(0),
-                          character->animations->ko_shot_front);
+        BOOST_CHECK_EQUAL(
+            character->animator->getAnimation(0),
+            character->animations->animation(AnimCycle::KnockOutShotFront0));
 
         Global::get().e->destroyObject(character);
         delete controller;

--- a/tests/test_character.cpp
+++ b/tests/test_character.cpp
@@ -147,6 +147,21 @@ BOOST_AUTO_TEST_CASE(test_death) {
         delete controller;
     }
 }
+
+BOOST_AUTO_TEST_CASE(test_cycle_animating) {
+    {
+        auto character =
+            Global::get().e->createPedestrian(1, {100.f, 100.f, 50.f});
+
+        BOOST_REQUIRE(character != nullptr);
+
+        // Set the character cycle
+        character->playCycle(AnimCycle::ArrestGun);
+
+        BOOST_CHECK_EQUAL(static_cast<uint32_t>(character->getCurrentCycle()),
+                          static_cast<uint32_t>(AnimCycle::ArrestGun));
+    }
+}
 #endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Refactor Animation Groups
- Add hard-coded data for each animation group
- Refactor CharacterController to remove usage of Animation* (mostly, still talks directly to Animator in a few places)
- Apply the correct animation group to every character

I don't like the hard-coded data in AnimGroup.cpp, any ideas on how that could be better written is appreciated.