### PR TITLE
Forgotten flush of packet

### DIFF
--- a/rwengine/src/audio/SoundManager.cpp
+++ b/rwengine/src/audio/SoundManager.cpp
@@ -166,6 +166,7 @@ void SoundManager::SoundSource::loadFromFile(const std::string& filename) {
                 }
             }
         }
+        av_free_packet(&readingPacket);
     }
 
     // Cleanup


### PR DESCRIPTION
Probably forgotten during porting ffmpeg. And probably it's last memory leak.
Ref:
https://github.com/leixiaohua1020/simplest_ffmpeg_audio_player/blob/master/simplest_ffmpeg_audio_decoder/simplest_ffmpeg_audio_decoder.cpp#L137
Btw: av_free_packet is deprecated, so I used unref. Edit. not available in travis's ffmpeg.
Btw2: If you want to test, try heaptrack it's much, much faster than valgrind. Before ~20MB leak. 