### PR TITLE
libglm-dev 0.9.9 'default initialization' fix

### DIFF
--- a/rwengine/src/ai/AIGraph.cpp
+++ b/rwengine/src/ai/AIGraph.cpp
@@ -28,8 +28,7 @@ void AIGraph::createPathNodes(const glm::vec3& position,
         glm::vec3 nodePosition = position + (rotation * node.position);
 
         if (node.type == PathNode::EXTERNAL) {
-            for (size_t rn = 0; rn < externalNodes.size(); ++rn) {
-                auto& realNode = externalNodes[rn];
+            for (auto &realNode : externalNodes) {
                 auto d = glm::distance2(realNode->position, nodePosition);
                 if (d < 1.f) {
                     pathNodes.push_back(realNode);

--- a/rwengine/src/ai/AIGraphNode.hpp
+++ b/rwengine/src/ai/AIGraphNode.hpp
@@ -14,7 +14,7 @@ struct AIGraphNode {
     };
 
     NodeType type;
-    glm::vec3 position;
+    glm::vec3 position{};
     float size;
     int other_thing;
     int other_thing2;

--- a/rwengine/src/ai/DefaultAIController.hpp
+++ b/rwengine/src/ai/DefaultAIController.hpp
@@ -4,7 +4,7 @@
 #include <ai/CharacterController.hpp>
 
 class DefaultAIController : public CharacterController {
-    glm::vec3 gotoPos;
+    glm::vec3 gotoPos{};
 
 public:
     DefaultAIController()

--- a/rwengine/src/ai/PlayerController.hpp
+++ b/rwengine/src/ai/PlayerController.hpp
@@ -6,9 +6,9 @@
 #include <ai/CharacterController.hpp>
 
 class PlayerController : public CharacterController {
-    glm::quat cameraRotation;
+    glm::quat cameraRotation{1.0f,0.0f,0.0f,0.0f};
 
-    glm::vec3 direction;
+    glm::vec3 direction{};
 
     glm::quat lastRotation;
 

--- a/rwengine/src/data/Chase.cpp
+++ b/rwengine/src/data/Chase.cpp
@@ -31,7 +31,7 @@ bool ChaseKeyframe::load(const std::string &filePath,
         uint8_t driving;
         uint8_t braking;
         uint8_t handbrake;
-        glm::vec3 position;
+        glm::vec3 position{};
     };
 
     static_assert(sizeof(ChaseEntryRecord) == 28,

--- a/rwengine/src/data/CollisionModel.hpp
+++ b/rwengine/src/data/CollisionModel.hpp
@@ -19,14 +19,14 @@ struct CollisionModel {
 
     /// @todo give shapes surface data
     struct Sphere {
-        glm::vec3 center;
+        glm::vec3 center{};
         float radius;
         Surface surface;
     };
 
     struct Box {
-        glm::vec3 min;
-        glm::vec3 max;
+        glm::vec3 min{};
+        glm::vec3 max{};
         Surface surface;
     };
 

--- a/rwengine/src/data/CutsceneData.hpp
+++ b/rwengine/src/data/CutsceneData.hpp
@@ -21,7 +21,7 @@ struct CutsceneMetadata {
     std::string name;
 
     /// The origin for coordinates in the cutscene
-    glm::vec3 sceneOffset;
+    glm::vec3 sceneOffset{};
 
     std::vector<ModelEntry> models;
     std::map<float, TextEntry> texts;

--- a/rwengine/src/data/GameTexts.cpp
+++ b/rwengine/src/data/GameTexts.cpp
@@ -2,8 +2,8 @@
 
 GameString GameStringUtil::fromString(const std::string& str) {
     GameString s;
-    for (std::string::size_type i = 0u; i < str.size(); ++i) {
-        s += str[i];
+    for (const char &i : str) {
+        s += i;
     }
     return s;
 }

--- a/rwengine/src/data/PathData.hpp
+++ b/rwengine/src/data/PathData.hpp
@@ -14,7 +14,7 @@ struct PathNode {
 
     NodeType type;
     int32_t next;
-    glm::vec3 position;
+    glm::vec3 position{};
     float size;
     int other_thing;
     int other_thing2;

--- a/rwengine/src/data/WeaponData.hpp
+++ b/rwengine/src/data/WeaponData.hpp
@@ -18,7 +18,7 @@ struct WeaponData {
     float meleeRadius;
     float lifeSpan;
     float spread;
-    glm::vec3 fireOffset;
+    glm::vec3 fireOffset{};
     std::string animation1;
     std::string animation2;
     float animLoopStart;
@@ -51,10 +51,10 @@ struct WeaponScan {
 
     float damage;
 
-    glm::vec3 center;
+    glm::vec3 center{};
     float radius;
 
-    glm::vec3 end;
+    glm::vec3 end{};
 
     WeaponData* weapon;
 

--- a/rwengine/src/data/Weather.hpp
+++ b/rwengine/src/data/Weather.hpp
@@ -13,12 +13,12 @@ enum class WeatherCondition { Sunny = 0, Cloudy = 1, Rainy = 2, Foggy = 3 };
 class Weather {
 public:
     struct Entry {
-        glm::vec3 ambientColor;
-        glm::vec3 directLightColor;
-        glm::vec3 skyTopColor;
-        glm::vec3 skyBottomColor;
-        glm::vec3 sunCoreColor;
-        glm::vec3 sunCoronaColor;
+        glm::vec3 ambientColor{};
+        glm::vec3 directLightColor{};
+        glm::vec3 skyTopColor{};
+        glm::vec3 skyBottomColor{};
+        glm::vec3 sunCoreColor{};
+        glm::vec3 sunCoronaColor{};
         float sunCoreSize;
         float sunCoronaSize;
         float sunBrightness;
@@ -28,9 +28,9 @@ public:
         float farClipping;
         float fogStart;
         float amountGroundLight;
-        glm::vec3 lowCloudColor;
-        glm::vec3 topCloudColor;
-        glm::vec3 bottomCloudColor;
+        glm::vec3 lowCloudColor{};
+        glm::vec3 topCloudColor{};
+        glm::vec3 bottomCloudColor{};
         uint8_t unknown[4];
     };
 

--- a/rwengine/src/data/ZoneData.hpp
+++ b/rwengine/src/data/ZoneData.hpp
@@ -16,24 +16,24 @@ struct ZoneData {
     /**
     * The name of the Zone (see .gxt)
     */
-    std::string name;
+    std::string name{};
 
-    int type;
+    int type{};
 
     /**
     * Bottom left of the Zone
     */
-    glm::vec3 min;
+    glm::vec3 min{};
 
     /**
     * Top Right of the zone
     */
-    glm::vec3 max;
+    glm::vec3 max{};
 
     /**
     * Island number
     */
-    int island;
+    int island{};
 
     /**
     * Text of the zone?

--- a/rwengine/src/dynamics/CollisionInstance.cpp
+++ b/rwengine/src/dynamics/CollisionInstance.cpp
@@ -78,8 +78,7 @@ bool CollisionInstance::createPhysicsBody(GameObject* object,
     t.setIdentity();
 
     // Boxes
-    for (size_t i = 0; i < collision->boxes.size(); ++i) {
-        auto& box = collision->boxes[i];
+    for (const auto &box : collision->boxes) {
         auto size = (box.max - box.min) / 2.f;
         auto mid = (box.min + box.max) / 2.f;
         btCollisionShape* bshape =
@@ -94,8 +93,7 @@ bool CollisionInstance::createPhysicsBody(GameObject* object,
     }
 
     // Spheres
-    for (size_t i = 0; i < collision->spheres.size(); ++i) {
-        auto& sphere = collision->spheres[i];
+    for (const auto &sphere : collision->spheres) {
         btCollisionShape* sshape = new btSphereShape(sphere.radius);
         t.setOrigin(
             btVector3(sphere.center.x, sphere.center.y, sphere.center.z));

--- a/rwengine/src/engine/Animator.cpp
+++ b/rwengine/src/engine/Animator.cpp
@@ -19,8 +19,8 @@ void Animator::tick(float dt) {
     }
 
     struct BoneTransform {
-        glm::vec3 translation;
-        glm::quat rotation;
+        glm::vec3 translation{};
+        glm::quat rotation{1.0f,0.0f,0.0f,0.0f};
     };
 
 #if 0

--- a/rwengine/src/engine/GameState.cpp
+++ b/rwengine/src/engine/GameState.cpp
@@ -99,10 +99,12 @@ GameState::GameState()
     , maxWantedLevel(0)
     , playerObject(0)
     , scriptOnMissionFlag(nullptr)
+    , nextRestartLocation{}
     , fadeOut(true)
     , fadeStart(0.f)
     , fadeTime(0.f)
     , fadeSound(false)
+    , fadeColour{}
     , skipCutscene(false)
     , isIntroPlaying(false)
     , currentCutscene(nullptr)
@@ -111,6 +113,8 @@ GameState::GameState()
     , hudFlash(HudFlash::Disabled)
     , cameraNear(0.1f)
     , cameraFixed(false)
+    , cameraPosition{}
+    , cameraRotation{1.0f,0.0f,0.0f,0.0f}
     , cameraTarget(0)
     , importExportPortland(0)
     , importExportShoreside(0)
@@ -121,9 +125,9 @@ GameState::GameState()
 
 int GameState::addRadarBlip(BlipData& blip) {
     int l = 0;
-    for (auto x = radarBlips.begin(); x != radarBlips.end(); ++x) {
-        if ((x->first) != l) {
-            l = x->first - 1;
+    for (const auto &radarBlip : radarBlips) {
+        if ((radarBlip.first) != l) {
+            l = radarBlip.first - 1;
         } else {
             l++;
         }

--- a/rwengine/src/engine/GameState.hpp
+++ b/rwengine/src/engine/GameState.hpp
@@ -159,10 +159,10 @@ struct GameStats {
 struct TextDisplayData {
     // This is set by the final display text command.
     GameString text;
-    glm::vec2 position;
+    glm::vec2 position{};
 
-    glm::vec4 colourFG;
-    glm::vec4 colourBG;
+    glm::vec4 colourFG{};
+    glm::vec4 colourBG{};
 };
 
 /**
@@ -181,7 +181,7 @@ struct BlipData {
     BlipType type;
     GameObjectID target;
     // If target is null then use coord
-    glm::vec3 coord;
+    glm::vec3 coord{};
 
     std::string texture;  // Texture for use in the radar
     uint32_t colour = 0;  // Color value (index or RGBA)

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -86,8 +86,7 @@ bool GameWorld::placeItems(const std::string& name) {
 
     if (ipll.load(path)) {
         // Find the object.
-        for (size_t i = 0; i < ipll.m_instances.size(); ++i) {
-            std::shared_ptr<InstanceData> inst = ipll.m_instances[i];
+        for (auto inst : ipll.m_instances) {
             if (!createInstance(inst->id, inst->pos, inst->rot)) {
                 logger->error("World", "No object data for instance " +
                                            std::to_string(inst->id) + " in " +

--- a/rwengine/src/engine/GameWorld.hpp
+++ b/rwengine/src/engine/GameWorld.hpp
@@ -59,8 +59,8 @@ struct AreaIndicatorInfo {
     enum AreaIndicatorType { Cylinder };
 
     AreaIndicatorType type;
-    glm::vec3 position;
-    glm::vec3 radius;
+    glm::vec3 position{};
+    glm::vec3 radius{};
 };
 
 /**
@@ -102,34 +102,34 @@ public:
      * Creates an instance
      */
     InstanceObject* createInstance(const uint16_t id, const glm::vec3& pos,
-                                   const glm::quat& rot = glm::quat());
+                                   const glm::quat& rot = glm::quat{1.0f,0.0f,0.0f,0.0f});
 
     /**
      * @brief Creates an InstanceObject for use in the current Cutscene.
      */
     CutsceneObject* createCutsceneObject(const uint16_t id,
                                          const glm::vec3& pos,
-                                         const glm::quat& rot = glm::quat());
+                                         const glm::quat& rot = glm::quat{1.0f,0.0f,0.0f,0.0f});
 
     /**
      * Creates a vehicle
      */
     VehicleObject* createVehicle(const uint16_t id, const glm::vec3& pos,
-                                 const glm::quat& rot = glm::quat(),
+                                 const glm::quat& rot = glm::quat{1.0f,0.0f,0.0f,0.0f},
                                  GameObjectID gid = 0);
 
     /**
      * Creates a pedestrian.
      */
     CharacterObject* createPedestrian(const uint16_t id, const glm::vec3& pos,
-                                      const glm::quat& rot = glm::quat(),
+                                      const glm::quat& rot = glm::quat{1.0f,0.0f,0.0f,0.0f},
                                       GameObjectID gid = 0);
 
     /**
      * Creates a player
      */
     CharacterObject* createPlayer(const glm::vec3& pos,
-                                  const glm::quat& rot = glm::quat(),
+                                  const glm::quat& rot = glm::quat{1.0f,0.0f,0.0f,0.0f},
                                   GameObjectID gid = 0);
 
     /**

--- a/rwengine/src/engine/SaveGame.cpp
+++ b/rwengine/src/engine/SaveGame.cpp
@@ -26,6 +26,19 @@
 #include "script/ScriptMachine.hpp"
 #include "script/ScriptTypes.hpp"
 
+namespace {
+    constexpr int kNrOfWeapons = 13;
+    constexpr int kNrOfStoredCars = 18;
+    constexpr int kNrOfPickups = 336;
+    constexpr int kNrOfBlips = 32;
+    constexpr int kNrOfNavZones = 50;
+    constexpr int kNrOfDayNightInfo = 100;
+    constexpr int kNrOfMapZones = 25;
+    constexpr int kNrOfAudioZones = 36;
+    constexpr int kNrOfGangs = 9;
+    constexpr int kNrOfPedTypes = 23;
+}
+
 // Original save game file data structures
 typedef uint16_t BlockWord;
 typedef uint32_t BlockDword;
@@ -95,12 +108,12 @@ struct StructWeaponSlot {
 };
 struct StructPed {
     uint8_t unknown0_[52];
-    glm::vec3 position;
+    glm::vec3 position{};
     uint8_t unknown1[640];
     float health;
     float armour;
     uint8_t unknown2[148];
-    StructWeaponSlot weapons[13];
+    std::array<StructWeaponSlot, kNrOfWeapons> weapons;
     uint8_t unknown3[348];
 };
 
@@ -117,8 +130,8 @@ struct Block1PlayerPed {
 
 struct StructStoredCar {
     BlockDword modelId;
-    glm::vec3 position;
-    glm::vec3 rotation;
+    glm::vec3 position{};
+    glm::vec3 rotation{};
     BlockDword immunities;
     uint8_t colorFG;
     uint8_t colorBG;
@@ -173,8 +186,8 @@ struct StructGarage {
     float z2;
     float doorOpenStart;
     float doorOpenAngle;
-    glm::vec2 unknownCoord1;
-    glm::vec2 unknownCoord2;
+    glm::vec2 unknownCoord1{};
+    glm::vec2 unknownCoord2{};
     float doorAZ;
     float doorBZ;
     BlockDword unknown15;
@@ -210,12 +223,12 @@ struct Block2GarageData {
     BlockDword bfImportExportShoreside;
     BlockDword bfImportExportUnused;
     BlockDword GA_21lastTime;
-    StructStoredCar cars[18];
+    std::array<StructStoredCar, kNrOfStoredCars> cars;
 };
 
 struct Block3VehicleState {
     uint8_t unknown1[52];
-    glm::vec3 position;
+    glm::vec3 position{};
     uint8_t unknown2[1384];
 };
 
@@ -228,7 +241,7 @@ struct Block3Vehicle {
 
 struct Block3BoatState {
     uint8_t unknown1[52];
-    glm::vec3 position;
+    glm::vec3 position{};
     uint8_t unknown2[1092];
 };
 
@@ -242,7 +255,7 @@ struct Block3Boat {
 struct Block4Object {
     BlockWord modelId;
     BlockDword reference;
-    glm::vec3 position;
+    glm::vec3 position{};
     int8_t rotation[9];  /// @todo Confirm that this is: right, forward, down
     uint8_t unknown1[3];
     float unknown2;
@@ -264,7 +277,7 @@ struct Block6Crane {
     float y1Pickup;
     float x2Pickup;
     float y2Pickup;
-    glm::vec3 dropoff;
+    glm::vec3 dropoff{};
     float dropoffHeadingRads;
     float pickupArmRads;
     float dropoffArmRads;
@@ -275,8 +288,8 @@ struct Block6Crane {
     float armCurrentRads;
     float armCurrentDistance;
     float armCurrentHeight;
-    glm::vec3 hookInitialPosition;
-    glm::vec3 hookCurrentPosition;
+    glm::vec3 hookInitialPosition{};
+    glm::vec3 hookCurrentPosition{};
     float unknown1[2];
     BlockDword vehiclePtr;
     BlockDword gameTime;
@@ -304,11 +317,11 @@ struct Block7Pickup {
     BlockDword regenTime;
     BlockWord modelId;
     BlockWord flags;
-    glm::vec3 position;
+    glm::vec3 position{};
 };
 
 struct Block7Data {
-    Block7Pickup pickups[336];
+    std::array<Block7Pickup, kNrOfPickups> pickups;
     BlockWord pickupIndex;
     uint8_t align[2];
     BlockWord collectedPickups[20];
@@ -320,7 +333,7 @@ struct Block8Data {
 };
 
 struct Block8Phone {
-    glm::vec3 position;
+    glm::vec3 position{};
     BlockDword messagePtr[6];
     BlockDword messageEndTime;
     BlockDword staticIndex;
@@ -330,7 +343,7 @@ struct Block8Phone {
 };
 
 struct Block9Restart {
-    glm::vec3 position;
+    glm::vec3 position{};
     float angle;
 };
 
@@ -354,7 +367,7 @@ struct Block10Blip {
     BlockDword entityHandle;
     float unknown1;
     float unknown2;
-    glm::vec3 position;
+    glm::vec3 position{};
     BlockWord unknown3;
     uint8_t brightness;
     uint8_t unknown4;
@@ -366,13 +379,13 @@ struct Block10Blip {
 };
 
 struct Block10Data {
-    Block10Blip blips[32];
+    std::array<Block10Blip, kNrOfBlips> blips;
 };
 
 struct Block11Zone {
     char name[8];
-    glm::vec3 coordA;
-    glm::vec3 coordB;
+    glm::vec3 coordA{};
+    glm::vec3 coordB{};
     BlockDword type;
     BlockDword level;
     BlockWord dayZoneInfo;
@@ -398,12 +411,12 @@ struct Block11Data {
     BlockDword currentLevel;
     BlockWord findIndex;
     BlockWord align;
-    Block11Zone navZones[50];
-    Block11ZoneInfo dayNightInfo[100];
+    std::array<Block11Zone, kNrOfNavZones> navZones;
+    std::array<Block11ZoneInfo, kNrOfDayNightInfo> dayNightInfo;
     BlockWord numNavZones;
     BlockWord numZoneInfos;
-    Block11Zone mapZones[25];
-    Block11AudioZone audioZones[36];
+    std::array<Block11Zone, kNrOfMapZones> mapZones;
+    std::array<Block11AudioZone, kNrOfAudioZones> audioZones;
     BlockWord numMapZones;
     BlockWord numAudioZones;
 };
@@ -417,12 +430,12 @@ struct Block12Gang {
 };
 
 struct Block12Data {
-    Block12Gang gangs[9];
+    std::array<Block12Gang, kNrOfGangs> gangs;
 };
 
 struct Block13CarGenerator {
     BlockDword modelId;
-    glm::vec3 position;
+    glm::vec3 position{};
     float angle;
     BlockWord colourFG;
     BlockWord colourBG;
@@ -462,7 +475,7 @@ struct Block15AudioObject {
     BlockDword index;
     BlockWord soundIndex;
     uint8_t align[2];
-    glm::vec3 position;
+    glm::vec3 position{};
     BlockDword unknown1;
 };
 
@@ -481,7 +494,7 @@ struct Block19PedType {
     BlockDword avoidflags_;
 };
 struct Block19Data {
-    Block19PedType types[23];
+    std::array<Block19PedType, kNrOfPedTypes> types;
 };
 
 void SaveGame::writeGame(GameState& state, const std::string& file) {
@@ -595,8 +608,7 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
         std::cout << "Player Health: " << ped.info.health << " ("
                   << ped.info.armour << ")" << std::endl;
         std::cout << "Player model: " << ped.modelName << std::endl;
-        for (int w = 0; w < 13; ++w) {
-            auto& wep = players[p].info.weapons[w];
+        for (const auto &wep : players[p].info.weapons) {
             std::cout << "ID " << wep.weaponId << " " << wep.inClip << " "
                       << wep.totalBullets << std::endl;
         }
@@ -636,8 +648,7 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
     std::cout << "Shoreside IE: " << garageData.bfImportExportShoreside
               << std::endl;
     std::cout << "GA21 last shown: " << garageData.GA_21lastTime << std::endl;
-    for (int c = 0; c < 18; ++c) {
-        StructStoredCar& car = garageData.cars[c];
+    for (const auto &car : garageData.cars) {
         if (car.modelId == 0) continue;
         std::cout << " " << car.modelId << " " << uint16_t(car.colorFG) << "/"
                   << uint16_t(car.colorBG) << " " << car.immunities
@@ -796,11 +807,10 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
     READ_VALUE(pickupData);
 
 #if RW_DEBUG
-    for (int c = 0; c < 336; ++c) {
-        Block7Pickup& p = pickupData.pickups[c];
-        if (p.type == 0) continue;
-        std::cout << " " << uint16_t(p.type) << " " << p.position.x << " "
-                  << p.position.y << " " << p.position.z << std::endl;
+    for (const auto &pickup : pickupData.pickups) {
+        if (pickup.type == 0) continue;
+        std::cout << " " << uint16_t(pickup.type) << " " << pickup.position.x << " "
+                  << pickup.position.y << " " << pickup.position.z << std::endl;
     }
 #endif
 
@@ -866,11 +876,10 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
     READ_VALUE(radarData);
 
 #if RW_DEBUG
-    for (int b = 0; b < 32; ++b) {
-        Block10Blip& p = radarData.blips[b];
-        if (p.type == 0) continue;
-        std::cout << " " << p.position.x << " " << p.position.y << " "
-                  << p.position.z << std::endl;
+    for (const auto &blip : radarData.blips) {
+        if (blip.type == 0) continue;
+        std::cout << " " << blip.position.x << " " << blip.position.y << " "
+                  << blip.position.z << std::endl;
     }
 #endif
 
@@ -887,8 +896,7 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
     READ_VALUE(zoneData.currentLevel);
     READ_VALUE(zoneData.findIndex);
     READ_VALUE(zoneData.align);
-    for (int z = 0; z < 50; z++) {
-        Block11Zone& zone = zoneData.navZones[z];
+    for (auto &zone : zoneData.navZones) {
         READ_VALUE(zone.name);
         READ_VALUE(zone.coordA);
         READ_VALUE(zone.coordB);
@@ -900,8 +908,7 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
         READ_VALUE(zone.parentZone);
         READ_VALUE(zone.siblingZone);
     }
-    for (int z = 0; z < 100; z++) {
-        Block11ZoneInfo& info = zoneData.dayNightInfo[z];
+    for (auto &info : zoneData.dayNightInfo) {
         READ_VALUE(info.density)
         READ_VALUE(info.unknown1)
         READ_VALUE(info.peddensity)
@@ -911,8 +918,7 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
     }
     READ_VALUE(zoneData.numNavZones);
     READ_VALUE(zoneData.numZoneInfos);
-    for (int z = 0; z < 25; z++) {
-        Block11Zone& zone = zoneData.mapZones[z];
+    for (auto &zone : zoneData.mapZones) {
         READ_VALUE(zone.name);
         READ_VALUE(zone.coordA);
         READ_VALUE(zone.coordB);
@@ -924,8 +930,8 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
         READ_VALUE(zone.parentZone);
         READ_VALUE(zone.siblingZone);
     }
-    for (int z = 0; z < 36; z++) {
-        READ_VALUE(zoneData.audioZones[z]);
+    for (auto &audioZone : zoneData.audioZones) {
+        READ_VALUE(audioZone);
     }
     READ_VALUE(zoneData.numMapZones);
     READ_VALUE(zoneData.numAudioZones);
@@ -1008,10 +1014,9 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
     READ_VALUE(gangData);
 
 #if RW_DEBUG
-    for (int g = 0; g < 9; ++g) {
-        Block12Gang& p = gangData.gangs[g];
-        std::cout << " " << p.carModelId << " " << p.weaponPrimary << " "
-                  << p.weaponSecondary << std::endl;
+    for (const auto &gang : gangData.gangs) {
+        std::cout << " " << gang.carModelId << " " << gang.weaponPrimary << " "
+                  << gang.weaponSecondary << std::endl;
     }
 #endif
 
@@ -1203,15 +1208,15 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
     READ_VALUE(pedTypeData);
 
 #if RW_DEBUG
-    for (int i = 0; i < 23; ++i) {
-        printf("%08x: %f %f %f %f %f threat %08x avoid %08x\n", pedTypeData.types[i].bitstring_,
-               pedTypeData.types[i].unknown2,
-               pedTypeData.types[i].unknown3,
-               pedTypeData.types[i].unknown4,
-               pedTypeData.types[i].fleedistance,
-               pedTypeData.types[i].headingchangerate,
-               pedTypeData.types[i].threatflags_,
-               pedTypeData.types[i].avoidflags_);
+    for (const auto &type : pedTypeData.types) {
+        printf("%08x: %f %f %f %f %f threat %08x avoid %08x\n", type.bitstring_,
+               type.unknown2,
+               type.unknown3,
+               type.unknown4,
+               type.fleedistance,
+               type.headingchangerate,
+               type.threatflags_,
+               type.avoidflags_);
     }
 #endif
 
@@ -1251,7 +1256,7 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
         cs.armour = players[0].info.armour;
         state.playerObject = player->getGameObjectID();
         state.maxWantedLevel = players[0].maxWantedLevel;
-        for (int w = 0; w < 13; ++w) {
+        for (int w = 0; w < kNrOfWeapons; ++w) {
             auto& wep = ply.info.weapons[w];
             cs.weapons[w].weaponId = wep.weaponId;
             cs.weapons[w].bulletsClip = wep.inClip;
@@ -1267,9 +1272,9 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
              (int)g, glm::vec3(garage.x1, garage.y1, garage.z1),
              glm::vec3(garage.x2, garage.y2, garage.z2), garage.type);
     }
-    for (int c = 0; c < 18; ++c) {
-        if (garageData.cars[c].modelId == 0) continue;
-        auto& car = garageData.cars[c];
+    for (auto &c : garageData.cars) {
+        if (c.modelId == 0) continue;
+        auto& car = c;
         glm::quat rotation(
             glm::mat3(glm::cross(car.rotation, glm::vec3(0.f, 0.f, 1.f)),
                       car.rotation, glm::vec3(0.f, 0.f, 1.f)));

--- a/rwengine/src/engine/ScreenText.cpp
+++ b/rwengine/src/engine/ScreenText.cpp
@@ -8,13 +8,13 @@ void ScreenText::tick(float dt) {
     // Remove all the immedate text
     m_textQueues[static_cast<size_t>(ScreenTextType::Immediate)].clear();
 
-    for (unsigned int t = 0; t < m_textQueues.size(); ++t) {
-        for (unsigned int i = 0; i < m_textQueues[t].size();) {
-            auto& big = m_textQueues[t][i];
+    for (auto &textQueue : m_textQueues) {
+        for (unsigned int i = 0; i < textQueue.size();) {
+            auto& big = textQueue[i];
 
             big.displayedMS += millis;
             if (big.displayedMS >= big.durationMS) {
-                m_textQueues[t].erase(m_textQueues[t].begin() + i);
+                textQueue.erase(textQueue.begin() + i);
             } else {
                 ++i;
             }

--- a/rwengine/src/engine/ScreenText.hpp
+++ b/rwengine/src/engine/ScreenText.hpp
@@ -37,15 +37,15 @@ struct ScreenTextEntry {
     /// After processing numbers
     GameString text;
     /// in the virtual 640x480 screen space
-    glm::vec2 position;
+    glm::vec2 position{};
     /// Font number
     int font;
     /// Font size
     int size;
     /// Background colour (or, if a == 0, shadow offset)
-    glm::u8vec4 colourBG;
+    glm::u8vec4 colourBG{};
     /// Foreground colour
-    glm::u8vec3 colourFG;
+    glm::u8vec3 colourFG{};
     /// Alignment (left = 0, center = 1, right = 2)
     unsigned char alignment;
     /// Onscreen duration

--- a/rwengine/src/loaders/LoaderIFP.cpp
+++ b/rwengine/src/loaders/LoaderIFP.cpp
@@ -48,9 +48,9 @@ AnimationKeyframe AnimationBone::getInterpolatedKeyframe(float time) {
 }
 
 AnimationKeyframe AnimationBone::getKeyframe(float time) {
-    for (size_t f = 0; f < frames.size(); ++f) {
-        if (time >= frames[f].starttime) {
-            return frames[f];
+    for (auto &frame : frames) {
+        if (time >= frame.starttime) {
+            return frame;
         }
     }
     return frames.back();

--- a/rwengine/src/loaders/LoaderIFP.hpp
+++ b/rwengine/src/loaders/LoaderIFP.hpp
@@ -13,9 +13,9 @@
 #include <rw/forward.hpp>
 
 struct AnimationKeyframe {
-    glm::quat rotation;
-    glm::vec3 position;
-    glm::vec3 scale;
+    glm::quat rotation{1.0f,0.0f,0.0f,0.0f};
+    glm::vec3 position{};
+    glm::vec3 scale{1.0f};
     float starttime = 0.f;
     int id = 0;
 

--- a/rwengine/src/loaders/WeatherLoader.cpp
+++ b/rwengine/src/loaders/WeatherLoader.cpp
@@ -47,9 +47,9 @@ bool WeatherLoader::load(const std::string& filename, Weather& outWeather) {
         weather.bottomCloudColor = readRGB(ss);
 
         int d;
-        for (size_t i = 0; i < 4; i++) {
+        for (auto &i : weather.unknown) {
             ss >> d;
-            weather.unknown[i] = d;
+            i = d;
         }
 
         outWeather.entries.push_back(weather);

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -120,7 +120,7 @@ void CharacterObject::destroyActor() {
 }
 
 glm::vec3 CharacterObject::updateMovementAnimation(float dt) {
-    glm::vec3 animTranslate;
+    glm::vec3 animTranslate{};
 
     if (motionBlockedByActivity) {
         // Clear any residual motion animation
@@ -521,16 +521,16 @@ void CharacterObject::resetToAINode() {
     bool vehicleNode = !!getCurrentVehicle();
     AIGraphNode* nearest = nullptr;
     float d = std::numeric_limits<float>::max();
-    for (auto it = nodes.begin(); it != nodes.end(); ++it) {
+    for (const auto &node : nodes) {
         if (vehicleNode) {
-            if ((*it)->type == AIGraphNode::Pedestrian) continue;
+            if (node->type == AIGraphNode::Pedestrian) continue;
         } else {
-            if ((*it)->type == AIGraphNode::Vehicle) continue;
+            if (node->type == AIGraphNode::Vehicle) continue;
         }
 
-        float dist = glm::length((*it)->position - getPosition());
+        float dist = glm::length(node->position - getPosition());
         if (dist < d) {
-            nearest = *it;
+            nearest = node;
             d = dist;
         }
     }

--- a/rwengine/src/objects/CharacterObject.hpp
+++ b/rwengine/src/objects/CharacterObject.hpp
@@ -61,8 +61,8 @@ private:
     void createActor(const glm::vec2& size = glm::vec2(0.45f, 1.2f));
     void destroyActor();
 
-    glm::vec3 movement;
-    glm::vec2 m_look;
+    glm::vec3 movement{};
+    glm::vec2 m_look{};
 
     bool running;
     bool jumped;
@@ -71,7 +71,7 @@ private:
     bool motionBlockedByActivity;
 
     glm::vec3 updateMovementAnimation(float dt);
-    glm::vec3 currenteMovementStep;
+    glm::vec3 currenteMovementStep{};
 
     AnimCycle cycle_;
 

--- a/rwengine/src/objects/GameObject.hpp
+++ b/rwengine/src/objects/GameObject.hpp
@@ -161,12 +161,12 @@ public:
         /**
          * World position of damage
          */
-        glm::vec3 damageLocation;
+        glm::vec3 damageLocation{};
 
         /**
          * World position of the source (used for direction)
          */
-        glm::vec3 damageSource;
+        glm::vec3 damageSource{};
 
         /**
          * Magnitude of destruction
@@ -209,7 +209,7 @@ public:
     }
 
     glm::mat4 getTimeAdjustedTransform(float alpha) const {
-        glm::mat4 t;
+        glm::mat4 t{1.0f};
         t = glm::translate(t, glm::mix(_lastPosition, getPosition(), alpha));
         t = t * glm::mat4_cast(glm::slerp(_lastRotation, getRotation(), alpha));
         return t;

--- a/rwengine/src/objects/PickupObject.cpp
+++ b/rwengine/src/objects/PickupObject.cpp
@@ -84,7 +84,7 @@ uint32_t PickupObject::behaviourFlags(PickupType type) {
 
 PickupObject::PickupObject(GameWorld* world, const glm::vec3& position,
                            BaseModelInfo* modelinfo, PickupType type)
-    : GameObject(world, position, glm::quat(), modelinfo)
+    : GameObject(world, position, glm::quat{1.0f,0.0f,0.0f,0.0f}, modelinfo)
     , m_ghost(nullptr)
     , m_shape(nullptr)
     , m_enabled(false)

--- a/rwengine/src/objects/ProjectileObject.cpp
+++ b/rwengine/src/objects/ProjectileObject.cpp
@@ -113,7 +113,7 @@ void ProjectileObject::cleanup() {
 
 ProjectileObject::ProjectileObject(GameWorld* world, const glm::vec3& position,
                                    const ProjectileObject::ProjectileInfo& info)
-    : GameObject(world, position, glm::quat(), nullptr)
+    : GameObject(world, position, glm::quat{1.0f,0.0f,0.0f,0.0f}, nullptr)
     , _info(info)
     , _body(nullptr)
     , _ghostBody(nullptr)

--- a/rwengine/src/objects/ProjectileObject.hpp
+++ b/rwengine/src/objects/ProjectileObject.hpp
@@ -24,7 +24,7 @@ public:
 
     struct ProjectileInfo {
         ProjectileType type;
-        glm::vec3 direction;
+        glm::vec3 direction{};
         float velocity;
 
         /** Time to dentonation or removal */

--- a/rwengine/src/objects/VehicleInfo.hpp
+++ b/rwengine/src/objects/VehicleInfo.hpp
@@ -19,8 +19,8 @@ struct VehicleHandlingInfo {
 
     std::string ID;
     float mass;
-    glm::vec3 dimensions;
-    glm::vec3 centerOfMass;
+    glm::vec3 dimensions{};
+    glm::vec3 centerOfMass{};
     float percentSubmerged;
     float tractionMulti;
     float tractionLoss;
@@ -65,11 +65,11 @@ struct VehicleHandlingInfo {
 };
 
 struct WheelInfo {
-    glm::vec3 position;
+    glm::vec3 position{};
 };
 
 struct SeatInfo {
-    glm::vec3 offset;
+    glm::vec3 offset{};
 };
 
 /**

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -351,7 +351,7 @@ void VehicleObject::tickPhysics(float dt) {
         for (auto& seat : seatOccupants) {
             auto character = static_cast<CharacterObject*>(seat.second);
 
-            glm::vec3 passPosition;
+            glm::vec3 passPosition{};
             if (character->isEnteringOrExitingVehicle()) {
                 passPosition = getSeatEntryPositionWorld(seat.first);
             } else {

--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -328,7 +328,7 @@ void GameRenderer::renderWorld(GameWorld* world, const ViewCamera& camera,
             continue;
         }
 
-        glm::mat4 model;
+        glm::mat4 model{1.0f};
 
         if (blip.second.target > 0) {
             auto object = world->getBlipTarget(blip.second);
@@ -390,7 +390,7 @@ void GameRenderer::renderWorld(GameWorld* world, const ViewCamera& camera,
     renderer->setUniform(skyProg.get(), "BottomColor",
                          glm::vec4{weather.skyBottomColor, 1.f});
 
-    renderer->draw(glm::mat4(), &skyDbuff, dp);
+    renderer->draw(glm::mat4(1.0f), &skyDbuff, dp);
 
     profSky = renderer->popDebugGroup();
 
@@ -471,7 +471,7 @@ void GameRenderer::renderPostProcess() {
     wdp.count = ssRectGeom.getCount();
     wdp.textures = {fbTextures[0]};
 
-    renderer->drawArrays(glm::mat4(), &ssRectDraw, wdp);
+    renderer->drawArrays(glm::mat4(1.0f), &ssRectDraw, wdp);
 }
 
 void GameRenderer::renderEffects(GameWorld* world) {

--- a/rwengine/src/render/MapRenderer.cpp
+++ b/rwengine/src/render/MapRenderer.cpp
@@ -88,9 +88,9 @@ void MapRenderer::draw(GameWorld* world, const MapInfo& mi) {
     float worldScale = mi.screenSize / mi.worldSize;
 
     auto proj = renderer->get2DProjection();
-    glm::mat4 view, model;
+    glm::mat4 view{1.0f}, model{1.0f};
     renderer->setUniform(rectProg.get(), "proj", proj);
-    renderer->setUniform(rectProg.get(), "model", glm::mat4());
+    renderer->setUniform(rectProg.get(), "model", glm::mat4(1.0f));
     renderer->setUniform(rectProg.get(), "colour", glm::vec4(0.f, 0.f, 0.f, 1.f));
 
     view = glm::translate(view, glm::vec3(mi.screenPosition, 0.f));
@@ -104,7 +104,7 @@ void MapRenderer::draw(GameWorld* world, const MapInfo& mi) {
         glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
         glStencilMask(0xFF);
         glColorMask(0x00, 0x00, 0x00, 0x00);
-        renderer->drawArrays(glm::mat4(), &circle, dp);
+        renderer->drawArrays(glm::mat4(1.0f), &circle, dp);
         glColorMask(0xFF, 0xFF, 0xFF, 0xFF);
         glStencilFunc(GL_EQUAL, 1, 0xFF);
     }
@@ -140,11 +140,11 @@ void MapRenderer::draw(GameWorld* world, const MapInfo& mi) {
 
         renderer->setUniform(rectProg.get(), "model", tilemodel);
 
-        renderer->drawArrays(glm::mat4(), &rect, dp);
+        renderer->drawArrays(glm::mat4(1.0f), &rect, dp);
     }
 
     // From here on out we will work in screenspace
-    renderer->setUniform(rectProg.get(), "view", glm::mat4());
+    renderer->setUniform(rectProg.get(), "view", glm::mat4(1.0f));
 
     if (mi.clipToSize) {
         glDisable(GL_STENCIL_TEST);
@@ -154,11 +154,11 @@ void MapRenderer::draw(GameWorld* world, const MapInfo& mi) {
             data->findSlotTexture("hud", "radardisc");
         dp.textures = {radarDisc->getName()};
 
-        glm::mat4 model;
+        glm::mat4 model{1.0f};
         model = glm::translate(model, glm::vec3(mi.screenPosition, 0.0f));
         model = glm::scale(model, glm::vec3(mi.screenSize * 1.07f));
         renderer->setUniform(rectProg.get(), "model", model);
-        renderer->drawArrays(glm::mat4(), &rect, dp);
+        renderer->drawArrays(glm::mat4(1.0f), &rect, dp);
         glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE,
                             GL_ZERO);
     }
@@ -256,7 +256,7 @@ void MapRenderer::prepareBlip(const glm::vec2& coord, const glm::mat4& view,
 
     glm::vec3 viewPos(
         view * glm::vec4(glm::vec2(1.f, -1.f) * adjustedCoord, 0.f, 1.f));
-    glm::mat4 model;
+    glm::mat4 model{1.0f};
     model = glm::translate(model, viewPos);
     model = glm::scale(model, glm::vec3(size));
     model = glm::rotate(model, heading, glm::vec3(0.f, 0.f, 1.f));

--- a/rwengine/src/render/MapRenderer.hpp
+++ b/rwengine/src/render/MapRenderer.hpp
@@ -23,14 +23,14 @@ class MapRenderer {
 public:
     struct MapInfo {
         /// World coordinate center
-        glm::vec2 worldCenter;
+        glm::vec2 worldCenter{};
         /// World units to fit on the map
         float worldSize;
 
         /// yaw of the map
         float rotation = 0.f;
 
-        glm::vec2 screenPosition;
+        glm::vec2 screenPosition{};
         float screenSize;
         /// Make the map circular, or don't.
         bool clipToSize = true;

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -204,7 +204,7 @@ void ObjectRenderer::renderInstance(InstanceObject* instance,
     }
 
     // Render the atomic the instance thinks it should be
-    renderAtomic(atomic.get(), glm::mat4(), instance, outList);
+    renderAtomic(atomic.get(), glm::mat4(1.0f), instance, outList);
 }
 
 void ObjectRenderer::renderCharacter(CharacterObject* pedestrian,
@@ -229,7 +229,7 @@ void ObjectRenderer::renderCharacter(CharacterObject* pedestrian,
         }
     }
 
-    renderClump(pedestrian->getClump().get(), glm::mat4(), nullptr, outList);
+    renderClump(pedestrian->getClump().get(), glm::mat4(1.0f), nullptr, outList);
 
     auto item = pedestrian->getActiveItem();
     const auto& weapon = pedestrian->engine->data->weaponData[item];
@@ -268,7 +268,7 @@ void ObjectRenderer::renderVehicle(VehicleObject* vehicle,
         vehicle->getLowLOD()->setFlag(Atomic::ATOMIC_RENDER, !highLOD);
     }
 
-    renderClump(clump.get(), glm::mat4(), vehicle, outList);
+    renderClump(clump.get(), glm::mat4(1.0f), vehicle, outList);
 
     auto modelinfo = vehicle->getVehicle();
     auto woi =
@@ -295,7 +295,7 @@ void ObjectRenderer::renderVehicle(VehicleObject* vehicle,
             btMatrix3x3(steerQ) * btMatrix3x3(rollQ) * basis,
             wi.m_chassisConnectionPointCS +
                 wi.m_wheelDirectionCS * wi.m_raycastInfo.m_suspensionLength);
-        glm::mat4 wheelM;
+        glm::mat4 wheelM{1.0f};
         t.getOpenGLMatrix(glm::value_ptr(wheelM));
         wheelM = clump->getFrame()->getWorldTransform() * wheelM;
         wheelM = glm::scale(wheelM, glm::vec3(modelinfo->wheelscale_));
@@ -310,7 +310,7 @@ void ObjectRenderer::renderVehicle(VehicleObject* vehicle,
 void ObjectRenderer::renderPickup(PickupObject* pickup, RenderList& outList) {
     if (!pickup->isEnabled()) return;
 
-    glm::mat4 modelMatrix = glm::translate(glm::mat4(), pickup->getPosition());
+    glm::mat4 modelMatrix = glm::translate(glm::mat4(1.0f), pickup->getPosition());
     modelMatrix = glm::rotate(modelMatrix, m_world->getGameTime(),
                               glm::vec3(0.f, 0.f, 1.f));
 
@@ -328,7 +328,7 @@ void ObjectRenderer::renderCutsceneObject(CutsceneObject* cutscene,
 
     auto cutsceneOffset = m_world->state->currentCutscene->meta.sceneOffset +
                           glm::vec3(0.f, 0.f, 1.f);
-    glm::mat4 cutscenespace;
+    glm::mat4 cutscenespace{1.0f};
 
     cutscenespace = glm::translate(cutscenespace, cutsceneOffset);
     if (cutscene->getParentActor()) {

--- a/rwengine/src/render/OpenGLRenderer.hpp
+++ b/rwengine/src/render/OpenGLRenderer.hpp
@@ -23,7 +23,7 @@ typedef uint64_t RenderKey;
 typedef std::uint32_t RenderIndex;
 
 struct VertexP2 {
-    glm::vec2 position;
+    glm::vec2 position{};
 
     static const AttributeList vertex_attributes() {
         return {{ATRS_Position, 2, sizeof(VertexP2), 0ul}};
@@ -39,7 +39,7 @@ struct VertexP2 {
 
 
 struct VertexP3 {
-    glm::vec3 position;
+    glm::vec3 position{};
 
     static const AttributeList vertex_attributes() {
         return {
@@ -80,7 +80,7 @@ public:
         // Depth writing state
         bool depthWrite;
         /// Material
-        glm::u8vec4 colour;
+        glm::u8vec4 colour{};
         /// Material
         float ambient;
         /// Material
@@ -120,20 +120,20 @@ public:
     typedef std::vector<RenderInstruction> RenderList;
 
     struct ObjectUniformData {
-        glm::mat4 model;
-        glm::vec4 colour;
+        glm::mat4 model{1.0f};
+        glm::vec4 colour{1.0f};
         float diffuse;
         float ambient;
         float visibility;
     };
 
     struct SceneUniformData {
-        glm::mat4 projection;
-        glm::mat4 view;
-        glm::vec4 ambient;
-        glm::vec4 dynamic;
-        glm::vec4 fogColour;
-        glm::vec4 campos;
+        glm::mat4 projection{1.0f};
+        glm::mat4 view{1.0f};
+        glm::vec4 ambient{};
+        glm::vec4 dynamic{};
+        glm::vec4 fogColour{};
+        glm::vec4 campos{};
         float fogStart;
         float fogEnd;
     };
@@ -234,8 +234,8 @@ public:
     virtual const ProfileInfo& popDebugGroup() = 0;
 
 private:
-    glm::ivec2 viewport;
-    glm::mat4 projection2D;
+    glm::ivec2 viewport{};
+    glm::mat4 projection2D{1.0f};
 
 protected:
     int drawCounter;

--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -91,9 +91,7 @@ TextRenderer::TextRenderer(GameRenderer* renderer) : renderer(renderer) {
     textShader = renderer->getRenderer()->createShader(TextVertexShader,
                                                        TextFragmentShader);
 
-    for (int g = 0; g < GAME_GLYPHS; g++) {
-        glyphData[g] = {.9f};
-    }
+    std::fill(glyphData.begin(), glyphData.end(), GlyphInfo{.9f});
 
     glyphData[charToIndex(' ')].widthFrac = 0.4f;
     glyphData[charToIndex('-')].widthFrac = 0.5f;
@@ -304,7 +302,7 @@ void TextRenderer::renderText(const TextRenderer::TextInfo& ti,
     dp.textures = {ftexture->getName()};
     dp.depthWrite = false;
 
-    renderer->getRenderer()->drawArrays(glm::mat4(), &db, dp);
+    renderer->getRenderer()->drawArrays(glm::mat4(1.0f), &db, dp);
 
     renderer->getRenderer()->popDebugGroup();
 }

--- a/rwengine/src/render/TextRenderer.hpp
+++ b/rwengine/src/render/TextRenderer.hpp
@@ -35,13 +35,13 @@ public:
         /// Message to be displayed (including markup)
         GameString text;
         /// On screen position
-        glm::vec2 screenPosition;
+        glm::vec2 screenPosition{};
         /// font size
         float size;
         /// Base colour
-        glm::u8vec3 baseColour;
+        glm::u8vec3 baseColour{};
         /// Background colour
-        glm::u8vec4 backgroundColour;
+        glm::u8vec4 backgroundColour{};
         /// Horizontal Alignment
         TextAlignemnt align;
         /// Wrap width
@@ -66,7 +66,7 @@ public:
 
 private:
     std::string fonts[GAME_FONTS];
-    GlyphInfo glyphData[GAME_GLYPHS];
+    std::array<GlyphInfo, GAME_GLYPHS> glyphData;
 
     GameRenderer* renderer;
     std::unique_ptr<Renderer::ShaderProgram> textShader;

--- a/rwengine/src/render/ViewCamera.hpp
+++ b/rwengine/src/render/ViewCamera.hpp
@@ -11,7 +11,8 @@ public:
     glm::vec3 position;
     glm::quat rotation;
 
-    ViewCamera(const glm::vec3& pos = {}, const glm::quat& rot = {})
+    ViewCamera(const glm::vec3& pos = {},
+	       const glm::quat& rot = {1.0f,0.0f,0.0f,0.0f})
         : frustum({0.1f, 5000.f, glm::radians(45.f), 1.f})
         , position(pos)
         , rotation(rot) {

--- a/rwengine/src/render/ViewFrustum.hpp
+++ b/rwengine/src/render/ViewFrustum.hpp
@@ -12,8 +12,8 @@ class ViewFrustum {
 public:
     class ViewPlane {
     public:
-        glm::vec3 normal;
-        float distance;
+	glm::vec3 normal{};
+        float distance{};
     };
 
     float near;
@@ -50,8 +50,8 @@ public:
         float d;
         bool result = true;
 
-        for (size_t i = 0; i < 6; ++i) {
-            d = glm::dot(planes[i].normal, center) + planes[i].distance;
+        for (const auto &plane : planes) {
+            d = glm::dot(plane.normal, center) + plane.distance;
             if (d < -radius) result = false;
         }
 

--- a/rwengine/src/render/VisualFX.cpp
+++ b/rwengine/src/render/VisualFX.cpp
@@ -40,7 +40,7 @@ VisualFX::~VisualFX() {
 }
 
 const glm::vec3& VisualFX::getPosition() const {
-    static glm::vec3 errorRef;
+    static glm::vec3 errorRef{};
     switch (type) {
         case VisualFX::Particle:
             return particle.position;

--- a/rwengine/src/render/VisualFX.hpp
+++ b/rwengine/src/render/VisualFX.hpp
@@ -17,10 +17,10 @@ public:
     };
     struct ParticleData {
         /** Initial world position */
-        glm::vec3 position;
+        glm::vec3 position{};
 
         /** Direction of particle */
-        glm::vec3 direction;
+        glm::vec3 direction{};
 
         /** Particle orientation modes */
         enum Orientation {

--- a/rwengine/src/script/SCMFile.cpp
+++ b/rwengine/src/script/SCMFile.cpp
@@ -26,8 +26,8 @@ void SCMFile::loadFile(char *data, unsigned int size) {
     int i = modelSectionOffset + sizeof(uint32_t);
     for (unsigned int m = 0; m < model_count; ++m) {
         char model_name[24];
-        for (size_t c = 0; c < 24; ++c) {
-            model_name[c] = read<char>(i++);
+        for (char &c : model_name) {
+            c = read<char>(i++);
         }
         models.push_back(model_name);
     }

--- a/rwgame/MenuSystem.hpp
+++ b/rwgame/MenuSystem.hpp
@@ -99,7 +99,7 @@ public:
      */
     int activeEntry;
 
-    glm::vec2 offset;
+    glm::vec2 offset{};
 
     void draw(GameRenderer* r) {
         glm::vec2 basis(offset);
@@ -126,9 +126,9 @@ public:
 
     void click(const float x, const float y) {
         glm::vec2 c(x - offset.x, y - offset.y);
-        for (auto it = entries.begin(); it != entries.end(); ++it) {
+        for (auto &entry : entries) {
             if (c.y > 0.f && c.y < size) {
-                (*it).activate(c.x, c.y);
+                entry.activate(c.x, c.y);
                 return;
             } else {
                 c.y -= size;

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -683,8 +683,7 @@ void RWGame::renderDebugPaths(float time) {
     }
 
     // Draw Garage bounds
-    for (size_t g = 0; g < state.garages.size(); ++g) {
-        auto& garage = state.garages[g];
+    for (const auto &garage : state.garages) {
         btVector3 minColor(1.f, 0.f, 0.f);
         btVector3 maxColor(0.f, 1.f, 0.f);
         btVector3 min(garage.min.x, garage.min.y, garage.min.z);
@@ -699,8 +698,7 @@ void RWGame::renderDebugPaths(float time) {
     }
 
     // Draw vehicle generators
-    for (size_t v = 0; v < state.vehicleGenerators.size(); ++v) {
-        auto& generator = state.vehicleGenerators[v];
+    for (const auto &generator : state.vehicleGenerators) {
         btVector3 color(1.f, 0.f, 0.f);
         btVector3 position(generator.position.x, generator.position.y,
                            generator.position.z);

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -43,7 +43,7 @@ class RWGame : public GameBase {
     };
 
     DebugViewMode debugview_ = DebugViewMode::Disabled;
-    int lastDraws;  /// Number of draws issued for the last frame.
+    int lastDraws{};  /// Number of draws issued for the last frame.
 
     std::string cheatInputWindow = std::string(32, ' ');
 

--- a/rwgame/states/BenchmarkState.cpp
+++ b/rwgame/states/BenchmarkState.cpp
@@ -24,7 +24,7 @@ void BenchmarkState::enter() {
     game->getWorld()->state->basic.gameMinute = clockMinute;
 
     float time = 0.f;
-    glm::vec3 tmpPos;
+    glm::vec3 tmpPos{};
     while (benchstream) {
         TrackPoint point;
         benchstream >> point.time;

--- a/rwgame/states/BenchmarkState.hpp
+++ b/rwgame/states/BenchmarkState.hpp
@@ -6,8 +6,8 @@
 class BenchmarkState : public State {
     struct TrackPoint {
         float time;
-        glm::vec3 position;
-        glm::quat angle;
+        glm::vec3 position{};
+        glm::quat angle{1.0f,0.0f,0.0f,0.0f};
     };
     std::vector<TrackPoint> track;
 

--- a/rwgame/states/DebugState.cpp
+++ b/rwgame/states/DebugState.cpp
@@ -352,7 +352,7 @@ void DebugState::spawnFollower(unsigned int id) {
 
     glm::vec3 fwd = ch->rotation * glm::vec3(0.f, 1.f, 0.f);
 
-    glm::vec3 hit, normal;
+    glm::vec3 hit{}, normal{};
     if (game->hitWorldRay(ch->position + (fwd * 10.f), {0.f, 0.f, -2.f}, hit,
                           normal)) {
         auto spawnPos = hit + normal;

--- a/rwgame/states/DebugState.hpp
+++ b/rwgame/states/DebugState.hpp
@@ -5,8 +5,8 @@
 
 class DebugState : public State {
     ViewCamera _debugCam;
-    glm::vec3 _movement;
-    glm::vec2 _debugLook;
+    glm::vec3 _movement{};
+    glm::vec2 _debugLook{};
     bool _freeLook = false;
     bool _sonicMode = false;
     bool _invertedY;
@@ -19,7 +19,7 @@ class DebugState : public State {
 
 public:
     DebugState(RWGame* game, const glm::vec3& vp = {},
-               const glm::quat& vd = {});
+               const glm::quat& vd = {1.0f,0.0f,0.0f,0.0f});
 
     void enter() override;
 

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -193,7 +193,7 @@ void IngameState::tick(float dt) {
             }
         }
 
-        glm::vec3 movement;
+        glm::vec3 movement{};
         movement.x = input(GameInputState::GoForward) -
                      input(GameInputState::GoBackwards),
         movement.y =

--- a/rwgame/states/IngameState.hpp
+++ b/rwgame/states/IngameState.hpp
@@ -20,13 +20,13 @@ class IngameState : public State {
     std::string save;
     bool newgame;
     ViewCamera _look;
-    glm::vec3 cameraPosition;
+    glm::vec3 cameraPosition{};
     /** Timer to hold user camera position */
     float autolookTimer;
     CameraMode camMode;
 
     /// Player camera input since the last update
-    glm::vec2 cameradelta_;
+    glm::vec2 cameradelta_{};
     /// Invert Y axis movement
     bool m_invertedY;
     /// Free look in vehicles.

--- a/rwlib/source/data/Clump.cpp
+++ b/rwlib/source/data/Clump.cpp
@@ -23,7 +23,7 @@ ModelFrame::ModelFrame(unsigned int index, glm::mat3 dR, glm::vec3 dT)
 }
 
 void ModelFrame::reset() {
-    matrix = glm::translate(glm::mat4(), defaultTranslation) *
+    matrix = glm::translate(glm::mat4(1.0f), defaultTranslation) *
              glm::mat4(defaultRotation);
     updateHierarchyTransform();
 }

--- a/rwlib/source/data/Clump.hpp
+++ b/rwlib/source/data/Clump.hpp
@@ -22,14 +22,14 @@ class ModelFrame {
     unsigned int index;
     glm::mat3 defaultRotation;
     glm::vec3 defaultTranslation;
-    glm::mat4 matrix;
-    glm::mat4 worldtransform_;
+    glm::mat4 matrix{1.0f};
+    glm::mat4 worldtransform_{1.0f};
     ModelFrame* parent_;
     std::string name;
     std::vector<ModelFramePtr> children_;
 
 public:
-    ModelFrame(unsigned int index = 0, glm::mat3 dR = glm::mat3(),
+    ModelFrame(unsigned int index = 0, glm::mat3 dR = glm::mat3{1.0f},
                glm::vec3 dT = glm::vec3());
 
     void reset();
@@ -114,10 +114,10 @@ struct SubGeometry {
 };
 
 struct GeometryVertex {
-    glm::vec3 position; /* 0 */
-    glm::vec3 normal;   /* 24 */
-    glm::vec2 texcoord; /* 48 */
-    glm::u8vec4 colour; /* 64 */
+    glm::vec3 position{}; /* 0 */
+    glm::vec3 normal{};   /* 24 */
+    glm::vec2 texcoord{}; /* 48 */
+    glm::u8vec4 colour{}; /* 64 */
 
     /** @see GeometryBuffer */
     static const AttributeList vertex_attributes() {
@@ -155,7 +155,7 @@ struct Geometry {
 
     struct Material {
         std::vector<Texture> textures;
-        glm::u8vec4 colour;
+        glm::u8vec4 colour{};
 
         uint8_t flags;
 

--- a/rwlib/source/loaders/LoaderIMG.cpp
+++ b/rwlib/source/loaders/LoaderIMG.cpp
@@ -40,9 +40,9 @@ bool LoaderIMG::load(const rwfs::path& filepath) {
 /// Get the information of a asset in the examining archive
 bool LoaderIMG::findAssetInfo(const std::string& assetname,
                               LoaderIMGFile& out) {
-    for (size_t i = 0; i < m_assets.size(); ++i) {
-        if (boost::iequals(m_assets[i].name, assetname)) {
-            out = m_assets[i];
+    for (auto &asset : m_assets) {
+        if (boost::iequals(asset.name, assetname)) {
+            out = asset;
             return true;
         }
     }

--- a/rwviewer/ViewerWidget.cpp
+++ b/rwviewer/ViewerWidget.cpp
@@ -69,7 +69,7 @@ void ViewerWidget::initGL() {
 }
 
 void ViewerWidget::drawModel(GameRenderer& r, ClumpPtr& model) {
-    glm::mat4 view, proj;
+    glm::mat4 view{1.0f}, proj{1.0f};
     const auto& vc = OrbitCamera({width(), height()},
                                  viewAngles,
                                  viewDistance,
@@ -83,7 +83,7 @@ void ViewerWidget::drawModel(GameRenderer& r, ClumpPtr& model) {
 
     ObjectRenderer _renderer(world(), vc, 1.f, 0);
     RenderList renders;
-    _renderer.renderClump(model.get(), glm::mat4(), nullptr, renders);
+    _renderer.renderClump(model.get(), glm::mat4(1.0f), nullptr, renders);
     r.getRenderer()->drawBatched(renders);
 
     drawFrameWidget(model->getFrame().get());
@@ -91,7 +91,7 @@ void ViewerWidget::drawModel(GameRenderer& r, ClumpPtr& model) {
 }
 
 void ViewerWidget::drawObject(GameRenderer &r, GameObject *object) {
-    glm::mat4 view, proj;
+    glm::mat4 view{1.0f}, proj{1.0f};
     const auto& vc = OrbitCamera({width(), height()},
                                  viewAngles,
                                  viewDistance,
@@ -263,7 +263,7 @@ void ViewerWidget::exportModel() {
 void ViewerWidget::keyPressEvent(QKeyEvent* e) {
     if (e->key() == Qt::Key_Shift) moveFast = true;
 
-    glm::vec3 movement;
+    glm::vec3 movement{};
     if (e->key() == Qt::Key_W) movement.y += moveFast ? 10.f : 1.f;
     if (e->key() == Qt::Key_S) movement.y -= moveFast ? 10.f : 1.f;
     if (e->key() == Qt::Key_A) movement.x -= moveFast ? 10.f : 1.f;

--- a/rwviewer/ViewerWidget.hpp
+++ b/rwviewer/ViewerWidget.hpp
@@ -85,12 +85,12 @@ protected:
 
 
     float viewDistance;
-    glm::vec2 viewAngles;
-    glm::vec3 viewPosition;
+    glm::vec2 viewAngles{};
+    glm::vec3 viewPosition{};
 
     bool dragging;
     QPointF dstart;
-    glm::vec2 dastart;
+    glm::vec2 dastart{};
     bool moveFast;
 
     DrawBuffer* _frameWidgetDraw;

--- a/tests/test_Animation.cpp
+++ b/tests/test_Animation.cpp
@@ -26,8 +26,8 @@ BOOST_AUTO_TEST_CASE(test_matrix) {
                 1.0f,
                 AnimationBone::RT0,
                 {
-                    {glm::quat(), glm::vec3(0.f, 0.f, 0.f), glm::vec3(), 0.f, 0},
-                    {glm::quat(), glm::vec3(0.f, 1.f, 0.f), glm::vec3(), 1.0f, 1},
+                    {glm::quat{1.0f,0.0f,0.0f,0.0f}, glm::vec3(0.f, 0.f, 0.f), glm::vec3(), 0.f, 0},
+                    {glm::quat{1.0f,0.0f,0.0f,0.0f}, glm::vec3(0.f, 1.f, 0.f), glm::vec3(), 1.0f, 1},
                 }
             };
 

--- a/tests/test_Buoyancy.cpp
+++ b/tests/test_Buoyancy.cpp
@@ -9,7 +9,7 @@ BOOST_AUTO_TEST_CASE(test_vehicle_buoyancy) {
     glm::vec2 tpos(-WATER_WORLD_SIZE / 2.f + 10.f);
     {
         VehicleObject* vehicle = Global::get().e->createVehicle(
-            90u, glm::vec3(tpos, 100.f), glm::quat());
+            90u, glm::vec3(tpos, 100.f), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
         BOOST_REQUIRE(vehicle != nullptr);
 

--- a/tests/test_Character.cpp
+++ b/tests/test_Character.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(test_activities) {
     }
     {
         VehicleObject* vehicle = Global::get().e->createVehicle(
-            90u, glm::vec3(10.f, 0.f, 0.f), glm::quat());
+            90u, glm::vec3(10.f, 0.f, 0.f), glm::quat{1.0f,0.0f,0.0f,0.0f});
         BOOST_REQUIRE(vehicle != nullptr);
         BOOST_REQUIRE(vehicle->getModel() != nullptr);
 

--- a/tests/test_Object.cpp
+++ b/tests/test_Object.cpp
@@ -12,7 +12,7 @@ BOOST_AUTO_TEST_CASE(instance_test_damage)
 	std::shared_ptr<ObjectData> object(new ObjectData);
 	InstanceObject inst(Global::get().e,
 					 glm::vec3(0.f, 0.f, 0.f),
-					 glm::quat(), nullptr,
+					 glm::quat{1.0f,0.0f,0.0f,0.0f}, nullptr,
 					 glm::vec3(1.f),
 					 object, nullptr, nullptr
 					);
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(instance_test_destroy)
 	std::shared_ptr<ObjectData> object(new ObjectData);
 	InstanceObject inst(Global::get().e,
 					 glm::vec3(0.f, 0.f, 0.f),
-					 glm::quat(), nullptr,
+					 glm::quat{1.0f,0.0f,0.0f,0.0f}, nullptr,
 					 glm::vec3(1.f),
 					 object, nullptr, nullptr
 					);

--- a/tests/test_TrafficDirector.cpp
+++ b/tests/test_TrafficDirector.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(test_available_nodes) {
                       {PathNode::EXTERNAL, -1, {-10.f, 10.f, 0.f}, 1.f, 0, 0},
                   }};
 
-    graph.createPathNodes(glm::vec3(), glm::quat(), path);
+    graph.createPathNodes(glm::vec3(), glm::quat{1.0f,0.0f,0.0f,0.0f}, path);
 
     TrafficDirector director(&graph, Global::get().e);
 
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(test_node_not_blocking) {
                       {PathNode::EXTERNAL, 1, {10.f, 10.f, 0.f}, 1.f, 0, 0},
                   }};
 
-    graph.createPathNodes(glm::vec3(), glm::quat(), path);
+    graph.createPathNodes(glm::vec3(), glm::quat{1.0f,0.0f,0.0f,0.0f}, path);
 
     TrafficDirector director(&graph, Global::get().e);
 
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(test_node_blocking) {
                       {PathNode::EXTERNAL, 1, {10.f, 10.f, 0.f}, 1.f, 0, 0},
                   }};
 
-    graph.createPathNodes(glm::vec3(), glm::quat(), path);
+    graph.createPathNodes(glm::vec3(), glm::quat{1.0f,0.0f,0.0f,0.0f}, path);
 
     TrafficDirector director(&graph, Global::get().e);
 
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(test_node_density) {
                       {PathNode::EXTERNAL, 1, {10.f, 10.f, 0.f}, 1.f, 0, 0},
                   }};
 
-    graph.createPathNodes(glm::vec3(), glm::quat(), path);
+    graph.createPathNodes(glm::vec3(), glm::quat{1.0f,0.0f,0.0f,0.0f}, path);
 
     TrafficDirector director(&graph, Global::get().e);
 
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(test_create_traffic) {
                       {PathNode::EXTERNAL, 1, {10.f, 10.f, 0.f}, 1.f, 0, 0},
                   }};
 
-    graph.createPathNodes(glm::vec3(), glm::quat(), path);
+    graph.createPathNodes(glm::vec3(), glm::quat{1.0f,0.0f,0.0f,0.0f}, path);
 
     TrafficDirector director(&graph, Global::get().e);
 

--- a/tests/test_Vehicle.cpp
+++ b/tests/test_Vehicle.cpp
@@ -8,7 +8,7 @@ BOOST_AUTO_TEST_SUITE(VehicleTests)
 #if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_create_vehicle) {
     VehicleObject* vehicle =
-        Global::get().e->createVehicle(90u, glm::vec3(), glm::quat());
+        Global::get().e->createVehicle(90u, glm::vec3(), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
     BOOST_REQUIRE(vehicle != nullptr);
 
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(test_create_vehicle) {
 
 BOOST_AUTO_TEST_CASE(vehicle_parts) {
     VehicleObject* vehicle =
-        Global::get().e->createVehicle(90u, glm::vec3(), glm::quat());
+        Global::get().e->createVehicle(90u, glm::vec3(), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
     BOOST_REQUIRE(vehicle != nullptr);
     BOOST_REQUIRE(vehicle->getModel() != nullptr);
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(vehicle_parts) {
 
 BOOST_AUTO_TEST_CASE(vehicle_part_vis) {
     VehicleObject* vehicle =
-        Global::get().e->createVehicle(90u, glm::vec3(), glm::quat());
+        Global::get().e->createVehicle(90u, glm::vec3(), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
     BOOST_REQUIRE(vehicle != nullptr);
     BOOST_REQUIRE(vehicle->getModel() != nullptr);
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(vehicle_part_vis) {
 
 BOOST_AUTO_TEST_CASE(test_door_position) {
     VehicleObject* vehicle = Global::get().e->createVehicle(
-        90u, glm::vec3(10.f, 0.f, 0.f), glm::quat());
+        90u, glm::vec3(10.f, 0.f, 0.f), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
     BOOST_REQUIRE(vehicle != nullptr);
 
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(test_door_position) {
 
 BOOST_AUTO_TEST_CASE(test_hinges) {
     VehicleObject* vehicle = Global::get().e->createVehicle(
-        90u, glm::vec3(10.f, 0.f, 0.f), glm::quat());
+        90u, glm::vec3(10.f, 0.f, 0.f), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
     BOOST_REQUIRE(vehicle != nullptr);
 
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(test_hinges) {
 
 BOOST_AUTO_TEST_CASE(test_open_part) {
     VehicleObject* vehicle = Global::get().e->createVehicle(
-        90u, glm::vec3(10.f, 0.f, 0.f), glm::quat());
+        90u, glm::vec3(10.f, 0.f, 0.f), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
     BOOST_REQUIRE(vehicle != nullptr);
 


### PR DESCRIPTION
Starting from version 0.9.9, libglm will no longer default initialize data types.
This results in undefined behaviour when using uninitialized vectors and matrices (and others).
This PR takes care of this, making the engine usable with the newer versions of libglm.

partially fixes #385 