### PR TITLE
Fix order of transparent objects

### DIFF
--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -357,7 +357,11 @@ void GameRenderer::renderWorld(GameWorld* world, const ViewCamera& camera,
     std::sort(renderList.begin(), renderList.end(),
               [](const Renderer::RenderInstruction& a,
                  const Renderer::RenderInstruction& b) {
-                  return a.sortKey < b.sortKey;
+                    if (!a.drawInfo.blend && b.drawInfo.blend) return true;
+                    if (a.drawInfo.blend && !b.drawInfo.blend) return false;
+                    if (a.sortKey < b.sortKey) return true;
+
+                    return false;
               });
     RW_PROFILE_END();
 

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -35,13 +35,10 @@ constexpr float kMagicLODDistance = 330.f;
 constexpr float kVehicleLODDistance = 70.f;
 constexpr float kVehicleDrawDistance = 280.f;
 
-RenderKey createKey(bool transparent, float normalizedDepth,
+RenderKey createKey(float normalizedDepth,
                     Renderer::Textures& textures) {
-    return ((transparent ? 0x1 : 0x0) << 31) |
-           uint32_t(0x7FFFFF *
-                    (transparent ? 1.f - normalizedDepth : normalizedDepth))
-               << 8 |
-           uint8_t(0xFF & (!textures.empty() ? textures[0] : 0)) << 0;
+    return (uint32_t(0x7FFFFF * normalizedDepth) << 8 |
+           uint8_t(0xFF & (!textures.empty() ? textures[0] : 0)));
 }
 
 void ObjectRenderer::renderGeometry(Geometry* geom,
@@ -110,7 +107,7 @@ void ObjectRenderer::renderGeometry(Geometry* geom,
         float depth = (distance - m_camera.frustum.near) /
                       (m_camera.frustum.far - m_camera.frustum.near);
         outList.emplace_back(
-            createKey(isTransparent, depth * depth, dp.textures), modelMatrix,
+            createKey(depth * depth, dp.textures), modelMatrix,
             &geom->dbuff, dp);
     }
 }


### PR DESCRIPTION
https://learnopengl.com/Advanced-OpenGL/Blending
suggests transparent objects should be last.
![screenshot_20180317_141158](https://user-images.githubusercontent.com/7227492/37555792-3730b166-29e5-11e8-82c9-ece16f3950d1.png)

It should partially help with #258.