### PR TITLE
Interpolation PULL for discusion

### DIFF
--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -27,9 +27,6 @@ class RWGame : public GameBase {
     std::unique_ptr<ScriptMachine> vm;
     std::unique_ptr<SCMFile> script;
 
-    std::chrono::steady_clock clock;
-    std::chrono::steady_clock::time_point last_clock_time;
-
     bool inFocus = true;
     ViewCamera currentCam;
 
@@ -46,7 +43,6 @@ class RWGame : public GameBase {
 
     std::string cheatInputWindow = std::string(32, ' ');
 
-    float accum = 0.f;
     float timescale = 1.f;
 
 public:


### PR DESCRIPTION
I'm not sure, is it a solution similar to the previous one(which has been interpolating everything)? I've used this example: http://bulletphysics.org/mediawiki-1.5.8/index.php/Canonical_Game_Loop
To do:
- [x]     Player movement is too fast, the player is sliding around. 
- [x]     The world continues to update while in the pause and debug menus, where it should be 
paused.

- [x] Get rid of second clock

Ref:
#297