### PR TITLE
Prevent Rhino's front wheels from changing steering angle

### DIFF
--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -275,11 +275,12 @@ void ObjectRenderer::renderVehicle(VehicleObject* vehicle,
         auto& wi = vehicle->physVehicle->getWheelInfo(w);
         // Construct our own matrix so we can use the local transform
         vehicle->physVehicle->updateWheelTransform(w, false);
+        bool isRhino = (vehicle->getVehicle()->vehiclename_ == "RHINO");
 
         auto up = -wi.m_wheelDirectionCS;
         auto right = wi.m_wheelAxleCS;
         auto fwd = up.cross(right);
-        btQuaternion steerQ(up, wi.m_steering);
+        btQuaternion steerQ(up, (isRhino) ? 0.f : wi.m_steering);
         btQuaternion rollQ(right, -wi.m_rotation);
         btMatrix3x3 basis(right[0], fwd[0], up[0], right[1], fwd[1], up[1],
                           right[2], fwd[2], up[2]);


### PR DESCRIPTION
This is my latest masterpiece.

None of Rhino's wheels change angle in vanilla. The vehicle however is able to somehow turn.

Whatever Rhino really is, tanks make turns by making continuous tracks run in opposite directions from one another. My conspiracy theory here's that's what was supposed to happen in GTA-III to allow Rhino to be more mobile and turn on the same spot.
But in the original engine Rhino has to be in motion in order to make a turn, yet all of its wheels are parallel at all times. Go figure.

This PR prevents Rhino from turning completely, but since that thing barely moves at the moment, this could be considered an improvement because the normally concealed front wheels no longer point through the sides of the vehicle whenever player presses "left" or "right" control keys.