### PR TITLE
Add experimental flag needed by glm 0.9.9

### DIFF
--- a/cmake_configure.cmake
+++ b/cmake_configure.cmake
@@ -17,6 +17,7 @@ target_compile_definitions(rw_interface
     INTERFACE
         "$<$<CONFIG:Debug>:RW_DEBUG=1>"
         "GLM_FORCE_RADIANS"
+        "GLM_ENABLE_EXPERIMENTAL"
         "RW_VERBOSE_DEBUG_MESSAGES=$<BOOL:${RW_VERBOSE_DEBUG_MESSAGES}>"
     )
 


### PR DESCRIPTION
In order to build OpenRW with libglm-dev version >= 0.9.9,
the flag GLM_ENABLE_EXPERIMENTAL needs to be set.

This is now done in cmake_configure.cmake , I'm not sure if it's the best spot but it works.