### PR TITLE
Replace manual conversion with glm's function

### DIFF
--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -264,7 +264,7 @@ void VehicleObject::tickPhysics(float dt) {
             if (wi.m_bIsFrontWheel) {
                 float sign = std::signbit(steerAngle) ? -1.f : 1.f;
                 physVehicle->setSteeringValue(
-                    std::min(info->handling.steeringLock * (3.141f / 180.f),
+                    std::min(glm::radians(info->handling.steeringLock),
                              std::abs(steerAngle)) *
                         sign,
                     w);
@@ -294,7 +294,7 @@ void VehicleObject::tickPhysics(float dt) {
             if (isInWater()) {
                 float sign = std::signbit(steerAngle) ? -1.f : 1.f;
                 float steer =
-                    std::min(info->handling.steeringLock * (3.141f / 180.f),
+                    std::min(glm::radians(info->handling.steeringLock),
                              std::abs(steerAngle)) *
                     sign;
                 auto orient = collision->getBulletBody()->getOrientation();


### PR DESCRIPTION
Glm allows to use angle manipulation functions. One of them is conversion degrees to radians.
It gives optimal precision and isn't strictly connected with float.
https://glm.g-truc.net/0.9.4/api/a00136.html#ga4fb76e28851c9ff6653532566084e091
// For mainteiners:
Please close https://github.com/rwengine/openrw/pull/295
New pull request prevents trash in history, and it's easier to read. Thx.