### PR TITLE
docker: use latest branched fedora version instead of rawhide + fix mac ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
     osx_image: xcode9.2
     install:
       - brew update
+      - brew upgrade python
       - brew upgrade
       - brew install boost cmake bullet ffmpeg glm openal-soft qt5 sdl2 jack
       - export PATH="/usr/local/opt/qt/bin:$PATH"

--- a/scripts/docker/fedora_latest.docker
+++ b/scripts/docker/fedora_latest.docker
@@ -1,4 +1,4 @@
-FROM fedora:rawhide
+FROM fedora:branched
 
 # ffmpeg-devel needs rpmfusion
 RUN dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
@@ -10,6 +10,7 @@ RUN dnf update -y \
         gcc gcc-c++ \
         boost-devel \
         cmake \
+        make \
         bullet-devel \
         ffmpeg-devel \
         glm-devel \


### PR DESCRIPTION
This fixes the fails of Fedora and Apple on ci.