### PR TITLE
Add build time option for CXX17 or boost filesystem

### DIFF
--- a/cmake_configure.cmake
+++ b/cmake_configure.cmake
@@ -38,6 +38,25 @@ else()
     message(FATAL_ERROR "Unknown platform \"${CMAKE_SYSTEM_NAME}\". please update CMakeLists.txt.")
 endif()
 
+if(FILESYSTEM_LIBRARY STREQUAL "CXX17")
+    target_compile_definitions(rw_interface INTERFACE "RW_FS_LIBRARY=0")
+elseif(FILESYSTEM_LIBRARY STREQUAL "CXXTS")
+    target_compile_definitions(rw_interface INTERFACE "RW_FS_LIBRARY=1")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_link_libraries(rw_interface INTERFACE "stdc++fs")
+    endif()
+elseif(FILESYSTEM_LIBRARY STREQUAL "BOOST")
+    find_package(Boost COMPONENTS system filesystem REQUIRED)
+    target_compile_definitions(rw_interface INTERFACE "RW_FS_LIBRARY=2")
+    target_include_directories(rw_interface INTERFACE ${Boost_INCLUDE_DIRS})
+    target_link_libraries(rw_interface INTERFACE
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_SYSTEM_LIBRARY}
+        )
+else()
+    message(FATAL_ERROR "Illegal FILESYSTEM_LIBRARY option. (was '${FILESYSTEM_LIBRARY}')")
+endif()
+
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
     target_compile_options(rw_interface INTERFACE "-Wno-gnu-array-member-paren-init")
 endif()

--- a/cmake_options.cmake
+++ b/cmake_options.cmake
@@ -11,6 +11,9 @@ option(TESTS_NODATA "Build tests for no-data testing")
 set(FAILED_CHECK_ACTION "IGNORE" CACHE STRING "What action to perform on a failed RW_CHECK (in debug mode)")
 set_property(CACHE FAILED_CHECK_ACTION PROPERTY STRINGS "IGNORE" "ABORT" "BREAKPOINT")
 
+set(FILESYSTEM_LIBRARY "BOOST" CACHE STRING "Which filesystem library to use")
+set_property(CACHE FILESYSTEM_LIBRARY PROPERTY STRINGS "CXX17" "CXXTS" "BOOST")
+
 set(BIN_DIR "bin" CACHE STRING "Prefix subdirectory to put the binaries in.")
 set(DOC_DIR "share/doc/openrw" CACHE STRING "Prefix subdirectory to put the documentation in.")
 

--- a/rwengine/src/engine/SaveGame.cpp
+++ b/rwengine/src/engine/SaveGame.cpp
@@ -11,8 +11,7 @@
 #include <script/SCMFile.hpp>
 #include <script/ScriptMachine.hpp>
 
-#include <boost/filesystem.hpp>
-#include <boost/range/iterator_range.hpp>
+#include <rw/filesystem.hpp>
 
 // Original save game file data structures
 typedef uint16_t BlockWord;
@@ -1311,8 +1310,6 @@ bool SaveGame::getSaveInfo(const std::string& file, BasicState* basicState) {
 }
 
 std::vector<SaveGameInfo> SaveGame::getAllSaveGameInfo() {
-    using namespace boost::filesystem;
-
     // TODO consider windows
     auto homedir = getenv("HOME");
     if (homedir == nullptr) {
@@ -1321,16 +1318,14 @@ std::vector<SaveGameInfo> SaveGame::getAllSaveGameInfo() {
     }
     const char gameDir[] = "GTA3 User Files";
 
-    path gamePath(homedir);
+    rwfs::path gamePath(homedir);
     gamePath /= gameDir;
 
-    if (!exists(gamePath) || !is_directory(gamePath)) return {};
+    if (!rwfs::exists(gamePath) || !rwfs::is_directory(gamePath)) return {};
 
     std::vector<SaveGameInfo> infos;
-    for (const path& save_path :
-         boost::make_iterator_range(directory_iterator(gamePath), {})) {
+    for (const rwfs::path& save_path : rwfs::directory_iterator(gamePath)) {
         if (save_path.extension() == ".b") {
-            std::cout << save_path.string() << std::endl;
             infos.emplace_back(
                 SaveGameInfo{save_path.string(), false, BasicState()});
             infos.back().valid =

--- a/rwlib/CMakeLists.txt
+++ b/rwlib/CMakeLists.txt
@@ -2,7 +2,7 @@
 ##      RWLIB
 ###########################################################
 
-find_package(Boost COMPONENTS filesystem system REQUIRED)
+find_package(Boost REQUIRED)
 
 SET(RWLIB_SOURCES
     # GL stuff is only here temporarily, hoping to move it back to rwengine
@@ -16,6 +16,7 @@ SET(RWLIB_SOURCES
     source/gl/TextureData.cpp
 
     source/rw/abort.cpp
+    source/rw/filesystem.hpp
     source/rw/forward.hpp
     source/rw/types.hpp
     source/rw/defines.hpp
@@ -49,7 +50,7 @@ target_include_directories(rwlib
 
 target_include_directories(rwlib
     SYSTEM
-    PUBLIC
+    PRIVATE
         ${Boost_INCLUDE_DIRS}
     )
 
@@ -58,8 +59,6 @@ target_link_libraries(rwlib
         openrw::interface
     PRIVATE
         OpenGL::OpenGL
-        ${Boost_FILESYSTEM_LIBRARY}
-        ${Boost_SYSTEM_LIBRARY}
     )
 
 openrw_target_apply_options(TARGET rwlib)

--- a/rwlib/source/platform/FileIndex.cpp
+++ b/rwlib/source/platform/FileIndex.cpp
@@ -1,22 +1,20 @@
 #include <algorithm>
-#include <boost/range/iterator_range.hpp>
 #include <fstream>
 #include <loaders/LoaderIMG.hpp>
 #include <platform/FileIndex.hpp>
 
-using namespace boost::filesystem;
-
-void FileIndex::indexGameDirectory(const fs::path& base_path) {
+void FileIndex::indexGameDirectory(const rwfs::path& base_path) {
     gamedatapath_ = base_path;
 
-    for (const path& entry : boost::make_iterator_range(
-             recursive_directory_iterator(base_path), {})) {
-        if (is_regular_file(entry)) {
-            std::string name = entry.string();
-            std::transform(name.begin(), name.end(), name.begin(), ::tolower);
-
-            filesystemfiles_[name] = entry;
+    for (const rwfs::path& path :
+         rwfs::recursive_directory_iterator(base_path)) {
+        if (!rwfs::is_regular_file(path)) {
+            continue;
         }
+
+        std::string name = path.string();
+        std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+        filesystemfiles_[name] = path;
     }
 }
 
@@ -37,26 +35,26 @@ FileHandle FileIndex::openFilePath(const std::string& file_path) {
 }
 
 void FileIndex::indexTree(const std::string& root) {
-    for (const path& entry :
-         boost::make_iterator_range(recursive_directory_iterator(root), {})) {
-        std::string directory = entry.parent_path().string();
-        std::string realName = entry.filename().string();
+    for (const rwfs::path& path : rwfs::recursive_directory_iterator(root)) {
+        if (!rwfs::is_regular_file(path)) {
+            continue;
+        }
+
+        std::string directory = path.parent_path().string();
+        std::string realName = path.filename().string();
         std::string lowerName = realName;
         std::transform(lowerName.begin(), lowerName.end(), lowerName.begin(),
                        ::tolower);
-
-        if (is_regular_file(entry)) {
-            files[lowerName] = {lowerName, realName, directory, ""};
-        }
+        files[lowerName] = {lowerName, realName, directory, ""};
     }
 }
 
 void FileIndex::indexArchive(const std::string& archive) {
     // Split directory from archive name
-    path archive_path = path(archive);
-    path directory = archive_path.parent_path();
-    path archive_basename = archive_path.filename();
-    path archive_full_path = directory / archive_basename;
+    auto archive_path = rwfs::path(archive);
+    auto directory = archive_path.parent_path();
+    auto archive_basename = archive_path.filename();
+    auto archive_full_path = directory / archive_basename;
 
     LoaderIMG img;
     if (!img.load(archive_full_path.string())) {

--- a/rwlib/source/platform/FileIndex.hpp
+++ b/rwlib/source/platform/FileIndex.hpp
@@ -1,32 +1,21 @@
 #ifndef RWENGINE_FILEINDEX_HPP
 #define RWENGINE_FILEINDEX_HPP
-#include "FileHandle.hpp"
+#include <platform/FileHandle.hpp>
+#include <rw/filesystem.hpp>
 
-#include <boost/filesystem.hpp>
-#include <boost/functional/hash.hpp>
 #include <map>
 #include <string>
 #include <unordered_map>
 
-namespace fs = boost::filesystem;
-
-namespace std {
-template <>
-struct hash<fs::path> {
-    size_t operator()(const fs::path& p) const {
-        return fs::hash_value(p);
-    }
-};
-}
 
 class FileIndex {
 private:
     /**
      * Mapping type (lower case name) => (on disk name)
      */
-    using FileSystemMap = std::unordered_map<fs::path, fs::path>;
+    using FileSystemMap = std::unordered_map<rwfs::path, rwfs::path>;
 
-    fs::path gamedatapath_;
+    rwfs::path gamedatapath_;
     FileSystemMap filesystemfiles_;
 
 public:
@@ -38,14 +27,14 @@ public:
      * true case on the file system for platforms where this is an issue.
      *
      */
-    void indexGameDirectory(const fs::path& base_path);
+    void indexGameDirectory(const rwfs::path& base_path);
 
     /**
      * @brief findFilePath finds disk path for a game data file
      * @param path
      * @return The file path as it exists on disk
      */
-    fs::path findFilePath(std::string path) {
+    rwfs::path findFilePath(std::string path) {
         auto backslash = std::string::npos;
         while ((backslash = path.find("\\")) != std::string::npos) {
             path.replace(backslash, 1, "/");

--- a/rwlib/source/rw/filesystem.hpp
+++ b/rwlib/source/rw/filesystem.hpp
@@ -1,0 +1,49 @@
+#ifndef RWLIB_FILESYSTEM_HPP
+#define RWLIB_FILESYSTEM_HPP
+
+#define RW_FS_CXX17 0
+#define RW_FS_CXXTS 1
+#define RW_FS_BOOST 2
+
+#if RW_FS_LIBRARY == RW_FS_CXX17
+#include <filesystem>
+namespace rwfs = std::filesystem;
+#elif RW_FS_LIBRARY == RW_FS_CXXTS
+#include <experimental/filesystem>
+namespace rwfs = std::experimental::filesystem;
+#elif RW_FS_LIBRARY == RW_FS_BOOST
+#include <boost/filesystem.hpp>
+#include <boost/functional/hash.hpp>
+namespace rwfs = boost::filesystem;
+#if BOOST_VERSION < 105600
+namespace boost {
+namespace filesystem {
+inline const directory_iterator& begin(const directory_iterator& iter) {
+    return iter;
+}
+inline directory_iterator end(const directory_iterator&) {
+    return {};
+}
+inline const recursive_directory_iterator& begin(const recursive_directory_iterator& iter) {
+    return iter;
+}
+inline recursive_directory_iterator end(const recursive_directory_iterator&) {
+    return {};
+}
+}
+}
+#endif
+#else
+#error Invalid RW_FS_LIBRARY value
+#endif
+
+namespace std {
+template <>
+struct hash<rwfs::path> {
+    size_t operator()(const rwfs::path& p) const {
+        return rwfs::hash_value(p);
+    }
+};
+}
+
+#endif

--- a/tests/test_Config.cpp
+++ b/tests/test_Config.cpp
@@ -1,6 +1,5 @@
 #include <GameConfig.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <boost/property_tree/ini_parser.hpp>
@@ -9,10 +8,11 @@
 #include <fstream>
 #include <map>
 
-#include "rw/defines.hpp"
+#include <rw/defines.hpp>
+#include <rw/filesystem.hpp>
 
 namespace pt = boost::property_tree;
-namespace fs = boost::filesystem;
+namespace fs = rwfs;
 
 typedef std::map<std::string, std::map<std::string, std::string>>
     simpleConfig_t;


### PR DESCRIPTION
The existing filesystem usage has been adjusted to using the rwfs namespace.
The FILESYSTEM_LIBRARY option allows a choice between how the rwfs namespace will be defined:

- ___CXX17___: using the ``<filesystem>`` header & ``std::filesystem``.
- ___CXXTS___: using the ``<experimental/filesystem>`` header and ``std::experimental::filesystem``.
- ___BOOST___: using boost filesystem. The default for now as we still target C++14.
