### PR TITLE
Offset vehicle spawn height to account for dimensions

### DIFF
--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -864,6 +864,17 @@ VehicleObject* GameWorld::tryToSpawnVehicle(VehicleGenerator& gen) {
         /// @todo use zone information to decide vehicle id
     }
 
+    auto model = data->findModelInfo<VehicleModelInfo>(id);
+    RW_ASSERT(model);
+    if (model) {
+        auto info = data->vehicleInfo.find(model->handling_);
+        if (info != data->vehicleInfo.end()) {
+            const auto& handling = info->second->handling;
+            position.z +=
+                (handling.dimensions.z / 2.f) - handling.centerOfMass.z;
+        }
+    }
+
     auto vehicle = createVehicle(id, position);
     vehicle->setHeading(gen.heading);
     vehicle->setLifetime(GameObject::TrafficLifetime);


### PR DESCRIPTION
Should prevent vehicles spawning in, and falling through, the ground.

Fixes #162 