### PR TITLE
Clang double promotion warns

### DIFF
--- a/rwengine/src/data/WeaponData.hpp
+++ b/rwengine/src/data/WeaponData.hpp
@@ -31,7 +31,7 @@ struct WeaponData {
     int modelID;
     std::uint32_t flags;
 
-    int inventorySlot;
+    std::uint32_t inventorySlot;
 };
 
 /**

--- a/rwengine/src/engine/Animator.cpp
+++ b/rwengine/src/engine/Animator.cpp
@@ -1,5 +1,6 @@
 #include "engine/Animator.hpp"
 
+#include <cmath>
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 
@@ -47,7 +48,7 @@ void Animator::tick(float dt) {
         if (!state.repeat) {
             animTime = std::min(animTime, state.animation->duration);
         } else {
-            animTime = fmod(animTime, state.animation->duration);
+            animTime = std::fmod(animTime, state.animation->duration);
         }
 
         for (auto& b : state.boneInstances) {

--- a/rwengine/src/engine/SaveGame.cpp
+++ b/rwengine/src/engine/SaveGame.cpp
@@ -1210,11 +1210,11 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
 #if RW_DEBUG
     for (const auto &type : pedTypeData.types) {
         printf("%08x: %f %f %f %f %f threat %08x avoid %08x\n", type.bitstring_,
-               type.unknown2,
-               type.unknown3,
-               type.unknown4,
-               type.fleedistance,
-               type.headingchangerate,
+               static_cast<double>(type.unknown2),
+               static_cast<double>(type.unknown3),
+               static_cast<double>(type.unknown4),
+               static_cast<double>(type.fleedistance),
+               static_cast<double>(type.headingchangerate),
                type.threatflags_,
                type.avoidflags_);
     }

--- a/rwengine/src/objects/CharacterObject.hpp
+++ b/rwengine/src/objects/CharacterObject.hpp
@@ -185,8 +185,8 @@ public:
 
     glm::vec3 getLookDirection() const {
         float theta = m_look.y - glm::half_pi<float>();
-        return glm::vec3(sin(-m_look.x) * cos(theta),
-                         cos(-m_look.x) * cos(theta), sin(theta));
+        return glm::vec3(std::sin(-m_look.x) * std::cos(theta),
+                         std::cos(-m_look.x) * std::cos(theta), std::sin(theta));
     }
 
     /**


### PR DESCRIPTION
Before: https://gist.github.com/ShFil119/85d77d2e03503db711af715d12104907

I've also changed type of inventorySlot. So it fixes that annoying warning in each travis build.  
"warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
                                     return i.weaponId == pistol->inventorySlot;"