### PR TITLE
Fix bugs in Windows build

### DIFF
--- a/rwengine/src/data/CutsceneData.hpp
+++ b/rwengine/src/data/CutsceneData.hpp
@@ -35,13 +35,13 @@ struct CutsceneTracks {
     std::map<float, float> zoom;
     std::map<float, float> rotation;
     std::map<float, glm::vec3> position;
-    std::map<float, glm::vec3>
-        target;  /// Rotation is around the direction to this vector
+    std::map<float, glm::vec3> target;
+    /* Rotation is angle around the target vector */
 
     float duration{0.f};
 
     glm::vec3 getPositionAt(float time) {
-        glm::vec3 p = position.end()->second;
+        glm::vec3 p = position.rbegin()->second;
         for (auto it = position.begin(); it != position.end(); ++it) {
             if (it->first <= time) {
                 auto a = it->second;
@@ -64,7 +64,7 @@ struct CutsceneTracks {
     }
 
     glm::vec3 getTargetAt(float time) {
-        glm::vec3 p = position.end()->second;
+        glm::vec3 p = position.rbegin()->second;
         for (auto it = target.begin(); it != target.end(); ++it) {
             if (it->first <= time) {
                 auto a = it->second;
@@ -87,7 +87,7 @@ struct CutsceneTracks {
     }
 
     float getZoomAt(float time) {
-        float r = zoom.end()->second;
+        float r = zoom.rbegin()->second;
         for (auto it = zoom.begin(); it != zoom.end(); ++it) {
             if (it->first <= time) {
                 auto a = it->second;
@@ -110,7 +110,7 @@ struct CutsceneTracks {
     }
 
     float getRotationAt(float time) {
-        float r = rotation.end()->second;
+        float r = rotation.rbegin()->second;
         for (auto it = rotation.begin(); it != rotation.end(); ++it) {
             if (it->first <= time) {
                 auto a = it->second;

--- a/rwengine/src/loaders/GenericDATLoader.cpp
+++ b/rwengine/src/loaders/GenericDATLoader.cpp
@@ -50,6 +50,9 @@ void GenericDATLoader::loadDynamicObjects(const std::string& name,
             if (ss.peek() == ',') ss.ignore(1);
             ss >> dyndata->cameraAvoid;
 
+            assert(ss.eof() || ss.good());
+            RW_CHECK(ss.eof() || ss.good(), "Loading dynamicsObject data file " << name << " failed");
+
             data.insert({dyndata->modelName, dyndata});
         }
     }
@@ -115,6 +118,9 @@ void GenericDATLoader::loadWeapons(const std::string& name,
             ss >> data->modelID;
             ss >> data->flags;
 
+            assert(ss.eof() || ss.good());
+            RW_CHECK(ss.eof() || ss.good(), "Loading weapon data file " << name << " failed");
+
             data->inventorySlot = slotNum++;
 
             weaponData.push_back(data);
@@ -167,6 +173,9 @@ void GenericDATLoader::loadHandling(const std::string& name,
             ss >> info.suspensionLowerLimit;
             ss >> info.suspensionBias;
             ss >> std::hex >> info.flags;
+
+            assert(ss.eof() || ss.good());
+            RW_CHECK(ss.eof() || ss.good(), "Loading handling data file " << name << " failed");
 
             auto mit = vehicleData.find(info.ID);
             if (mit == vehicleData.end()) {

--- a/rwengine/src/loaders/GenericDATLoader.cpp
+++ b/rwengine/src/loaders/GenericDATLoader.cpp
@@ -17,6 +17,7 @@ void GenericDATLoader::loadDynamicObjects(const std::string& name,
 
         while (std::getline(dfile, lineBuff)) {
             if (lineBuff.at(0) == ';') continue;
+            if (lineBuff.at(0) == '*') continue;
             std::stringstream ss(lineBuff);
 
             DynamicObjectDataPtr dyndata(new DynamicObjectData);

--- a/rwengine/src/loaders/LoaderCutsceneDAT.cpp
+++ b/rwengine/src/loaders/LoaderCutsceneDAT.cpp
@@ -1,6 +1,9 @@
-#include <algorithm>
 #include <loaders/LoaderCutsceneDAT.hpp>
+
+#include <algorithm>
 #include <sstream>
+
+#include <rw/defines.hpp>
 
 void LoaderCutsceneDAT::load(CutsceneTracks &tracks, FileHandle file) {
     std::string dataStr(file->data, file->length);
@@ -79,4 +82,7 @@ void LoaderCutsceneDAT::load(CutsceneTracks &tracks, FileHandle file) {
         tracks.target[t] = p;
         tracks.duration = std::max(t, tracks.duration);
     }
+
+    assert(ss.eof() || ss.good());
+    RW_CHECK(ss.eof() || ss.good(), "Loading CutsceneDAT file failed");
 }

--- a/rwengine/src/loaders/LoaderCutsceneDAT.cpp
+++ b/rwengine/src/loaders/LoaderCutsceneDAT.cpp
@@ -14,7 +14,7 @@ void LoaderCutsceneDAT::load(CutsceneTracks &tracks, FileHandle file) {
         float t = 0.f;
         float z = 0.f;
         ss >> t;
-        ss.ignore(1, ',');
+        ss.ignore(2, ',');
         ss >> z;
         ss.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         tracks.zoom[t] = z;
@@ -31,7 +31,7 @@ void LoaderCutsceneDAT::load(CutsceneTracks &tracks, FileHandle file) {
         float t = 0.f;
         float r = 0.f;
         ss >> t;
-        ss.ignore(1, ',');
+        ss.ignore(2, ',');
         ss >> r;
         ss.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         tracks.rotation[t] = r;
@@ -48,7 +48,7 @@ void LoaderCutsceneDAT::load(CutsceneTracks &tracks, FileHandle file) {
         float t = 0.f;
         glm::vec3 p;
         ss >> t;
-        ss.ignore(1, ',');
+        ss.ignore(2, ',');
         ss >> p.x;
         ss.ignore(1, ',');
         ss >> p.y;
@@ -69,7 +69,7 @@ void LoaderCutsceneDAT::load(CutsceneTracks &tracks, FileHandle file) {
         float t = 0.f;
         glm::vec3 p;
         ss >> t;
-        ss.ignore(1, ',');
+        ss.ignore(2, ',');
         ss >> p.x;
         ss.ignore(1, ',');
         ss >> p.y;

--- a/rwengine/src/script/modules/GTA3ModuleImpl.inl
+++ b/rwengine/src/script/modules/GTA3ModuleImpl.inl
@@ -855,6 +855,8 @@ void opcode_004f(const ScriptArguments& args, const ScriptLabel arg1) {
 	/// @todo prevent overflow
 	/// @todo don't do pointer casting
 	for (auto i = 1u; i < args.getParameters().size(); ++i) {
+		if (args[i].type == EndOfArgList)
+			break;
 		*reinterpret_cast<ScriptInt*>(thread.locals.data() +
 		                        sizeof(ScriptInt) * (i - 1)) =
 		    args[i].integerValue();


### PR DESCRIPTION
rwengine/openrw#286 only enables building OpenRW on Windows. The generated binary does not work.
This PR fixes some blatant bugs that will solve this problem.

The Windows performance is not good, but this allows implementing Windows integration like rwengine/openrw#276