### PR TITLE
tests: boost 1.64 has a print_log_value<nullptr_t> implementation

### DIFF
--- a/cmake_configure.cmake
+++ b/cmake_configure.cmake
@@ -90,11 +90,11 @@ endif()
 
 if(TEST_COVERAGE)
     if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-        message("Test Coverage enabled. Setting CMAKE_BUILD_TYPE to Debug.")
+        message("TEST_COVERAGE enabled. Setting CMAKE_BUILD_TYPE to Debug.")
         set(CMAKE_BUILD_TYPE "Debug")
     endif()
     if(NOT BUILD_TESTS)
-        message("TestCoverage enabled. Enabling BUILD_TESTS.")
+        message("TEST_COVERAGE enabled. Enabling BUILD_TESTS.")
         set(BUILD_TESTS "ON")
     endif()
     target_compile_options(rw_interface

--- a/tests/test_Globals.hpp
+++ b/tests/test_Globals.hpp
@@ -1,5 +1,5 @@
-#ifndef _TESTGLOBABLS_HPP_
-#define _TESTGLOBABLS_HPP_
+#ifndef _TESTGLOBALS_HPP_
+#define _TESTGLOBALS_HPP_
 
 #include <SDL2/SDL.h>
 #include <GameWindow.hpp>
@@ -31,10 +31,11 @@ struct print_log_value<glm::vec3> {
         s << glm::to_string(v);
     }
 };
-}
-}
 BOOST_NS_MAGIC_CLOSING
+}
+}
 
+#if BOOST_VERSION < 106400
 namespace boost {
 namespace test_tools {
 BOOST_NS_MAGIC
@@ -44,9 +45,10 @@ struct print_log_value<std::nullptr_t> {
         s << "nullptr";
     }
 };
-}
-}
 BOOST_NS_MAGIC_CLOSING
+}
+}
+#endif
 
 namespace boost {
 namespace test_tools {
@@ -59,9 +61,9 @@ struct print_log_value<GameString> {
         }
     }
 };
-}
-}
 BOOST_NS_MAGIC_CLOSING
+}
+}
 
 #undef BOOST_NS_MAGIC
 #undef BOOST_NS_MAGIC_CLOSING


### PR DESCRIPTION
Recent versions of Arch Linux and Fedora Linux bring Boost 1.65+
Boost-unit-test includes a nullptr_t specialization of the printer,
so only use it on older versions of the boost libraries.

See [this travis log](https://travis-ci.org/madebr/openrw/jobs/314980016) for the error on Arch Linux.

fixes:
error C2766: explicit specialization;
'boost::test_tools::tt_detail::print_log_value<std::nullptr_t>' has
already been defined
C:\Boost\include\boost-1_64\boost/test/tools/detail/print_helper.hpp(169):
note: see previous definition of 'print_log_value<std::nullptr_t>