### PR TITLE
More weapon scrollback fixes

### DIFF
--- a/rwgame/DrawUI.cpp
+++ b/rwgame/DrawUI.cpp
@@ -185,18 +185,27 @@ void drawPlayerInfo(PlayerController* player, GameWorld* world,
         const CharacterState& cs = player->getCharacter()->getCurrentState();
         const CharacterWeaponSlot& slotInfo = cs.weapons[cs.currentWeapon];
 
-        bool isProjectile = weapon->fireType == WeaponData::PROJECTILE;
-        bool isShotgun = weapon->modelID == 176;
-        bool isSniper = weapon->modelID == 177;
-        bool noClip = isProjectile || isShotgun || isSniper;
+        // In weapon.dat clip size of 0 or 1000+ indicates no reload
+        // Clip size of 1 is being visually omitted as well
+        bool noClip = weapon->clipSize < 2 || weapon->clipSize > 999;
+
+        uint32_t displayBulletsTotal = slotInfo.bulletsTotal;
 
         if (noClip) {
+            // The clip is actually there, but it holds just one shot/charge
+            displayBulletsTotal += slotInfo.bulletsClip;
+
             ti.text = GameStringUtil::fromString(
-                std::to_string(slotInfo.bulletsTotal));
+                std::to_string(displayBulletsTotal));
         } else {
+            // Limit the maximal displayed length for the total bullet count
+            if (slotInfo.bulletsTotal > 9999) {
+                displayBulletsTotal = 9999;
+            }
+
             ti.text = GameStringUtil::fromString(
-                std::to_string(slotInfo.bulletsClip) + "-" +
-                std::to_string(slotInfo.bulletsTotal));
+                std::to_string(displayBulletsTotal) + "-" +
+                std::to_string(slotInfo.bulletsClip));
         }
 
         ti.baseColour = ui_shadowColour;

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -302,7 +302,8 @@ void IngameState::handlePlayerInput(const SDL_Event& event) {
             }
             break;
         case SDL_MOUSEWHEEL:
-            if (player->getCharacter()->getCurrentVehicle() == nullptr) {
+            if (player->getCharacter()->getCurrentVehicle() == nullptr &&
+                player->getCharacter()->isAlive()) {
                 player->getCharacter()->cycleInventory(event.wheel.y > 0);
             }
             break;


### PR DESCRIPTION
Made a few more small fixes to the weapon inventory system.
The main issue that I currently see is that weapons which have clips don't get reloaded by themselves when picked up or scrolled to like in the vanilla engine. Most likely there needs to be a separate method to accomplish that which we'd call from both UseItem, onCharacterTouch and from cycleInventory.