### PR TITLE
Make vehicle wheels steer smoothly

### DIFF
--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -262,14 +262,23 @@ void VehicleObject::tickPhysics(float dt) {
             physVehicle->setBrake(brakeReal * brakeF, w);
 
             if (wi.m_bIsFrontWheel) {
-                float sign = std::signbit(steerAngle) ? -1.f : 1.f;
-                physVehicle->setSteeringValue(
-                    std::min(glm::radians(info->handling.steeringLock),
-                             std::abs(steerAngle)) *
-                        sign,
-                    w);
-                // physVehicle->setSteeringValue(std::min(3.141f/2.f,
-                // std::abs(steerAngle)) * sign, w);
+                float currentVal = physVehicle->getSteeringValue(w);
+                float currentSign = std::signbit(currentVal) ? -1.f : 1.f;
+                float newVal;
+
+                if (std::abs(steerAngle) < 0.001f) {   // no steering?
+                    newVal = std::max(0.0f,std::abs(currentVal) - 4.f * dt) *
+                        currentSign; 
+                } else {
+                    newVal = currentVal + steerAngle * dt * 4.f;
+
+                    float limit = glm::radians(info->handling.steeringLock);
+
+                    if (std::abs(newVal) > limit)
+                        newVal = limit * currentSign;
+                }
+
+                physVehicle->setSteeringValue(newVal,w);
             }
         }
 


### PR DESCRIPTION
Hello, this is my first attempt at PR to this repo. Feel free to throw criticism at me :)

EDIT:

Unlike in vanilla engine, the vehicle wheels instantly turned to their limit angle when the player steered. I corrected this by smoothly changing the angle in each physics tick, independently of framerate. It's not just a change of animation but actual physics behavior that allows for finer steering.