### PR TITLE
Use std::move

### DIFF
--- a/rwengine/src/TextureArchive.cpp
+++ b/rwengine/src/TextureArchive.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<TextureArchive> TextureArchive::create(
                    bufSize);
         }
 
-        textureArchive->textures.push_back(texture);
+        textureArchive->textures.push_back(std::move(texture));
 
         section = section->next;  // Extension
     }

--- a/rwengine/src/core/Profiler.hpp
+++ b/rwengine/src/core/Profiler.hpp
@@ -57,7 +57,7 @@ public:
         } else {
             auto tmp = currentStack.top();
             currentStack.pop();
-            currentStack.top().childProfiles.push_back(tmp);
+            currentStack.top().childProfiles.push_back(std::move(tmp));
         }
     }
 };

--- a/rwengine/src/data/ZoneData.hpp
+++ b/rwengine/src/data/ZoneData.hpp
@@ -14,30 +14,30 @@
  */
 struct ZoneData {
     /**
-    * The name of the Zone (see .gxt)
-    */
+     * The name of the Zone (see .gxt)
+     */
     std::string name{};
 
     int type{};
 
     /**
-    * Bottom left of the Zone
-    */
+     * Bottom left of the Zone
+     */
     glm::vec3 min{};
 
     /**
-    * Top Right of the zone
-    */
+     * Top Right of the zone
+     */
     glm::vec3 max{};
 
     /**
-    * Island number
-    */
+     * Island number
+     */
     int island{};
 
     /**
-    * Text of the zone?
-    */
+     * Text of the zone?
+     */
     std::string text = {};
 
     /**
@@ -72,6 +72,21 @@ struct ZoneData {
      * Totally contained zones
      */
     std::vector<ZoneData*> children_ = {};
+
+    ZoneData(const std::string& _name, const int& _type, const glm::vec3& _min,
+             const glm::vec3& _max, const int& _island,
+             const unsigned int& _pedGroupDay,
+             const unsigned int& _pedGroupNight)
+        : name(_name)
+        , type(_type)
+        , min(_min)
+        , max(_max)
+        , island(_island)
+        , pedGroupDay(_pedGroupDay)
+        , pedGroupNight(_pedGroupNight) {
+    }
+
+    ZoneData() = default;
 
     static bool isZoneContained(const ZoneData& inner, const ZoneData& outer) {
         return glm::all(glm::greaterThanEqual(inner.min, outer.min)) &&

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -73,7 +73,7 @@ void GameData::load() {
 
     // Clear existing zones
     gamezones = ZoneDataList{
-        {"CITYZON", 0, {-4000.f, -4000.f, -500.f}, {4000.f, 4000.f, 500.f}, 0}};
+        {"CITYZON", 0, {-4000.f, -4000.f, -500.f}, {4000.f, 4000.f, 500.f}, 0, 0, 0}};
 
     loadLevelFile("data/default.dat");
     loadLevelFile("data/gta3.dat");

--- a/rwengine/src/engine/SaveGame.cpp
+++ b/rwengine/src/engine/SaveGame.cpp
@@ -982,16 +982,9 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
         Block11Zone& zone = zoneData.navZones[z];
         Block11ZoneInfo& day = zoneData.dayNightInfo[zone.dayZoneInfo];
         Block11ZoneInfo& night = zoneData.dayNightInfo[zone.nightZoneInfo];
-        ZoneData zd;
-        zd.name = zone.name;
-        zd.type = zone.type;
-        zd.min = zone.coordA;
-        zd.max = zone.coordB;
-        zd.island = zone.level;
         // @toodo restore gang density
-        zd.pedGroupDay = day.pedgroup;
-        zd.pedGroupNight = night.pedgroup;
-        gamezones.push_back(zd);
+        gamezones.emplace_back(zone.name, zone.type, zone.coordA, zone.coordB,
+                            zone.level, day.pedgroup, night.pedgroup);
     }
     // Re-build zone hierarchy
     for (ZoneData& zone : gamezones) {

--- a/rwengine/src/loaders/LoaderIDE.cpp
+++ b/rwengine/src/loaders/LoaderIDE.cpp
@@ -237,7 +237,7 @@ bool LoaderIDE::load(const std::string &filename, const PedStatsList &stats) {
                         getline(buffstream, buff, ',');
                         node.other_thing2 = atoi(buff.c_str());
 
-                        path.nodes.push_back(node);
+                        path.nodes.push_back(std::move(node));
                     }
 
                     auto &object = objects[path.ID];

--- a/rwengine/src/loaders/LoaderIPL.cpp
+++ b/rwengine/src/loaders/LoaderIPL.cpp
@@ -125,7 +125,7 @@ bool LoaderIPL::load(const std::string& filename) {
                 zone.pedGroupDay = 0;
                 zone.pedGroupNight = 0;
 
-                zones.push_back(zone);
+                zones.push_back(std::move(zone));
             }
         }
     }

--- a/rwengine/src/script/SCMFile.cpp
+++ b/rwengine/src/script/SCMFile.cpp
@@ -29,7 +29,7 @@ void SCMFile::loadFile(char *data, unsigned int size) {
         for (char &c : model_name) {
             c = read<char>(i++);
         }
-        models.push_back(model_name);
+        models.emplace_back(model_name);
     }
 
     i = missionSectionOffset;

--- a/rwlib/source/data/Clump.hpp
+++ b/rwlib/source/data/Clump.hpp
@@ -149,6 +149,13 @@ struct Geometry {
         std::string name;
         std::string alphaName;
         TextureData::Handle texture;
+
+        template<class String1, class String2>
+        Texture(String1&& _name, String2&& _alphaName, const TextureData::Handle &_texture)
+            : name(std::forward<String1>(_name))
+            , alphaName(std::forward<String2>(_alphaName))
+            , texture(_texture) {
+        }
     };
 
     enum { MTF_PrimaryColour = 1 << 0, MTF_SecondaryColour = 1 << 1 };

--- a/rwlib/source/loaders/LoaderDFF.cpp
+++ b/rwlib/source/loaders/LoaderDFF.cpp
@@ -413,7 +413,7 @@ void LoaderDFF::readBinMeshPLG(GeometryPtr &geom, const RWBStream &stream) {
                     sizeof(std::uint32_t) * sg.numIndices);
         data += sizeof(std::uint32_t) * sg.numIndices;
 
-        geom->subgeom.push_back(sg);
+        geom->subgeom.push_back(std::move(sg));
     }
 }
 

--- a/rwlib/source/loaders/LoaderDFF.cpp
+++ b/rwlib/source/loaders/LoaderDFF.cpp
@@ -364,7 +364,7 @@ void LoaderDFF::readTexture(Geometry::Material &material,
 
     TextureData::Handle textureinst =
         texturelookup ? texturelookup(name, alpha) : nullptr;
-    material.textures.push_back({name, alpha, textureinst});
+    material.textures.emplace_back(std::move(name), std::move(alpha), textureinst);
 }
 
 void LoaderDFF::readGeometryExtension(GeometryPtr &geom,


### PR DESCRIPTION
One more emplace_back and usage std::move when possible.

- [x] remove unneeded std::move (POD/ptr)
- [x] avoid temporary zd
- [x] cleanup