### PR TITLE
Implement in-car perks

### DIFF
--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -237,6 +237,9 @@ bool Activities::EnterVehicle::update(CharacterObject *character,
             }
         } else if (character->getCurrentCycle() == cycle_enter) {
             if (character->animator->isCompleted(AnimIndexAction)) {
+                /// @todo move to a more suitable place
+                vehicle->grantOccupantRewards(character);
+
                 // VehicleGetIn is over, finish activity
                 return true;
             }

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -384,6 +384,10 @@ void CharacterObject::setPosition(const glm::vec3& pos) {
     getClump()->getFrame()->setTranslation(pos);
 }
 
+bool CharacterObject::isPlayer() const {
+    return true; /// @todo implement detection via playerObject
+}
+
 bool CharacterObject::isAlive() const {
     return currentState.health > 0.f;
 }

--- a/rwengine/src/objects/CharacterObject.hpp
+++ b/rwengine/src/objects/CharacterObject.hpp
@@ -113,6 +113,8 @@ public:
 
     virtual void setPosition(const glm::vec3& pos);
 
+    bool isPlayer() const;
+
     bool isAlive() const;
     bool takeDamage(const DamageInfo& damage) override;
 

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -86,6 +86,7 @@ VehicleObject::VehicleObject(GameWorld* engine, const glm::vec3& pos,
     , throttle(0.f)
     , brake(0.f)
     , handbrake(true)
+    , mHasSpecial(true)
     , info(info)
     , colourPrimary(prim)
     , colourSecondary(sec)
@@ -773,4 +774,37 @@ void VehicleObject::setSecondaryColour(uint8_t color) {
 
 bool VehicleObject::isStopped() const {
     return fabsf(physVehicle->getCurrentSpeedKmHour()) < 0.75f;
+}
+
+bool VehicleObject::collectSpecial() {
+    bool hadSpecial = mHasSpecial;
+
+    mHasSpecial = false;
+
+    return hadSpecial;
+}
+
+void VehicleObject::grantOccupantRewards(CharacterObject* character) {
+    if (character->isPlayer() && collectSpecial()) {
+        if (getVehicle()->vehiclename_ == "TAXI"
+            || getVehicle()->vehiclename_ == "CABBIE"
+            || getVehicle()->vehiclename_ == "BORGNINE") {
+            // Earn $25 from taxi cabs
+            /// @todo implement this
+        } else if (getVehicle()->vehiclename_ == "POLICAR") {
+            // Police cruisers give 5 shotgun cartridges
+            character->addToInventory(4, 5);
+        } else if (getVehicle()->vehiclename_ == "ENFORCR") {
+            // Obtain 100 armour if it's an Enforcer
+            character->getCurrentState().armour = 100.f;
+        } else if (getVehicle()->vehiclename_ == "AMBULAN") {
+            // Receive up to 20 HPs from ambulances
+            float health = character->getCurrentState().health;
+            float fullHealth = 100.f;
+            if (health < fullHealth) {
+                character->getCurrentState().health =
+                    (health >= 80.f) ? fullHealth : health + 20.f;
+            }
+        }
+    }
 }

--- a/rwengine/src/objects/VehicleObject.hpp
+++ b/rwengine/src/objects/VehicleObject.hpp
@@ -2,6 +2,7 @@
 #ifndef _VEHICLEOBJECT_HPP_
 #define _VEHICLEOBJECT_HPP_
 #include <map>
+#include <objects/CharacterObject.hpp>
 #include <objects/GameObject.hpp>
 #include <objects/VehicleInfo.hpp>
 
@@ -29,6 +30,7 @@ public:
     VehicleInfoHandle info;
     glm::u8vec3 colourPrimary;
     glm::u8vec3 colourSecondary;
+    bool mHasSpecial;
 
     std::map<size_t, GameObject*> seatOccupants;
 
@@ -150,6 +152,14 @@ public:
     * @return True if the vehicle isn't moving
     */
     bool isStopped() const;
+
+    /**
+    * @brief collectSpecial
+    * @return True if mHasSpecial was true opon calling
+    */
+    bool collectSpecial();
+
+    void grantOccupantRewards(CharacterObject* character);
 
 private:
     void registerPart(ModelFrame* mf);


### PR DESCRIPTION
This is quite primitive yet works fine.
Somehow I've kept running into one trouble after another, spending way too much time on trying to get $25 out of cabs. There seems to be no easy way to increase the amount of money from the inside of that class.

My wild guess is that this all should be happening via OpCodes, and perhaps within some other class. Every vehicle instance should also have a flag which shows that the perk has already been collected (which gets set to true if the car got spawned out of a garage).
