### PR TITLE
Fix jumping in newer bullet version

### DIFF
--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -472,7 +472,7 @@ bool CharacterObject::takeDamage(const GameObject::DamageInfo& dmg) {
 
 void CharacterObject::jump() {
     if (physCharacter) {
-        physCharacter->jump();
+        physCharacter->jump(btVector3(0.f, 0.f, 0.f));
         jumped = true;
         animator->playAnimation(AnimIndexMovement,
                                 animations->animation(AnimCycle::JumpLaunch),

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -472,7 +472,11 @@ bool CharacterObject::takeDamage(const GameObject::DamageInfo& dmg) {
 
 void CharacterObject::jump() {
     if (physCharacter) {
+#if BT_BULLET_VERSION < 285
+        physCharacter->jump();
+#else
         physCharacter->jump(btVector3(0.f, 0.f, 0.f));
+#endif
         jumped = true;
         animator->playAnimation(AnimIndexMovement,
                                 animations->animation(AnimCycle::JumpLaunch),


### PR DESCRIPTION
Fixes #318. Tested with bullet version 2.87, ~~probably breaks older versions of bullet where the jumping was working~~.