### PR TITLE
Add option to abort/break on failed checks or at request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ option(ENABLE_SCRIPT_DEBUG "Enable verbose script execution")
 option(ENABLE_PROFILING "Enable detailed profiling metrics")
 option(TESTS_NODATA "Build tests for no-data testing")
 
+set(FAILED_CHECK_ACTION "IGNORE" CACHE STRING "What action to perform on a failed RW_CHECK (IGNORE, ABORT or BREAKPOINT) (only in debug mode)")
+
 #
 # Build configuration
 #
@@ -65,6 +67,16 @@ ENDIF()
 IF(${ENABLE_SCRIPT_DEBUG})
 	add_definitions(-DRW_SCRIPT_DEBUG)
 ENDIF()
+
+if(FAILED_CHECK_ACTION STREQUAL "IGNORE")
+    add_definitions(-DRW_FAILED_CHECK_ACTION=0)
+elseif(FAILED_CHECK_ACTION STREQUAL "ABORT")
+    add_definitions(-DRW_FAILED_CHECK_ACTION=1)
+elseif(FAILED_CHECK_ACTION STREQUAL "BREAKPOINT")
+    add_definitions(-DRW_FAILED_CHECK_ACTION=2)
+else()
+    message(FATAL_ERROR "Illegal FAILED_CHECK_ACTION option.")
+endif()
 
 if(${RW_VERBOSE_DEBUG_MESSAGES})
 	add_definitions(-DRW_VERBOSE_DEBUG_MESSAGES=1)

--- a/rwengine/src/TextureArchive.cpp
+++ b/rwengine/src/TextureArchive.cpp
@@ -1,8 +1,9 @@
 #include <TextureArchive.hpp>
 
-#include <cassert>
 #include <cstring>
 #include <iostream>
+
+#include "rw/defines.hpp"
 
 namespace RW {
 
@@ -12,7 +13,7 @@ std::unique_ptr<TextureArchive> TextureArchive::create(
 
     auto section = binaryStream.rootHeader;
 
-    assert(section->ID == BinaryStream::TEXTURE_DICTIONARY &&
+    RW_ASSERT(section->ID == BinaryStream::TEXTURE_DICTIONARY &&
            "BinaryStream passed to this function must be a TEXTURE DICTIONARY");
 
     // Struct

--- a/rwengine/src/engine/SaveGame.cpp
+++ b/rwengine/src/engine/SaveGame.cpp
@@ -535,7 +535,7 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
 
     BlockDword scriptVarCount;
     READ_SIZE(scriptVarCount)
-    assert(scriptVarCount == state.script->getFile()->getGlobalsSize());
+    RW_ASSERT(scriptVarCount == state.script->getFile()->getGlobalsSize());
 
     if (fread(state.script->getGlobals(), sizeof(SCMByte), scriptVarCount,
               loadFile) != scriptVarCount) {

--- a/rwengine/src/loaders/GenericDATLoader.cpp
+++ b/rwengine/src/loaders/GenericDATLoader.cpp
@@ -50,7 +50,6 @@ void GenericDATLoader::loadDynamicObjects(const std::string& name,
             if (ss.peek() == ',') ss.ignore(1);
             ss >> dyndata->cameraAvoid;
 
-            assert(ss.eof() || ss.good());
             RW_CHECK(ss.eof() || ss.good(), "Loading dynamicsObject data file " << name << " failed");
 
             data.insert({dyndata->modelName, dyndata});
@@ -118,7 +117,6 @@ void GenericDATLoader::loadWeapons(const std::string& name,
             ss >> data->modelID;
             ss >> data->flags;
 
-            assert(ss.eof() || ss.good());
             RW_CHECK(ss.eof() || ss.good(), "Loading weapon data file " << name << " failed");
 
             data->inventorySlot = slotNum++;
@@ -174,7 +172,6 @@ void GenericDATLoader::loadHandling(const std::string& name,
             ss >> info.suspensionBias;
             ss >> std::hex >> info.flags;
 
-            assert(ss.eof() || ss.good());
             RW_CHECK(ss.eof() || ss.good(), "Loading handling data file " << name << " failed");
 
             auto mit = vehicleData.find(info.ID);

--- a/rwengine/src/loaders/LoaderCutsceneDAT.cpp
+++ b/rwengine/src/loaders/LoaderCutsceneDAT.cpp
@@ -83,6 +83,5 @@ void LoaderCutsceneDAT::load(CutsceneTracks &tracks, FileHandle file) {
         tracks.duration = std::max(t, tracks.duration);
     }
 
-    assert(ss.eof() || ss.good());
     RW_CHECK(ss.eof() || ss.good(), "Loading CutsceneDAT file failed");
 }

--- a/rwengine/src/render/OpenGLRenderer.cpp
+++ b/rwengine/src/render/OpenGLRenderer.cpp
@@ -411,7 +411,7 @@ void OpenGLRenderer::pushDebugGroup(const std::string& title) {
         glGetQueryObjectui64v(debugQuery, GL_QUERY_RESULT, &prof.timerStart);
 
         currentDebugDepth++;
-        assert(currentDebugDepth < MAX_DEBUG_DEPTH);
+        RW_ASSERT(currentDebugDepth < MAX_DEBUG_DEPTH);
     }
 #else
     RW_UNUSED(title);
@@ -423,7 +423,7 @@ const Renderer::ProfileInfo& OpenGLRenderer::popDebugGroup() {
     if (ogl_ext_KHR_debug) {
         glPopDebugGroup();
         currentDebugDepth--;
-        assert(currentDebugDepth >= 0);
+        RW_ASSERT(currentDebugDepth >= 0);
 
         ProfileInfo& prof = profileInfo[currentDebugDepth];
 

--- a/rwgame/GameBase.cpp
+++ b/rwgame/GameBase.cpp
@@ -64,6 +64,9 @@ GameBase::GameBase(Logger &inlog, int argc, char *argv[]) : log(inlog) {
         throw std::runtime_error("Failed to initialize SDL2!");
 
     window.create(kWindowTitle + " [" + kBuildStr + "]", w, h, fullscreen);
+
+    SET_RW_ABORT_CB([this]() {window.showCursor();},
+            [this]() {window.hideCursor();});
 }
 
 GameBase::~GameBase() {

--- a/rwlib/CMakeLists.txt
+++ b/rwlib/CMakeLists.txt
@@ -16,6 +16,7 @@ SET(RWLIB_SOURCES
 	"source/gl/TextureData.hpp"
 	"source/gl/TextureData.cpp"
 
+	"source/rw/abort.cpp"
 	"source/rw/types.hpp"
 	"source/rw/defines.hpp"
 

--- a/rwlib/source/loaders/RWBinaryStream.hpp
+++ b/rwlib/source/loaders/RWBinaryStream.hpp
@@ -3,8 +3,9 @@
 #include <cstdint>
 #include <glm/glm.hpp>
 
-#include <cassert>
 #include <cstddef>
+
+#include "rw/defines.hpp"
 
 /**
  * @brief Class for working with RenderWare binary streams.
@@ -339,7 +340,7 @@ public:
 
     BinaryStreamSection getNextChildSection(size_t& internalOffset) {
         size_t realOffset = internalOffset;
-        assert(realOffset < header.size);
+        RW_ASSERT(realOffset < header.size);
         BinaryStreamSection sec(data,
                                 offset + sizeof(BSSectionHeader) + realOffset);
         internalOffset += sec.header.size + sizeof(BSSectionHeader);

--- a/rwlib/source/rw/abort.cpp
+++ b/rwlib/source/rw/abort.cpp
@@ -1,0 +1,5 @@
+#include "rw/defines.hpp"
+
+#if RW_DEBUG
+std::function<void()> _rw_abort_cb[2] = {nullptr, nullptr};
+#endif

--- a/rwlib/source/rw/defines.hpp
+++ b/rwlib/source/rw/defines.hpp
@@ -1,17 +1,59 @@
 #ifndef _LIBRW_DEFINES_HPP_
 #define _LIBRW_DEFINES_HPP_
 
+#if RW_DEBUG
+#include <cstdlib>
+#include <functional>
+
+extern std::function<void()> _rw_abort_cb[2];
+#define SET_RW_ABORT_CB(cb0, cb1) do { _rw_abort_cb[0] = cb0; _rw_abort_cb[1] = cb1;} while (0)
+
+#define RW_ABORT() do { if(_rw_abort_cb[0]) _rw_abort_cb[0](); ::abort(); } while (0)
+#define RW_ASSERT(cond) do { if (!(cond)) RW_ABORT();} while (0)
+
+#if defined(RW_WINDOWS)
+#include <Windows.h>
+#define RW_BREAKPOINT() DebugBreak()
+#else
+#include <csignal>
+#define RW_BREAKPOINT() do { if(_rw_abort_cb[0]) _rw_abort_cb[0](); ::raise(SIGTRAP); if(_rw_abort_cb[1]) _rw_abort_cb[1](); } while (0)
+#endif
+
+#define RW_FAILED_NO_ACTION         0
+#define RW_FAILED_ABORT_OPTION      1
+#define RW_FAILED_BREAKPOINT_OPTION 2
+
+#if RW_FAILED_CHECK_ACTION == RW_FAILED_NO_ACTION
+#define _RW_FAILED_CHECK_ACTION()
+#elif RW_FAILED_CHECK_ACTION == RW_FAILED_ABORT_OPTION
+#define _RW_FAILED_CHECK_ACTION() RW_ABORT()
+#elif RW_FAILED_CHECK_ACTION == RW_FAILED_BREAKPOINT_OPTION
+#define _RW_FAILED_CHECK_ACTION() RW_BREAKPOINT()
+#endif
+
+#else
+#define SET_RW_ABORT_CB(cb0, cb1)
+#define RW_ABORT()
+#define RW_ASSERT(cond)
+#define RW_BREAKPOINT()
+#define _RW_FAILED_CHECK_ACTION()
+#endif
+
 #if RW_DEBUG && RW_VERBOSE_DEBUG_MESSAGES
 #include <iostream>
 #define RW_MESSAGE(msg) \
     std::cout << __FILE__ << ":" << __LINE__ << ": " << msg << std::endl
 #define RW_ERROR(msg) \
     std::cerr << __FILE__ << ":" << __LINE__ << ": " << msg << std::endl
-#define RW_CHECK(cond, msg) \
-    if (!(cond)) RW_ERROR(msg)
 #else
 #define RW_MESSAGE(msg)
 #define RW_ERROR(msg)
+#endif
+
+#if RW_DEBUG
+#define RW_CHECK(cond, msg) \
+    do { if (!(cond)) { RW_ERROR(msg); _RW_FAILED_CHECK_ACTION();}} while (0)
+#else
 #define RW_CHECK(cond, msg)
 #endif
 


### PR DESCRIPTION
This PR adds the following feature in Debug build mode:
- `RW_ABORT` to abort the current process and jump to the debugger. Process is not resumeable.
- `RW_ASSERT` to check an assertion. Jump to the debugger if check failed. Process is not resumeable if the check failed.
- `RW_BREAKPOINT` to break the current process and jump to the debugger. The process is resumeable

- Add a CMake option to choose what to do when a check fails..
- Add a callback to `RW_ABORT` and `RW_BREAKPOINT` to ungrab the mouse. The mouse is grabbed again in RW_BREAKPOINT when continuing..

- Change all occurrences of assert to RW_ASSERT to make use of the callbacks.

This should make it easier for people to debug OpenRW in IDEs.