### PR TITLE
Plug some memory holes

### DIFF
--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -29,9 +29,8 @@ bool CharacterController::updateActivity() {
     return false;
 }
 
-void CharacterController::setActivity(CharacterController::Activity *activity) {
-    if (_currentActivity) delete _currentActivity;
-    _currentActivity = activity;
+void CharacterController::setActivity(std::unique_ptr<Activity> activity) {
+    _currentActivity.swap(activity);
 }
 
 void CharacterController::skipActivity() {
@@ -43,14 +42,12 @@ void CharacterController::skipActivity() {
         setActivity(nullptr);
 }
 
-void CharacterController::setNextActivity(
-    CharacterController::Activity *activity) {
+void CharacterController::setNextActivity(std::unique_ptr<Activity> activity) {
     if (_currentActivity == nullptr) {
-        setActivity(activity);
+        setActivity(std::move(activity));
         _nextActivity = nullptr;
     } else {
-        if (_nextActivity) delete _nextActivity;
-        _nextActivity = activity;
+        _nextActivity.swap(activity);
     }
 }
 
@@ -97,13 +94,9 @@ void CharacterController::update(float dt) {
 
     if (updateActivity()) {
         character->activityFinished();
-        if (_currentActivity) {
-            delete _currentActivity;
-            _currentActivity = nullptr;
-        }
+        _currentActivity = nullptr;
         if (_nextActivity) {
-            setActivity(_nextActivity);
-            _nextActivity = nullptr;
+            setActivity(std::move(_nextActivity));
         }
     }
 }
@@ -282,7 +275,7 @@ bool Activities::EnterVehicle::update(CharacterObject *character,
             // out.
             character->playCycle(cycle_pullout);
             currentOccupant->controller->setNextActivity(
-                new Activities::ExitVehicle(true));
+                std::make_unique<Activities::ExitVehicle>(true));
         } else {
             character->playCycle(cycle_enter);
             character->enterVehicle(vehicle, seat);

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -30,7 +30,7 @@ bool CharacterController::updateActivity() {
 }
 
 void CharacterController::setActivity(std::unique_ptr<Activity> activity) {
-    _currentActivity.swap(activity);
+    _currentActivity = std::move(activity);
 }
 
 void CharacterController::skipActivity() {

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -11,15 +11,14 @@
 
 constexpr float kCloseDoorIdleTime = 2.f;
 
-CharacterController::CharacterController(CharacterObject *character)
-    : character(character)
+CharacterController::CharacterController()
+    : character(nullptr)
     , _currentActivity(nullptr)
     , _nextActivity(nullptr)
     , m_closeDoorTimer(0.f)
     , currentGoal(None)
     , leader(nullptr)
     , targetNode(nullptr) {
-    character->controller = this;
 }
 
 bool CharacterController::updateActivity() {

--- a/rwengine/src/ai/CharacterController.hpp
+++ b/rwengine/src/ai/CharacterController.hpp
@@ -75,7 +75,7 @@ protected:
     AIGraphNode* targetNode;
 
 public:
-    CharacterController(CharacterObject* character);
+    CharacterController();
 
     virtual ~CharacterController() {
     }
@@ -139,6 +139,8 @@ public:
     CharacterObject* getTargetCharacter() const {
         return leader;
     }
+
+    friend class CharacterObject;
 };
 
 #define DECL_ACTIVITY(activity_name)                     \

--- a/rwengine/src/ai/CharacterController.hpp
+++ b/rwengine/src/ai/CharacterController.hpp
@@ -3,6 +3,8 @@
 #define _CHARACTERCONTROLLER_HPP_
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
+
+#include <memory>
 #include <string>
 
 struct AIGraphNode;
@@ -61,11 +63,11 @@ protected:
      */
     CharacterObject* character;
 
-    Activity* _currentActivity;
-    Activity* _nextActivity;
+    std::unique_ptr<Activity> _currentActivity;
+    std::unique_ptr<Activity> _nextActivity;
 
     bool updateActivity();
-    void setActivity(Activity* activity);
+    void setActivity(std::unique_ptr<Activity> activity);
 
     float m_closeDoorTimer;
 
@@ -80,12 +82,22 @@ public:
     virtual ~CharacterController() {
     }
 
+    /**
+     * Get the current Activity.
+     * Callers may not store the returned pointer.
+     * @return Activity pointer.
+     */
     Activity* getCurrentActivity() const {
-        return _currentActivity;
+        return _currentActivity.get();
     }
 
+    /**
+     * Get the next Activity
+     * Callers may not store the returned pointer.
+     * @return Activity pointer.
+     */
     Activity* getNextActivity() const {
-        return _nextActivity;
+        return _nextActivity.get();
     }
 
     /**
@@ -98,7 +110,7 @@ public:
      * @param activity
      * @param position
      */
-    void setNextActivity(Activity* activity);
+    void setNextActivity(std::unique_ptr<Activity> activity);
 
     /**
      * @brief IsCurrentActivity

--- a/rwengine/src/ai/DefaultAIController.cpp
+++ b/rwengine/src/ai/DefaultAIController.cpp
@@ -25,12 +25,12 @@ void DefaultAIController::update(float dt) {
                 if (leader->getCurrentVehicle() !=
                     getCharacter()->getCurrentVehicle()) {
                     skipActivity();
-                    setNextActivity(new Activities::ExitVehicle);
+                    setNextActivity(std::make_unique<Activities::ExitVehicle>());
                 }
                 // else we're already in the right spot.
             } else {
                 if (leader->getCurrentVehicle()) {
-                    setNextActivity(new Activities::EnterVehicle(
+                    setNextActivity(std::make_unique<Activities::EnterVehicle>(
                         leader->getCurrentVehicle(), 1));
                 } else {
                     glm::vec3 dir =
@@ -42,7 +42,7 @@ void DefaultAIController::update(float dt) {
                                 leader->getPosition() +
                                 (glm::normalize(-dir) * followRadius * 0.7f);
                             skipActivity();
-                            setNextActivity(new Activities::GoTo(gotoPos));
+                            setNextActivity(std::make_unique<Activities::GoTo>(gotoPos));
                         }
                     }
                 }
@@ -60,9 +60,11 @@ void DefaultAIController::update(float dt) {
                     std::uniform_int_distribution<> d(
                         0, lastTarget->connections.size() - 1);
                     targetNode = lastTarget->connections.at(d(re));
-                    setNextActivity(new Activities::GoTo(targetNode->position));
+                    setNextActivity(std::make_unique<Activities::GoTo>(
+                        targetNode->position));
                 } else if (getCurrentActivity() == nullptr) {
-                    setNextActivity(new Activities::GoTo(targetNode->position));
+                    setNextActivity(std::make_unique<Activities::GoTo>(
+                        targetNode->position));
                 }
             } else {
                 // We need to pick an initial node

--- a/rwengine/src/ai/DefaultAIController.hpp
+++ b/rwengine/src/ai/DefaultAIController.hpp
@@ -9,8 +9,8 @@ class DefaultAIController : public CharacterController {
     glm::vec3 gotoPos;
 
 public:
-    DefaultAIController(CharacterObject* character)
-        : CharacterController(character) {
+    DefaultAIController()
+        : CharacterController() {
     }
 
     glm::vec3 getTargetPosition();

--- a/rwengine/src/ai/PlayerController.cpp
+++ b/rwengine/src/ai/PlayerController.cpp
@@ -5,8 +5,8 @@
 #include <objects/CharacterObject.hpp>
 #include <objects/VehicleObject.hpp>
 
-PlayerController::PlayerController(CharacterObject* character)
-    : CharacterController(character)
+PlayerController::PlayerController()
+    : CharacterController()
     , lastRotation(glm::vec3(0.f, 0.f, 0.f))
     , _enabled(true) {
 }

--- a/rwengine/src/ai/PlayerController.cpp
+++ b/rwengine/src/ai/PlayerController.cpp
@@ -33,7 +33,7 @@ void PlayerController::updateMovementDirection(const glm::vec3& dir,
 
 void PlayerController::exitVehicle() {
     if (character->getCurrentVehicle()) {
-        setNextActivity(new Activities::ExitVehicle());
+        setNextActivity(std::make_unique<Activities::ExitVehicle>());
     }
 }
 
@@ -54,7 +54,7 @@ void PlayerController::enterNearestVehicle() {
         }
 
         if (nearest) {
-            setNextActivity(new Activities::EnterVehicle(nearest, 0));
+            setNextActivity(std::make_unique<Activities::EnterVehicle>(nearest, 0));
         }
     }
 }
@@ -69,6 +69,6 @@ glm::vec3 PlayerController::getTargetPosition() {
 
 void PlayerController::jump() {
     if (!character->isInWater()) {
-        setNextActivity(new Activities::Jump());
+        setNextActivity(std::make_unique<Activities::Jump>());
     }
 }

--- a/rwengine/src/ai/PlayerController.hpp
+++ b/rwengine/src/ai/PlayerController.hpp
@@ -13,7 +13,7 @@ class PlayerController : public CharacterController {
     bool _enabled;
 
 public:
-    PlayerController(CharacterObject* character);
+    PlayerController();
 
     /**
      * @brief Enables and disables player input.

--- a/rwengine/src/data/AnimGroup.hpp
+++ b/rwengine/src/data/AnimGroup.hpp
@@ -2,7 +2,9 @@
 #define RWENGINE_DATA_ANIMGROUP_HPP
 #include <memory>
 #include <unordered_map>
-#include "rw/types.hpp"
+
+#include <rw/forward.hpp>
+#include <rw/types.hpp>
 
 struct Animation;
 
@@ -195,7 +197,7 @@ struct AnimCycleInfo {
     /// Flags
     uint32_t flags;
     /// The actual animation
-    Animation* anim = nullptr;
+    AnimationPtr anim = nullptr;
 
     AnimCycleInfo(const std::string& name = "", uint32_t flags = 0)
         : name(name), flags(flags) {
@@ -208,7 +210,7 @@ struct AnimGroup {
     /* Animations */
     AnimCycleInfo animations_[static_cast<uint32_t>(AnimCycle::_CycleCount)];
 
-    Animation* animation(AnimCycle cycle) const {
+    AnimationPtr animation(AnimCycle cycle) const {
         return animations_[static_cast<uint32_t>(cycle)].anim;
     }
 

--- a/rwengine/src/data/ModelData.hpp
+++ b/rwengine/src/data/ModelData.hpp
@@ -135,14 +135,14 @@ public:
     }
 
     /// @todo change with librw
-    void setAtomic(Clump* model, int n, AtomicPtr atomic) {
+    void setAtomic(ClumpPtr model, int n, AtomicPtr atomic) {
         model_ = model;
         /// @todo disassociated the Atomic from Clump
         atomics_[n] = atomic;
     }
 
     /// @todo remove this
-    Clump* getModel() const {
+    ClumpPtr getModel() const {
         return model_;
     }
 
@@ -178,11 +178,10 @@ public:
     }
 
     bool isLoaded() const override {
-        return model_ != nullptr;
+        return model_.get() != nullptr;
     }
 
     void unload() override {
-        delete model_;
         model_ = nullptr;
     }
 
@@ -249,7 +248,7 @@ public:
     }
 
 private:
-    Clump* model_ = nullptr;
+    ClumpPtr model_;
     std::array<AtomicPtr, 3> atomics_;
     float loddistances_[3] = {};
     uint8_t numatomics_ = 0;
@@ -280,25 +279,24 @@ public:
     ClumpModelInfo(ModelDataType type) : BaseModelInfo(type) {
     }
 
-    void setModel(Clump* model) {
+    void setModel(ClumpPtr model) {
         model_ = model;
     }
 
-    Clump* getModel() const {
+    ClumpPtr getModel() const {
         return model_;
     }
 
     bool isLoaded() const override {
-        return model_ != nullptr;
+        return model_.get() != nullptr;
     }
 
     void unload() override {
-        delete model_;
         model_ = nullptr;
     }
 
 private:
-    Clump* model_ = nullptr;
+    ClumpPtr model_ = nullptr;
 };
 
 /**

--- a/rwengine/src/engine/Animator.cpp
+++ b/rwengine/src/engine/Animator.cpp
@@ -4,7 +4,7 @@
 #include <loaders/LoaderDFF.hpp>
 #include <queue>
 
-Animator::Animator(Clump* model) : model(model) {
+Animator::Animator(ClumpPtr model) : model(model) {
 }
 
 void Animator::tick(float dt) {

--- a/rwengine/src/engine/Animator.hpp
+++ b/rwengine/src/engine/Animator.hpp
@@ -8,7 +8,7 @@
 #include <map>
 #include <rw/defines.hpp>
 
-class Clump;
+#include <rw/forward.hpp>
 class ModelFrame;
 
 /**
@@ -40,7 +40,7 @@ class Animator {
     /**
      * @brief model The model being animated.
      */
-    Clump* model;
+    ClumpPtr model;
 
     /**
      * @brief Currently playing animations
@@ -48,7 +48,7 @@ class Animator {
     std::vector<AnimationState> animations;
 
 public:
-    Animator(Clump* model);
+    Animator(ClumpPtr model);
 
     Animation* getAnimation(unsigned int slot) {
         if (slot < animations.size()) {

--- a/rwengine/src/engine/Animator.hpp
+++ b/rwengine/src/engine/Animator.hpp
@@ -27,7 +27,7 @@ class Animator {
      * animations
      */
     struct AnimationState {
-        Animation* animation;
+        AnimationPtr animation;
         /// Timestamp of the last frame
         float time;
         /// Speed multiplier
@@ -50,14 +50,14 @@ class Animator {
 public:
     Animator(ClumpPtr model);
 
-    Animation* getAnimation(unsigned int slot) {
+    AnimationPtr getAnimation(unsigned int slot) {
         if (slot < animations.size()) {
             return animations[slot].animation;
         }
         return nullptr;
     }
 
-    void playAnimation(unsigned int slot, Animation* anim, float speed,
+    void playAnimation(unsigned int slot, AnimationPtr anim, float speed,
                        bool repeat) {
         if (slot >= animations.size()) {
             animations.resize(slot + 1);

--- a/rwengine/src/engine/Animator.hpp
+++ b/rwengine/src/engine/Animator.hpp
@@ -34,7 +34,7 @@ class Animator {
         float speed;
         /// Automatically restart
         bool repeat;
-        std::map<AnimationBone*, ModelFrame*> boneInstances;
+        std::map<std::shared_ptr<AnimationBone>, ModelFrame*> boneInstances;
     };
 
     /**

--- a/rwengine/src/engine/Animator.hpp
+++ b/rwengine/src/engine/Animator.hpp
@@ -34,7 +34,7 @@ class Animator {
         float speed;
         /// Automatically restart
         bool repeat;
-        std::map<std::shared_ptr<AnimationBone>, ModelFrame*> boneInstances;
+        std::map<AnimationBone*, ModelFrame*> boneInstances;
     };
 
     /**

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -385,7 +385,7 @@ void GameData::getNameAndLod(std::string& name, int& lod) {
     }
 }
 
-Clump* GameData::loadClump(const std::string& name) {
+ClumpPtr GameData::loadClump(const std::string& name) {
     auto file = index.openFile(name);
     if (!file) {
         logger->error("Data", "Failed to load model " + name);

--- a/rwengine/src/engine/GameData.hpp
+++ b/rwengine/src/engine/GameData.hpp
@@ -133,7 +133,7 @@ public:
     /**
      * Loads an archived model and returns it directly
      */
-    Clump* loadClump(const std::string& name);
+    ClumpPtr loadClump(const std::string& name);
 
     /**
      * Loads a DFF and associates its atomics with models.

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -331,9 +331,9 @@ CharacterObject* GameWorld::createPedestrian(const uint16_t id,
         data->loadModel(id);
     }
 
-    auto ped = new CharacterObject(this, pos, rot, pt);
+    auto controller = new DefaultAIController();
+    auto ped = new CharacterObject(this, pos, rot, pt, controller);
     ped->setGameObjectID(gid);
-    new DefaultAIController(ped);
     pedestrianPool.insert(ped);
     allObjects.push_back(ped);
     return ped;
@@ -358,10 +358,11 @@ CharacterObject* GameWorld::createPlayer(const glm::vec3& pos,
         pt->setModel(model);
     }
 
-    auto ped = new CharacterObject(this, pos, rot, pt);
+    auto controller = new PlayerController();
+    auto ped = new CharacterObject(this, pos, rot, pt, controller);
     ped->setGameObjectID(gid);
     ped->setLifetime(GameObject::PlayerLifetime);
-    players.push_back(new PlayerController(ped));
+    players.push_back(controller);
     pedestrianPool.insert(ped);
     allObjects.push_back(ped);
     return ped;

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -98,8 +98,9 @@ GameWorld::GameWorld(Logger* log, GameData* dat)
         collisionConfig.get());
 
     dynamicsWorld->setGravity(btVector3(0.f, 0.f, -9.81f));
+    _overlappingPairCallback = std::make_unique<btGhostPairCallback>();
     broadphase->getOverlappingPairCache()->setInternalGhostPairCallback(
-        new btGhostPairCallback());
+        _overlappingPairCallback.get());
     gContactProcessedCallback = ContactProcessedCallback;
     dynamicsWorld->setInternalTickCallback(PhysicsTickCallback, this);
 }

--- a/rwengine/src/engine/GameWorld.hpp
+++ b/rwengine/src/engine/GameWorld.hpp
@@ -30,7 +30,6 @@ struct WeaponScan;
 struct VehicleGenerator;
 
 #include <data/Chase.hpp>
-
 #include <glm/glm.hpp>
 
 #include <btBulletCollisionCommon.h>
@@ -343,6 +342,11 @@ private:
      * Flag for pausing the simulation
      */
     bool paused;
+
+    /**
+     * Private data
+     */
+     std::unique_ptr<btOverlappingPairCallback> _overlappingPairCallback;
 };
 
 #endif

--- a/rwengine/src/loaders/LoaderIFP.cpp
+++ b/rwengine/src/loaders/LoaderIFP.cpp
@@ -66,7 +66,7 @@ bool LoaderIFP::loadFromMemory(char* data) {
         /*NAME* n =*/read<NAME>(data, dataI);
         std::string animname = readString(data, dataI);
 
-        Animation* animation = new Animation;
+        auto animation = std::make_shared<Animation>();
         animation->duration = 0.f;
         animation->name = animname;
 

--- a/rwengine/src/loaders/LoaderIFP.cpp
+++ b/rwengine/src/loaders/LoaderIFP.cpp
@@ -79,7 +79,7 @@ bool LoaderIFP::loadFromMemory(char* data) {
             CPAN* cpan = read<CPAN>(data, dataI);
             ANIM* frames = read<ANIM>(data, dataI);
 
-            AnimationBone* bonedata = new AnimationBone;
+            auto bonedata = std::make_shared<AnimationBone>();
             bonedata->name = frames->name;
             bonedata->frames.reserve(frames->frames);
 

--- a/rwengine/src/loaders/LoaderIFP.cpp
+++ b/rwengine/src/loaders/LoaderIFP.cpp
@@ -79,7 +79,7 @@ bool LoaderIFP::loadFromMemory(char* data) {
             CPAN* cpan = read<CPAN>(data, dataI);
             ANIM* frames = read<ANIM>(data, dataI);
 
-            auto bonedata = std::make_shared<AnimationBone>();
+            auto bonedata = new AnimationBone;
             bonedata->name = frames->name;
             bonedata->frames.reserve(frames->frames);
 

--- a/rwengine/src/loaders/LoaderIFP.hpp
+++ b/rwengine/src/loaders/LoaderIFP.hpp
@@ -40,7 +40,13 @@ struct AnimationBone {
  */
 struct Animation {
     std::string name;
-    std::map<std::string, std::shared_ptr<AnimationBone>> bones;
+    std::map<std::string, AnimationBone*> bones;
+
+    ~Animation() {
+        for (auto &bone_pair : bones) {
+            delete bone_pair.second;
+        }
+    }
 
     float duration;
 };

--- a/rwengine/src/loaders/LoaderIFP.hpp
+++ b/rwengine/src/loaders/LoaderIFP.hpp
@@ -8,6 +8,8 @@
 #include <string>
 #include <vector>
 
+#include "rw/forward.hpp"
+
 struct AnimationKeyframe {
     glm::quat rotation;
     glm::vec3 position;
@@ -105,7 +107,7 @@ public:
         std::string name;
     };
 
-    std::map<std::string, Animation*> animations;
+    AnimationSet animations;
 
     bool loadFromMemory(char* data);
 };

--- a/rwengine/src/loaders/LoaderIFP.hpp
+++ b/rwengine/src/loaders/LoaderIFP.hpp
@@ -40,7 +40,7 @@ struct AnimationBone {
  */
 struct Animation {
     std::string name;
-    std::map<std::string, AnimationBone*> bones;
+    std::map<std::string, std::shared_ptr<AnimationBone>> bones;
 
     float duration;
 };

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -199,7 +199,7 @@ glm::vec3 CharacterObject::updateMovementAnimation(float dt) {
         const auto& root = modelroot->getChildren()[0];
         auto it = movementAnimation->bones.find(root->getName());
         if (it != movementAnimation->bones.end()) {
-            AnimationBone* rootBone = it->second;
+            auto rootBone = it->second;
             float step = dt;
             const float duration =
                 animator->getAnimation(AnimIndexMovement)->duration;

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -123,8 +123,8 @@ glm::vec3 CharacterObject::updateMovementAnimation(float dt) {
         return glm::vec3();
     }
 
-    Animation* movementAnimation = animations->animation(AnimCycle::Idle);
-    Animation* currentAnim = animator->getAnimation(AnimIndexMovement);
+    AnimationPtr movementAnimation = animations->animation(AnimCycle::Idle);
+    AnimationPtr currentAnim = animator->getAnimation(AnimIndexMovement);
     bool isActionHappening =
         (animator->getAnimation(AnimIndexAction) != nullptr);
     float animationSpeed = 1.f;
@@ -174,7 +174,7 @@ glm::vec3 CharacterObject::updateMovementAnimation(float dt) {
                     movementAnimation = animations->animation(AnimCycle::Walk);
                 }
             } else {
-                // Keep walkin
+                // Keep walking
                 movementAnimation = animations->animation(AnimCycle::Walk);
             }
         }
@@ -524,7 +524,7 @@ void CharacterObject::resetToAINode() {
     }
 }
 
-void CharacterObject::playActivityAnimation(Animation* animation, bool repeat,
+void CharacterObject::playActivityAnimation(AnimationPtr animation, bool repeat,
                                             bool blocked) {
     RW_CHECK(animator != nullptr, "No Animator");
     animator->playAnimation(AnimIndexAction, animation, 1.f, repeat);
@@ -545,7 +545,7 @@ void CharacterObject::playCycle(AnimCycle cycle) {
                             flags & AnimCycleInfo::Repeat);
 }
 
-void CharacterObject::playCycleAnimOverride(AnimCycle cycle, Animation* anim) {
+void CharacterObject::playCycleAnimOverride(AnimCycle cycle, AnimationPtr anim) {
     auto flags = animations->flags(cycle);
 
     cycle_ = cycle;

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -38,7 +38,7 @@ CharacterObject::CharacterObject(GameWorld* engine, const glm::vec3& pos,
     setClump(ClumpPtr(info->getModel()->clone()));
     if (info->getModel()) {
         setModel(info->getModel());
-        animator = new Animator(getClump().get());
+        animator = new Animator(getClump());
 
         createActor();
     }
@@ -273,7 +273,7 @@ void CharacterObject::changeCharacterModel(const std::string& name) {
 
     setModel(newmodel);
 
-    animator = new Animator(getClump().get());
+    animator = new Animator(getClump());
 }
 
 void CharacterObject::updateCharacter(float dt) {

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -18,7 +18,8 @@ static glm::vec3 enter_offset(0.81756252f, 0.34800607f, -0.486281008f);
 const float CharacterObject::DefaultJumpSpeed = 2.f;
 
 CharacterObject::CharacterObject(GameWorld* engine, const glm::vec3& pos,
-                                 const glm::quat& rot, BaseModelInfo* modelinfo)
+                                 const glm::quat& rot, BaseModelInfo* modelinfo,
+                                 CharacterController* controller)
     : GameObject(engine, pos, rot, modelinfo)
     , currentState({})
     , currentVehicle(nullptr)
@@ -32,7 +33,7 @@ CharacterObject::CharacterObject(GameWorld* engine, const glm::vec3& pos,
     , physCharacter(nullptr)
     , physObject(nullptr)
     , physShape(nullptr)
-    , controller(nullptr) {
+    , controller(controller) {
 
     auto info = getModelInfo<PedModelInfo>();
     setClump(ClumpPtr(info->getModel()->clone()));
@@ -44,6 +45,8 @@ CharacterObject::CharacterObject(GameWorld* engine, const glm::vec3& pos,
     }
 
     animations = engine->data->getAnimGroup(info->animgroup_);
+
+    controller->character = this;
 }
 
 CharacterObject::~CharacterObject() {
@@ -51,6 +54,7 @@ CharacterObject::~CharacterObject() {
     if (currentVehicle) {
         currentVehicle->setOccupant(getCurrentSeat(), nullptr);
     }
+    delete controller;
 }
 
 void CharacterObject::createActor(const glm::vec2& size) {

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -615,7 +615,8 @@ void CharacterObject::useItem(bool active, bool primary) {
         if (primary) {
             if (!currentState.primaryActive && active) {
                 // If we've just started, activate
-                controller->setNextActivity(new Activities::UseItem(item));
+                controller->setNextActivity(
+                    std::make_unique<Activities::UseItem>(item));
             } else if (currentState.primaryActive && !active) {
                 // UseItem will cancel itself upon !primaryActive
             }

--- a/rwengine/src/objects/CharacterObject.hpp
+++ b/rwengine/src/objects/CharacterObject.hpp
@@ -80,7 +80,8 @@ public:
      * @param ped PEDS_t struct to use.
      */
     CharacterObject(GameWorld* engine, const glm::vec3& pos,
-                    const glm::quat& rot, BaseModelInfo* modelinfo);
+                    const glm::quat& rot, BaseModelInfo* modelinfo,
+                    CharacterController* controller);
 
     ~CharacterObject();
 

--- a/rwengine/src/objects/CharacterObject.hpp
+++ b/rwengine/src/objects/CharacterObject.hpp
@@ -182,7 +182,7 @@ public:
      * This allows controller activities to play their own animations and
      * controll blending with movement.
      */
-    void playActivityAnimation(Animation* animation, bool repeat,
+    void playActivityAnimation(AnimationPtr animation, bool repeat,
                                bool blocking);
     /**
      * @brief activityFinished removes activity animation
@@ -202,7 +202,7 @@ public:
      * This sets the same state as playCycle, but provides an alternate
      * animation to play.
      */
-    void playCycleAnimOverride(AnimCycle cycle, Animation* anim);
+    void playCycleAnimOverride(AnimCycle cycle, AnimationPtr anim);
 
     AnimCycle getCurrentCycle() const {
         return cycle_;

--- a/rwengine/src/objects/CutsceneObject.cpp
+++ b/rwengine/src/objects/CutsceneObject.cpp
@@ -1,8 +1,8 @@
-#include <engine/Animator.hpp>
 #include <objects/CutsceneObject.hpp>
+#include <engine/Animator.hpp>
 
 CutsceneObject::CutsceneObject(GameWorld *engine, const glm::vec3 &pos,
-                               const glm::quat &rot, Clump *model,
+                               const glm::quat &rot, ClumpPtr model,
                                BaseModelInfo *modelinfo)
     : GameObject(engine, pos, rot, modelinfo)
     , _parent(nullptr)
@@ -14,7 +14,7 @@ CutsceneObject::CutsceneObject(GameWorld *engine, const glm::vec3 &pos,
         setModel(getModelInfo<ClumpModelInfo>()->getModel());
     }
     setClump(ClumpPtr(getModel()->clone()));
-    animator = new Animator(getClump().get());
+    animator = new Animator(getClump());
 }
 
 CutsceneObject::~CutsceneObject() {

--- a/rwengine/src/objects/CutsceneObject.hpp
+++ b/rwengine/src/objects/CutsceneObject.hpp
@@ -12,7 +12,7 @@ class CutsceneObject : public GameObject, public ClumpObject {
 
 public:
     CutsceneObject(GameWorld* engine, const glm::vec3& pos,
-                   const glm::quat& rot, Clump* model,
+                   const glm::quat& rot, ClumpPtr model,
                    BaseModelInfo* modelinfo);
     ~CutsceneObject();
 

--- a/rwengine/src/objects/GameObject.hpp
+++ b/rwengine/src/objects/GameObject.hpp
@@ -31,7 +31,7 @@ class GameObject {
     /**
      * Model used for rendering
      */
-    Clump* model_;
+    ClumpPtr model_;
 
 protected:
     void changeModelInfo(BaseModelInfo* next) {
@@ -102,14 +102,14 @@ public:
     /**
      * @return The model used in rendering
      */
-    Clump* getModel() const {
+    ClumpPtr getModel() const {
         return model_;
     }
 
     /**
      * Changes the current model, used for re-dressing chars
      */
-    void setModel(Clump* model) {
+    void setModel(ClumpPtr model) {
         model_ = model;
     }
 

--- a/rwengine/src/objects/PickupObject.cpp
+++ b/rwengine/src/objects/PickupObject.cpp
@@ -142,6 +142,7 @@ PickupObject::~PickupObject() {
     if (m_ghost) {
         setEnabled(false);
         engine->destroyEffect(m_corona);
+        delete m_corona;
         delete m_ghost;
         delete m_shape;
     }

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -668,7 +668,7 @@ void VehicleObject::registerPart(ModelFrame* mf) {
 
     dynamicParts.insert(
         {mf->getName(),
-         {mf, normal, damage, nullptr, nullptr, false, 0.f, 0.f, 0.f}});
+         {mf, normal, damage, nullptr, nullptr, nullptr, false, 0.f, 0.f, 0.f}});
 }
 
 void VehicleObject::createObjectHinge(Part* part) {
@@ -737,6 +737,7 @@ void VehicleObject::createObjectHinge(Part* part) {
     hinge->setLimit(hingeMin, hingeMax);
     hinge->setBreakingImpulseThreshold(250.f);
 
+    part->cs = cs;
     part->body = subObject;
     part->constraint = hinge;
 
@@ -754,8 +755,10 @@ void VehicleObject::destroyObjectHinge(Part* part) {
         engine->dynamicsWorld->removeCollisionObject(part->body);
         delete part->body->getMotionState();
         delete part->body;
+        delete part->cs;
     }
 
+    part->cs = nullptr;
     part->body = nullptr;
     part->constraint = nullptr;
 

--- a/rwengine/src/objects/VehicleObject.hpp
+++ b/rwengine/src/objects/VehicleObject.hpp
@@ -42,6 +42,7 @@ public:
         ModelFrame* dummy;
         Atomic* normal;
         Atomic* damaged;
+        btCollisionShape *cs;
         btRigidBody* body;
         btHingeConstraint* constraint;
         bool moveToAngle;

--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -68,7 +68,7 @@ DrawBuffer ssRectDraw;
 GameRenderer::GameRenderer(Logger* log, GameData* _data)
     : data(_data)
     , logger(log)
-    , renderer(new OpenGLRenderer)
+    , renderer(std::make_shared<OpenGLRenderer>())
     , _renderAlpha(0.f)
     , _renderWorld(nullptr)
     , cullOverride(false)

--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -317,7 +317,7 @@ void GameRenderer::renderWorld(GameWorld* world, const ViewCamera& camera,
             m, glm::vec3(i.radius +
                          0.15f * glm::sin(_renderWorld->getGameTime() * 5.f)));
 
-        objectRenderer.renderClump(sphereModel, m, nullptr, renderList);
+        objectRenderer.renderClump(sphereModel.get(), m, nullptr, renderList);
     }
 
     // Render arrows above anything that isn't radar only (or hidden)
@@ -344,7 +344,7 @@ void GameRenderer::renderWorld(GameWorld* world, const ViewCamera& camera,
                                glm::vec3(0.f, 0.f, 2.5f + glm::sin(a) * 0.5f));
         model = glm::rotate(model, a, glm::vec3(0.f, 0.f, 1.f));
         model = glm::scale(model, glm::vec3(1.5f, 1.5f, 1.5f));
-        objectRenderer.renderClump(arrowModel, model, nullptr, renderList);
+        objectRenderer.renderClump(arrowModel.get(), model, nullptr, renderList);
     }
 
     RW_PROFILE_END();

--- a/rwengine/src/render/GameRenderer.hpp
+++ b/rwengine/src/render/GameRenderer.hpp
@@ -49,7 +49,7 @@ class GameRenderer {
     Logger* logger;
 
     /** The low-level drawing interface to use */
-    Renderer* renderer;
+    std::shared_ptr<Renderer> renderer;
 
     // Temporary variables used during rendering
     float _renderAlpha;
@@ -140,7 +140,7 @@ public:
     void setupRender();
     void renderPostProcess();
 
-    Renderer* getRenderer() {
+    std::shared_ptr<Renderer> getRenderer() {
         return renderer;
     }
 

--- a/rwengine/src/render/GameRenderer.hpp
+++ b/rwengine/src/render/GameRenderer.hpp
@@ -62,7 +62,7 @@ class GameRenderer {
     ViewCamera _camera;
     ViewCamera cullingCamera;
     bool cullOverride;
-    
+
     /** Number of culling events */
     size_t culled;
 
@@ -99,7 +99,7 @@ public:
     GLuint getMissingTexture() const {
         return m_missingTexture;
     }
-    
+
     size_t getCulledCount() {
         return culled;
     }
@@ -174,16 +174,15 @@ public:
      *
      * GameRenderer will take ownership of the Model* pointer
      */
-    void setSpecialModel(SpecialModel usage, Clump* model) {
-        specialmodels_[usage].reset(model);
+    void setSpecialModel(SpecialModel usage, ClumpPtr model) {
+        specialmodels_[usage] = model;
     }
 
 private:
     /// Hard-coded models to use for each of the special models
-    std::unique_ptr<Clump>
-        specialmodels_[SpecialModel::SpecialModelCount];
-    Clump* getSpecialModel(SpecialModel usage) const {
-        return specialmodels_[usage].get();
+    ClumpPtr specialmodels_[SpecialModel::SpecialModelCount];
+    ClumpPtr getSpecialModel(SpecialModel usage) const {
+        return specialmodels_[usage];
     }
 };
 

--- a/rwengine/src/render/MapRenderer.cpp
+++ b/rwengine/src/render/MapRenderer.cpp
@@ -37,7 +37,7 @@ void main()
 	outColour = vec4(colour.rgb + c.rgb, colour.a * c.a);
 })";
 
-MapRenderer::MapRenderer(Renderer* renderer, GameData* _data)
+MapRenderer::MapRenderer(std::shared_ptr<Renderer> renderer, GameData* _data)
     : data(_data), renderer(renderer) {
     rectGeom.uploadVertices<VertexP2>(
         {{-.5f, -.5f}, {.5f, -.5f}, {.5f, .5f}, {-.5f, .5f}});

--- a/rwengine/src/render/MapRenderer.hpp
+++ b/rwengine/src/render/MapRenderer.hpp
@@ -26,13 +26,13 @@ public:
         bool clipToSize = true;
     };
 
-    MapRenderer(Renderer* renderer, GameData* data);
+    MapRenderer(std::shared_ptr<Renderer> renderer, GameData* data);
 
     void draw(GameWorld* world, const MapInfo& mi);
 
 private:
     GameData* data;
-    Renderer* renderer;
+    std::shared_ptr<Renderer> renderer;
 
     GeometryBuffer rectGeom;
     DrawBuffer rect;

--- a/rwengine/src/script/modules/GTA3ModuleImpl.inl
+++ b/rwengine/src/script/modules/GTA3ModuleImpl.inl
@@ -5526,7 +5526,8 @@ void opcode_01d3(const ScriptArguments& args, const ScriptCharacter character, c
 	RW_UNUSED(vehicle);
 	RW_UNUSED(args);
 	character->controller->skipActivity();
-	character->controller->setNextActivity(new Activities::ExitVehicle);
+	character->controller->setNextActivity(
+            std::make_unique<Activities::ExitVehicle>());(new Activities::ExitVehicle);
 }
 
 /**
@@ -5539,7 +5540,9 @@ void opcode_01d3(const ScriptArguments& args, const ScriptCharacter character, c
 void opcode_01d4(const ScriptArguments& args, const ScriptCharacter character, const ScriptVehicle vehicle) {
 	RW_UNUSED(args);
 	character->controller->skipActivity();
-	character->controller->setNextActivity(new Activities::EnterVehicle(vehicle,Activities::EnterVehicle::ANY_SEAT));
+	character->controller->setNextActivity(
+            std::make_unique<Activities::EnterVehicle>(
+                vehicle,Activities::EnterVehicle::ANY_SEAT));
 }
 
 /**
@@ -5551,7 +5554,8 @@ void opcode_01d4(const ScriptArguments& args, const ScriptCharacter character, c
 */
 void opcode_01d5(const ScriptArguments& args, const ScriptCharacter character, const ScriptVehicle vehicle) {
 	RW_UNUSED(args);
-	character->controller->setNextActivity(new Activities::EnterVehicle(vehicle));
+	character->controller->setNextActivity(
+            std::make_unique<Activities::EnterVehicle>(vehicle));
 }
 
 /**
@@ -6331,10 +6335,12 @@ void opcode_0211(const ScriptArguments& args, const ScriptCharacter character, S
 	if( character->getCurrentVehicle() )
 	{
 		// Since we just cleared the Activities, this will become current immediatley.
-		character->controller->setNextActivity(new Activities::ExitVehicle);
+		character->controller->setNextActivity(
+                    std::make_unique<Activities::ExitVehicle>());
 	}
-	
-	character->controller->setNextActivity(new Activities::GoTo(target));
+
+	character->controller->setNextActivity(
+            std::make_unique<Activities::GoTo>(target));
 }
 
 /**
@@ -6786,7 +6792,8 @@ void opcode_0237(const ScriptArguments& args, const ScriptGang gangID, const Scr
 */
 void opcode_0239(const ScriptArguments& args, const ScriptCharacter character, ScriptVec2 coord) {
 	auto target = script::getGround(args, glm::vec3(coord, -100.f));
-	character->controller->setNextActivity(new Activities::GoTo(target, true));
+	character->controller->setNextActivity(
+            std::make_unique<Activities::GoTo>(target, true));
 }
 
 /**

--- a/rwengine/src/script/modules/GTA3ModuleImpl.inl
+++ b/rwengine/src/script/modules/GTA3ModuleImpl.inl
@@ -8276,7 +8276,7 @@ void opcode_02e6(const ScriptArguments& args, const ScriptObject object, const S
 	auto cutscene = args.getObject<CutsceneObject>(0);
 	std::string animName = arg2;
 	std::transform(animName.begin(), animName.end(), animName.begin(), ::tolower);
-	Animation* anim = args.getWorld()->data->animations[animName];
+	auto anim = args.getWorld()->data->animations[animName];
 	if( anim ) {
 		cutscene->animator->playAnimation(AnimIndexMovement, anim, 1.f, false);
 	}
@@ -8483,7 +8483,7 @@ void opcode_02f5(const ScriptArguments& args, const ScriptObject object, const S
 	GameObject* head = args.getObject<CutsceneObject>(0);
 	std::string animName = args[1].string;
 	std::transform(animName.begin(), animName.end(), animName.begin(), ::tolower);
-	Animation* anim = args.getWorld()->data->animations[animName];
+	auto anim = args.getWorld()->data->animations[animName];
 	if( anim ) {
 		head->animator->playAnimation(AnimIndexMovement, anim, 1.f, false);
 	}

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -456,6 +456,8 @@ int RWGame::run() {
         StateManager::get().updateStack();
     }
 
+    window.close();
+
     StateManager::get().clear();
 
     return 0;

--- a/rwlib/CMakeLists.txt
+++ b/rwlib/CMakeLists.txt
@@ -17,6 +17,7 @@ SET(RWLIB_SOURCES
 	"source/gl/TextureData.cpp"
 
 	"source/rw/abort.cpp"
+	"source/rw/forward.hpp"
 	"source/rw/types.hpp"
 	"source/rw/defines.hpp"
 

--- a/rwlib/source/data/Clump.cpp
+++ b/rwlib/source/data/Clump.cpp
@@ -8,6 +8,7 @@ Geometry::Geometry() : flags(0) {
 }
 
 Geometry::~Geometry() {
+    glDeleteBuffers(1, &EBO);
 }
 
 ModelFrame::ModelFrame(unsigned int index, glm::mat3 dR, glm::vec3 dT)

--- a/rwlib/source/data/Clump.hpp
+++ b/rwlib/source/data/Clump.hpp
@@ -12,18 +12,7 @@
 #include <gl/TextureData.hpp>
 #include <loaders/RWBinaryStream.hpp>
 
-// Forward Declerations
-class ModelFrame;
-struct Geometry;
-class Atomic;
-class Clump;
-
-// Pointer types
-using ModelFramePtr = std::shared_ptr<ModelFrame>;
-using GeometryPtr = std::shared_ptr<Geometry>;
-using AtomicPtr = std::shared_ptr<Atomic>;
-using AtomicList = std::vector<AtomicPtr>;
-using ClumpPtr = std::shared_ptr<Clump>;
+#include <rw/forward.hpp>
 
 /**
  * ModelFrame stores transformation hierarchy

--- a/rwlib/source/gl/TextureData.hpp
+++ b/rwlib/source/gl/TextureData.hpp
@@ -14,6 +14,10 @@ public:
         : texName(name), size(dims), hasAlpha(alpha) {
     }
 
+    ~TextureData() {
+        glDeleteTextures(1, &texName);
+    }
+
     GLuint getName() const {
         return texName;
     }

--- a/rwlib/source/loaders/LoaderDFF.cpp
+++ b/rwlib/source/loaders/LoaderDFF.cpp
@@ -439,8 +439,8 @@ AtomicPtr LoaderDFF::readAtomic(FrameList &framelist,
     return atomic;
 }
 
-Clump *LoaderDFF::loadFromMemory(FileHandle file) {
-    auto model = new Clump;
+ClumpPtr LoaderDFF::loadFromMemory(FileHandle file) {
+    auto model = std::make_shared<Clump>();
 
     RWBStream rootStream(file->data, file->length);
 

--- a/rwlib/source/loaders/LoaderDFF.hpp
+++ b/rwlib/source/loaders/LoaderDFF.hpp
@@ -29,7 +29,7 @@ public:
     using GeometryList = std::vector<GeometryPtr>;
     using FrameList = std::vector<ModelFramePtr>;
 
-    Clump* loadFromMemory(FileHandle file);
+    ClumpPtr loadFromMemory(FileHandle file);
 
     void setTextureLookupCallback(TextureLookupCallback tlc) {
         texturelookup = tlc;

--- a/rwlib/source/rw/forward.hpp
+++ b/rwlib/source/rw/forward.hpp
@@ -1,10 +1,12 @@
 #ifndef RWLIB_FORWARD_HPP
 #define RWLIB_FORWARD_HPP
 
+#include <map>
 #include <memory>
 #include <vector>
 
 // Forward Declarations
+struct Animation;
 class Clump;
 class ModelFrame;
 struct Geometry;
@@ -12,11 +14,14 @@ class Atomic;
 class Clump;
 
 // Pointer types
+using AnimationPtr = std::shared_ptr<Animation>;
 using ModelFramePtr = std::shared_ptr<ModelFrame>;
 using GeometryPtr = std::shared_ptr<Geometry>;
 using AtomicPtr = std::shared_ptr<Atomic>;
-using AtomicList = std::vector<AtomicPtr>;
 using ClumpPtr = std::shared_ptr<Clump>;
 
-#endif /* FORWARD_HPP */
+// Collections
+using AtomicList = std::vector<AtomicPtr>;
+typedef std::map<std::string, AnimationPtr> AnimationSet;
 
+#endif /* FORWARD_HPP */

--- a/rwlib/source/rw/forward.hpp
+++ b/rwlib/source/rw/forward.hpp
@@ -1,0 +1,22 @@
+#ifndef RWLIB_FORWARD_HPP
+#define RWLIB_FORWARD_HPP
+
+#include <memory>
+#include <vector>
+
+// Forward Declarations
+class Clump;
+class ModelFrame;
+struct Geometry;
+class Atomic;
+class Clump;
+
+// Pointer types
+using ModelFramePtr = std::shared_ptr<ModelFrame>;
+using GeometryPtr = std::shared_ptr<Geometry>;
+using AtomicPtr = std::shared_ptr<Atomic>;
+using AtomicList = std::vector<AtomicPtr>;
+using ClumpPtr = std::shared_ptr<Clump>;
+
+#endif /* FORWARD_HPP */
+

--- a/rwlib/source/rw/types.hpp
+++ b/rwlib/source/rw/types.hpp
@@ -30,10 +30,6 @@
 #define WORLD_GRID_WIDTH (WORLD_GRID_SIZE / WORLD_CELL_SIZE)
 #define WORLD_GRID_CELLS (WORLD_GRID_WIDTH * WORLD_GRID_WIDTH)
 
-struct Animation;
-
-typedef std::map<std::string, Animation*> AnimationSet;
-
 namespace RWTypes {
 
 /**

--- a/rwviewer/AnimationListModel.hpp
+++ b/rwviewer/AnimationListModel.hpp
@@ -4,7 +4,7 @@
 #include <QAbstractItemModel>
 #include <loaders/LoaderIFP.hpp>
 
-typedef std::vector<std::pair<std::string, Animation*>> AnimationList;
+typedef std::vector<std::pair<std::string, AnimationPtr>> AnimationList;
 
 class AnimationListModel : public QAbstractListModel {
     Q_OBJECT

--- a/rwviewer/AnimationListWidget.hpp
+++ b/rwviewer/AnimationListWidget.hpp
@@ -22,7 +22,7 @@ public:
 
 signals:
 
-    void selectedAnimationChanged(Animation* anim);
+    void selectedAnimationChanged(AnimationPtr anim);
 
 public slots:
     void selectedIndexChanged(const QModelIndex& current);

--- a/rwviewer/ViewerWidget.cpp
+++ b/rwviewer/ViewerWidget.cpp
@@ -103,7 +103,7 @@ void ViewerWidget::paintGL() {
     vc.frustum.fov = viewFov;
     vc.frustum.aspectRatio = width() / (height() * 1.f);
 
-    Clump* model = activeModel;
+    ClumpPtr model = activeModel;
     if (model != _lastModel) {
         _lastModel = model;
         emit modelChanged(_lastModel);
@@ -133,7 +133,7 @@ void ViewerWidget::paintGL() {
 
         ObjectRenderer renderer(world(), vc, 1.f, 0);
         RenderList renders;
-        renderer.renderClump(model, glm::mat4(), nullptr, renders);
+        renderer.renderClump(model.get(), glm::mat4(), nullptr, renders);
         r.getRenderer()->drawBatched(renders);
 
         drawFrameWidget(model->getFrame().get());
@@ -165,7 +165,7 @@ void ViewerWidget::drawFrameWidget(ModelFrame* f, const glm::mat4& m) {
         glLineWidth(1.f);
     }
     dp.textures = {whiteTex};
-    
+
     RW_CHECK(renderer != nullptr, "GameRenderer is null");
     if(renderer != nullptr) {
         renderer->getRenderer()->drawArrays(thisM, _frameWidgetDraw, dp);
@@ -207,7 +207,7 @@ void ViewerWidget::showObject(qint16 item) {
     }
 }
 
-void ViewerWidget::showModel(Clump* model) {
+void ViewerWidget::showModel(ClumpPtr model) {
     if (dummyObject) gworld->destroyObject(dummyObject);
     dummyObject = nullptr;
     activeModel = model;
@@ -269,7 +269,7 @@ void ViewerWidget::keyReleaseEvent(QKeyEvent* e) {
     if (e->key() == Qt::Key_Shift) moveFast = false;
 }
 
-Clump* ViewerWidget::currentModel() const {
+ClumpPtr ViewerWidget::currentModel() const {
     return activeModel;
 }
 

--- a/rwviewer/ViewerWidget.hpp
+++ b/rwviewer/ViewerWidget.hpp
@@ -27,12 +27,12 @@ class ViewerWidget : public QGLWidget {
     QTimer timer;
     GameWorld* gworld;
 
-    Clump* activeModel;
+    ClumpPtr activeModel;
     ModelFrame* selectedFrame;
     GameObject* dummyObject;
     quint16 currentObjectID;
 
-    Clump* _lastModel;
+    ClumpPtr _lastModel;
     Animation* canimation;
 
     float viewDistance;
@@ -60,7 +60,7 @@ public:
 
     virtual void paintGL();
 
-    Clump* currentModel() const;
+    ClumpPtr currentModel() const;
     GameObject* currentObject() const;
 
     GameWorld* world();
@@ -68,7 +68,7 @@ public:
 public slots:
 
     void showObject(qint16 item);
-    void showModel(Clump* model);
+    void showModel(ClumpPtr model);
     void selectFrame(ModelFrame* frame);
 
     void exportModel();
@@ -81,7 +81,7 @@ signals:
 
     void fileOpened(const QString& file);
 
-    void modelChanged(Clump* model);
+    void modelChanged(ClumpPtr model);
 
 protected:
     void keyPressEvent(QKeyEvent*) override;

--- a/rwviewer/models/DFFFramesTreeModel.cpp
+++ b/rwviewer/models/DFFFramesTreeModel.cpp
@@ -1,7 +1,7 @@
 #include "DFFFramesTreeModel.hpp"
 #include <data/Clump.hpp>
 
-DFFFramesTreeModel::DFFFramesTreeModel(Clump* m,
+DFFFramesTreeModel::DFFFramesTreeModel(ClumpPtr m,
                                        QObject* parent)
     : QAbstractItemModel(parent), model(m) {
 }

--- a/rwviewer/models/DFFFramesTreeModel.hpp
+++ b/rwviewer/models/DFFFramesTreeModel.hpp
@@ -2,15 +2,14 @@
 #ifndef _DFFFRAMESTREEMODEL_HPP_
 #define _DFFFRAMESTREEMODEL_HPP_
 #include <QAbstractItemModel>
+#include <rw/forward.hpp>
 #include <rw/types.hpp>
 
-class Clump;
-
 class DFFFramesTreeModel : public QAbstractItemModel {
-    Clump* model;
+    ClumpPtr model;
 
 public:
-    explicit DFFFramesTreeModel(Clump* m, QObject* parent = 0);
+    explicit DFFFramesTreeModel(ClumpPtr m, QObject* parent = 0);
 
     virtual int columnCount(const QModelIndex& parent = QModelIndex()) const;
 

--- a/rwviewer/views/ModelViewer.cpp
+++ b/rwviewer/views/ModelViewer.cpp
@@ -39,7 +39,7 @@ void ModelViewer::setViewerWidget(ViewerWidget* widget) {
     showModel(viewing);
 }
 
-void ModelViewer::showModel(Clump* model) {
+void ModelViewer::showModel(ClumpPtr model) {
     viewing = model;
     viewerWidget->showModel(model);
     frames->setModel(model);

--- a/rwviewer/views/ModelViewer.cpp
+++ b/rwviewer/views/ModelViewer.cpp
@@ -75,6 +75,6 @@ void ModelViewer::loadAnimations(const QString& file) {
     animationWidget->setAnimations(anims);
 }
 
-void ModelViewer::playAnimation(Animation* anim) {
+void ModelViewer::playAnimation(AnimationPtr anim) {
     viewerWidget->currentObject()->animator->playAnimation(0, anim, 1.f, true);
 }

--- a/rwviewer/views/ModelViewer.hpp
+++ b/rwviewer/views/ModelViewer.hpp
@@ -51,7 +51,7 @@ public slots:
     void showObject(uint16_t object);
 
     void loadAnimations(const QString& file);
-    void playAnimation(Animation* anim);
+    void playAnimation(AnimationPtr anim);
 };
 
 #endif

--- a/rwviewer/views/ModelViewer.hpp
+++ b/rwviewer/views/ModelViewer.hpp
@@ -21,7 +21,7 @@ class Animation;
 class ModelViewer : public ViewerInterface {
     Q_OBJECT
 
-    Clump* viewing;
+    ClumpPtr viewing;
 
     QSplitter* mainSplit;
     QVBoxLayout* mainLayout;
@@ -43,7 +43,7 @@ public slots:
     /**
      * Display a raw model
      */
-    void showModel(Clump* model);
+    void showModel(ClumpPtr model);
 
     /**
      * Display a game object's model

--- a/rwviewer/widgets/ModelFramesWidget.cpp
+++ b/rwviewer/widgets/ModelFramesWidget.cpp
@@ -2,7 +2,7 @@
 #include <data/Clump.hpp>
 #include <glm/gtx/string_cast.hpp>
 
-void ModelFramesWidget::updateInfoBox(Clump* model, ModelFrame* f) {
+void ModelFramesWidget::updateInfoBox(ClumpPtr model, ModelFrame* f) {
     if (f == nullptr) {
         _frameLabel->setText("");
     } else {
@@ -33,14 +33,14 @@ ModelFramesWidget::ModelFramesWidget(QWidget* parent, Qt::WindowFlags flags)
     setLayout(_layout);
 }
 
-void ModelFramesWidget::setModel(Clump* model) {
+void ModelFramesWidget::setModel(ClumpPtr model) {
     if (framemodel) {
         delete framemodel;
         framemodel = nullptr;
         tree->setModel(nullptr);
     }
     gmodel = model;
-    if (model != nullptr) {
+    if (model.get() != nullptr) {
         framemodel = new DFFFramesTreeModel(model, this);
         tree->setModel(framemodel);
         tree->setDisabled(false);

--- a/rwviewer/widgets/ModelFramesWidget.hpp
+++ b/rwviewer/widgets/ModelFramesWidget.hpp
@@ -13,7 +13,7 @@ class ModelFrame;
 class ModelFramesWidget : public QWidget {
     Q_OBJECT
 
-    Clump* gmodel;
+    ClumpPtr gmodel;
     DFFFramesTreeModel* framemodel;
     QTreeView* tree;
     QVBoxLayout* _layout;
@@ -21,7 +21,7 @@ class ModelFramesWidget : public QWidget {
 
 private slots:
 
-    void updateInfoBox(Clump* model, ModelFrame* f);
+    void updateInfoBox(ClumpPtr model, ModelFrame* f);
 
     void selectedModelChanged(const QModelIndex&, const QModelIndex&);
 
@@ -30,7 +30,7 @@ public:
 
 public slots:
 
-    void setModel(Clump* model);
+    void setModel(ClumpPtr model);
 
 signals:
 

--- a/tests/test_animation.cpp
+++ b/tests/test_animation.cpp
@@ -18,8 +18,7 @@ BOOST_AUTO_TEST_CASE(test_matrix) {
         Animator animator(test_model);
 
         animation->duration = 1.f;
-        animation->bones["player"] = std::shared_ptr<AnimationBone>(
-            new AnimationBone {
+        animation->bones["player"] = new AnimationBone{
                 "player",
                 0,
                 0,
@@ -29,8 +28,7 @@ BOOST_AUTO_TEST_CASE(test_matrix) {
                     {glm::quat(), glm::vec3(0.f, 0.f, 0.f), glm::vec3(), 0.f, 0},
                     {glm::quat(), glm::vec3(0.f, 1.f, 0.f), glm::vec3(), 1.0f, 1},
                 }
-            }
-        );
+            };
 
         animator.playAnimation(0, animation, 1.f, false);
 

--- a/tests/test_animation.cpp
+++ b/tests/test_animation.cpp
@@ -18,16 +18,19 @@ BOOST_AUTO_TEST_CASE(test_matrix) {
         Animator animator(test_model);
 
         animation->duration = 1.f;
-        animation->bones["player"] = new AnimationBone{
-            "player",
-            0,
-            0,
-            1.0f,
-            AnimationBone::RT0,
-            {
-                {glm::quat(), glm::vec3(0.f, 0.f, 0.f), glm::vec3(), 0.f, 0},
-                {glm::quat(), glm::vec3(0.f, 1.f, 0.f), glm::vec3(), 1.0f, 1},
-            }};
+        animation->bones["player"] = std::shared_ptr<AnimationBone>(
+            new AnimationBone {
+                "player",
+                0,
+                0,
+                1.0f,
+                AnimationBone::RT0,
+                {
+                    {glm::quat(), glm::vec3(0.f, 0.f, 0.f), glm::vec3(), 0.f, 0},
+                    {glm::quat(), glm::vec3(0.f, 1.f, 0.f), glm::vec3(), 1.0f, 1},
+                }
+            }
+        );
 
         animator.playAnimation(0, animation, 1.f, false);
 

--- a/tests/test_animation.cpp
+++ b/tests/test_animation.cpp
@@ -9,7 +9,7 @@ BOOST_AUTO_TEST_SUITE(AnimationTests)
 #if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_matrix) {
     {
-        Animation animation;
+        auto animation = std::make_shared<Animation>();
 
         /** Models are currently needed to relate animation bones <=> model
          * frame #s. */
@@ -17,8 +17,8 @@ BOOST_AUTO_TEST_CASE(test_matrix) {
 
         Animator animator(test_model);
 
-        animation.duration = 1.f;
-        animation.bones["player"] = new AnimationBone{
+        animation->duration = 1.f;
+        animation->bones["player"] = new AnimationBone{
             "player",
             0,
             0,
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(test_matrix) {
                 {glm::quat(), glm::vec3(0.f, 1.f, 0.f), glm::vec3(), 1.0f, 1},
             }};
 
-        animator.playAnimation(0, &animation, 1.f, false);
+        animator.playAnimation(0, animation, 1.f, false);
 
         animator.tick(0.0f);
 

--- a/tests/test_character.cpp
+++ b/tests/test_character.cpp
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_CASE(test_create) {
 
         // Check that Idle activities are instantly displaced.
         controller->setNextActivity(
-            new Activities::GoTo(glm::vec3{1000.f, 0.f, 0.f}));
+            std::make_unique<Activities::GoTo>(glm::vec3{1000.f, 0.f, 0.f}));
 
         BOOST_CHECK_EQUAL(controller->getCurrentActivity()->name(), "GoTo");
         BOOST_CHECK_EQUAL(controller->getNextActivity(), nullptr);
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(test_activities) {
         BOOST_REQUIRE(controller != nullptr);
 
         controller->setNextActivity(
-            new Activities::GoTo(glm::vec3{10.f, 10.f, 0.f}));
+            std::make_unique<Activities::GoTo>(glm::vec3{10.f, 10.f, 0.f}));
 
         BOOST_CHECK_EQUAL(controller->getCurrentActivity()->name(), "GoTo");
 
@@ -69,7 +69,8 @@ BOOST_AUTO_TEST_CASE(test_activities) {
         auto controller = character->controller;
         BOOST_REQUIRE(controller != nullptr);
 
-        controller->setNextActivity(new Activities::EnterVehicle(vehicle, 0));
+        controller->setNextActivity(
+            std::make_unique<Activities::EnterVehicle>(vehicle, 0));
 
         for (float t = 0.f; t < 0.5f; t += (1.f / 60.f)) {
             character->tick(1.f / 60.f);
@@ -85,7 +86,8 @@ BOOST_AUTO_TEST_CASE(test_activities) {
 
         BOOST_CHECK_EQUAL(vehicle, character->getCurrentVehicle());
 
-        controller->setNextActivity(new Activities::ExitVehicle());
+        controller->setNextActivity(
+            std::make_unique<Activities::ExitVehicle>());
 
         for (float t = 0.f; t < 9.0f; t += (1.f / 60.f)) {
             character->tick(1.f / 60.f);
@@ -95,7 +97,8 @@ BOOST_AUTO_TEST_CASE(test_activities) {
         BOOST_CHECK_EQUAL(nullptr, character->getCurrentVehicle());
 
         character->setPosition(glm::vec3(5.f, 0.f, 0.f));
-        controller->setNextActivity(new Activities::EnterVehicle(vehicle, 0));
+        controller->setNextActivity(
+            std::make_unique<Activities::EnterVehicle>(vehicle, 0));
 
         for (float t = 0.f; t < 0.5f; t += (1.f / 60.f)) {
             character->tick(1.f / 60.f);

--- a/tests/test_character.cpp
+++ b/tests/test_character.cpp
@@ -12,10 +12,10 @@ BOOST_AUTO_TEST_CASE(test_create) {
     {
         auto character =
             Global::get().e->createPedestrian(1, {100.f, 100.f, 50.f});
-
         BOOST_REQUIRE(character != nullptr);
 
-        auto controller = new DefaultAIController(character);
+        auto controller = character->controller;
+        BOOST_REQUIRE(controller != nullptr);
 
         // Check the initial activity is Idle.
         BOOST_CHECK_EQUAL(controller->getCurrentActivity(), nullptr);
@@ -36,10 +36,10 @@ BOOST_AUTO_TEST_CASE(test_activities) {
     {
         auto character =
             Global::get().e->createPedestrian(1, {0.f, 0.f, 225.6f});
-
         BOOST_REQUIRE(character != nullptr);
 
-        auto controller = new DefaultAIController(character);
+        auto controller = character->controller;
+        BOOST_REQUIRE(controller != nullptr);
 
         controller->setNextActivity(
             new Activities::GoTo(glm::vec3{10.f, 10.f, 0.f}));
@@ -56,7 +56,6 @@ BOOST_AUTO_TEST_CASE(test_activities) {
             glm::distance(character->getPosition(), {10.f, 10.f, 0.f}), 0.1f);
 
         Global::get().e->destroyObject(character);
-        delete controller;
     }
     {
         VehicleObject* vehicle = Global::get().e->createVehicle(
@@ -65,10 +64,10 @@ BOOST_AUTO_TEST_CASE(test_activities) {
         BOOST_REQUIRE(vehicle->getModel() != nullptr);
 
         auto character = Global::get().e->createPedestrian(1, {0.f, 0.f, 0.f});
-
         BOOST_REQUIRE(character != nullptr);
 
-        auto controller = new DefaultAIController(character);
+        auto controller = character->controller;
+        BOOST_REQUIRE(controller != nullptr);
 
         controller->setNextActivity(new Activities::EnterVehicle(vehicle, 0));
 
@@ -123,7 +122,6 @@ BOOST_AUTO_TEST_CASE(test_death) {
         auto character =
             Global::get().e->createPedestrian(1, {100.f, 100.f, 50.f});
         BOOST_REQUIRE(character != nullptr);
-        auto controller = new DefaultAIController(character);
 
         BOOST_CHECK_EQUAL(character->getCurrentState().health, 100.f);
         BOOST_CHECK(character->isAlive());
@@ -144,7 +142,6 @@ BOOST_AUTO_TEST_CASE(test_death) {
             character->animations->animation(AnimCycle::KnockOutShotFront0));
 
         Global::get().e->destroyObject(character);
-        delete controller;
     }
 }
 

--- a/tests/test_loaderdff.cpp
+++ b/tests/test_loaderdff.cpp
@@ -11,9 +11,9 @@ BOOST_AUTO_TEST_CASE(test_load_dff) {
 
         LoaderDFF loader;
 
-        Clump* m = loader.loadFromMemory(d);
+        auto m = loader.loadFromMemory(d);
 
-        BOOST_REQUIRE(m != nullptr);
+        BOOST_REQUIRE(m.get() != nullptr);
 
         BOOST_REQUIRE(m->getFrame());
 
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE(test_load_dff) {
         BOOST_REQUIRE(atomic->getGeometry());
         BOOST_REQUIRE(atomic->getFrame());
 
-        delete m;
+        m.reset();
     }
 }
 

--- a/tests/test_loaderdff.cpp
+++ b/tests/test_loaderdff.cpp
@@ -22,8 +22,6 @@ BOOST_AUTO_TEST_CASE(test_load_dff) {
 
         BOOST_REQUIRE(atomic->getGeometry());
         BOOST_REQUIRE(atomic->getFrame());
-
-        m.reset();
     }
 }
 


### PR DESCRIPTION
Hey,
Using Valgrind I plugged some memory holes.
These patches let OpenRW go from ([gist](https://gist.github.com/madebr/bfc3b31f97925e8f83422eb4bec4df06/1ae89d123c9d1c64650f3c54696d9ad1c69d08c2)):
```
==22737== LEAK SUMMARY:
==22737==    definitely lost: 561,692,681 bytes in 12,231 blocks
==22737==    indirectly lost: 70,419,415 bytes in 311,902 blocks
==22737==      possibly lost: 49,812 bytes in 148 blocks
==22737==    still reachable: 257,601 bytes in 1,283 blocks
==22737==         suppressed: 0 bytes in 0 blocks
```

to ([gist](https://gist.github.com/madebr/bfc3b31f97925e8f83422eb4bec4df06/1258c9e2f47d5036ed367ab145418b0807a08a60))

```
==26514== LEAK SUMMARY:
==26514==    definitely lost: 39,345 bytes in 18 blocks
==26514==    indirectly lost: 22,828 bytes in 65 blocks
==26514==      possibly lost: 800 bytes in 2 blocks
==26514==    still reachable: 225,491 bytes in 1,031 blocks
==26514==         suppressed: 0 bytes in 0 blocks
```

The remaining memory holes are in:
- the `SoundManager`, but that's being rewritten as we speak by @darkf
- createShader: which I'll leave to @ShFil119 (see #302 )
- memory allocated by SDL2/X/GL/... which is reclaimed by the OS at end of process.