### PR TITLE
[Read Only]Sfx sounds

### DIFF
--- a/cmake/modules/FindFFmpeg.cmake
+++ b/cmake/modules/FindFFmpeg.cmake
@@ -23,6 +23,7 @@ if (PKG_CONFIG_FOUND)
 pkg_check_modules(_FFMPEG_AVCODEC libavcodec QUIET)
 pkg_check_modules(_FFMPEG_AVFORMAT libavformat QUIET)
 pkg_check_modules(_FFMPEG_AVUTIL libavutil QUIET)
+pkg_check_modules(_FFMPEG_SWRESAMPLE libswresample QUIET)
 endif (PKG_CONFIG_FOUND)
 
 find_path(FFMPEG_AVCODEC_INCLUDE_DIR
@@ -61,6 +62,7 @@ set(FFMPEG_LIBRARIES
 ${FFMPEG_LIBAVCODEC}
 ${FFMPEG_LIBAVFORMAT}
 ${FFMPEG_LIBAVUTIL}
+${FFMPEG_SWRESAMPLE}
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/rwengine/CMakeLists.txt
+++ b/rwengine/CMakeLists.txt
@@ -21,6 +21,8 @@ set(RWENGINE_SOURCES
     src/ai/TrafficDirector.cpp
     src/ai/TrafficDirector.hpp
 
+    src/audio/Sound.cpp
+    src/audio/Sound.hpp
     src/audio/SoundManager.cpp
     src/audio/SoundManager.hpp
     src/audio/alCheck.cpp

--- a/rwengine/src/audio/Sound.cpp
+++ b/rwengine/src/audio/Sound.cpp
@@ -1,0 +1,436 @@
+#include "audio/alCheck.hpp"
+#include "audio/Sound.hpp"
+
+// Rename some functions for older libavcodec/ffmpeg versions (e.g. Ubuntu Trusty)
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55,28,1)
+#define av_frame_alloc  avcodec_alloc_frame
+#define av_frame_free   avcodec_free_frame
+#endif
+
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(57,80,100)
+#define avio_context_free av_freep
+#endif
+
+SoundBuffer::SoundBuffer() {
+    alCheck(alGenSources(1, &source));
+    alCheck(alGenBuffers(1, &buffer));
+
+    alCheck(alSourcef(source, AL_PITCH, 1));
+    alCheck(alSourcef(source, AL_GAIN, 1));
+    alCheck(alSource3f(source, AL_POSITION, 0, 0, 0));
+    alCheck(alSource3f(source, AL_VELOCITY, 0, 0, 0));
+    alCheck(alSourcei(source, AL_LOOPING, AL_FALSE));
+}
+
+bool SoundBuffer::bufferData(SoundSource& soundSource) {
+    alCheck(alBufferData(
+                buffer, soundSource.channels == 1 ? AL_FORMAT_MONO16
+                                                  : AL_FORMAT_STEREO16,
+                &soundSource.data.front(), soundSource.data.size() * sizeof(int16_t),
+                soundSource.sampleRate));
+    alCheck(alSourcei(source, AL_BUFFER, buffer));
+
+    return true;
+}
+
+void SoundSource::loadFromFile(const std::string& filename) {
+    // Allocate audio frame
+    AVFrame* frame = av_frame_alloc();
+    if (!frame) {
+        RW_ERROR("Error allocating the audio frame");
+        return;
+    }
+
+    // Allocate formatting context
+    AVFormatContext* formatContext = nullptr;
+    if (avformat_open_input(&formatContext, filename.c_str(), nullptr, nullptr) != 0) {
+        av_frame_free(&frame);
+        RW_ERROR("Error opening audio file (" << filename << ")");
+        return;
+    }
+
+    if (avformat_find_stream_info(formatContext, nullptr) < 0) {
+        av_frame_free(&frame);
+        avformat_close_input(&formatContext);
+        RW_ERROR("Error finding audio stream info");
+        return;
+    }
+
+    // Find the audio stream
+    //AVCodec* codec = nullptr;
+    int streamIndex = av_find_best_stream(formatContext, AVMEDIA_TYPE_AUDIO, -1, -1, nullptr, 0);
+    if (streamIndex < 0) {
+        av_frame_free(&frame);
+        avformat_close_input(&formatContext);
+        RW_ERROR("Could not find any audio stream in the file ");
+        return;
+    }
+
+    AVStream* audioStream = formatContext->streams[streamIndex];
+    AVCodec* codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
+
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57,5,0)
+    AVCodecContext* codecContext = audioStream->codec;
+    codecContext->codec = codec;
+
+    // Open the codec
+    if (avcodec_open2(codecContext, codecContext->codec, nullptr) != 0) {
+        av_frame_free(&frame);
+        avformat_close_input(&formatContext);
+        RW_ERROR("Couldn't open the audio codec context");
+        return;
+    }
+#else
+    // Initialize codec context for the decoder.
+    AVCodecContext* codecContext = avcodec_alloc_context3(codec);
+    if (!codecContext) {
+        av_frame_free(&frame);
+        avformat_close_input(&formatContext);
+        RW_ERROR("Couldn't allocate a decoding context.");
+        return;
+    }
+
+    // Fill the codecCtx with the parameters of the codec used in the read file.
+    if (avcodec_parameters_to_context(codecContext, audioStream->codecpar) != 0) {
+        avcodec_close(codecContext);
+        avcodec_free_context(&codecContext);
+        avformat_close_input(&formatContext);
+        RW_ERROR("Couldn't find parametrs for context");
+    }
+
+    // Initialize the decoder.
+    if (avcodec_open2(codecContext, codec, nullptr) != 0) {
+        avcodec_close(codecContext);
+        avcodec_free_context(&codecContext);
+        avformat_close_input(&formatContext);
+        RW_ERROR("Couldn't open the audio codec context");
+        return;
+    }
+#endif
+
+    // Expose audio metadata
+    channels = codecContext->channels;
+    sampleRate = codecContext->sample_rate;
+
+    // OpenAL only supports mono or stereo, so error on more than 2 channels
+    if(channels > 2) {
+        RW_ERROR("Audio has more than two channels");
+        av_frame_free(&frame);
+        avcodec_close(codecContext);
+        avformat_close_input(&formatContext);
+        return;
+    }
+
+    // Start reading audio packets
+    AVPacket readingPacket;
+    av_init_packet(&readingPacket);
+
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57,37,100)
+
+    while (av_read_frame(formatContext, &readingPacket) == 0) {
+        if (readingPacket.stream_index == audioStream->index) {
+            AVPacket decodingPacket = readingPacket;
+
+            while (decodingPacket.size > 0) {
+                // Decode audio packet
+                int gotFrame = 0;
+                int len = avcodec_decode_audio4(codecContext, frame, &gotFrame, &decodingPacket);
+
+                if (len >= 0 && gotFrame) {
+                    // Write samples to audio buffer
+
+                    for(size_t i = 0; i < static_cast<size_t>(frame->nb_samples); i++) {
+                        // Interleave left/right channels
+                        for(size_t channel = 0; channel < channels; channel++) {
+                            int16_t sample = reinterpret_cast<int16_t *>(frame->data[channel])[i];
+                            data.push_back(sample);
+                        }
+                    }
+
+                    decodingPacket.size -= len;
+                    decodingPacket.data += len;
+                }
+                else {
+                    decodingPacket.size = 0;
+                    decodingPacket.data = nullptr;
+                }
+            }
+        }
+        av_free_packet(&readingPacket);
+    }
+#else
+
+    while (av_read_frame(formatContext, &readingPacket) == 0) {
+        if (readingPacket.stream_index == audioStream->index) {
+            AVPacket decodingPacket = readingPacket;
+
+            int sendPacket = avcodec_send_packet(codecContext, &decodingPacket);
+            int receiveFrame = 0;
+
+            while ((receiveFrame = avcodec_receive_frame(codecContext, frame)) == 0) {
+                // Decode audio packet
+
+                if (receiveFrame == 0 && sendPacket == 0) {
+                    // Write samples to audio buffer
+
+                    for(size_t i = 0; i < static_cast<size_t>(frame->nb_samples); i++) {
+                        // Interleave left/right channels
+                        for(size_t channel = 0; channel < channels; channel++) {
+                            int16_t sample = reinterpret_cast<int16_t *>(frame->data[channel])[i];
+                            data.push_back(sample);
+                        }
+                    }
+                }
+            }
+        }
+        av_packet_unref(&readingPacket);
+    }
+
+#endif
+
+    // Cleanup
+    /// Free all data used by the frame.
+    av_frame_free(&frame);
+
+    /// Close the context and free all data associated to it, but not the context itself.
+    avcodec_close(codecContext);
+
+    /// Free the context itself.
+    avcodec_free_context(&codecContext);
+
+    /// We are done here. Close the input.
+    avformat_close_input(&formatContext);
+}
+
+void SoundSource::loadSfx(const std::string& path, const size_t& index) {
+    // Allocate audio frame
+    AVFrame* frame = av_frame_alloc();
+    if (!frame) {
+        RW_ERROR("Error allocating the audio frame");
+        return;
+    }
+
+    // Allocate formatting context
+    AVFormatContext* formatContext = nullptr;
+    LoaderSDT loader{};
+    loader.load(path + "audio/sfx");
+    formatContext = loader.loadSound(index);
+
+    if (avformat_open_input(&formatContext, "nothint", nullptr, nullptr) != 0) {
+        av_frame_free(&frame);
+        RW_ERROR("Error opening audio file (" << index << ")");
+        return;
+    }
+
+    if (avformat_find_stream_info(formatContext, nullptr) < 0) {
+        av_frame_free(&frame);
+        avformat_close_input(&formatContext);
+        RW_ERROR("Error finding audio stream info");
+        return;
+    }
+
+    // Find the audio stream
+    //AVCodec* codec = nullptr;
+    int streamIndex = av_find_best_stream(formatContext, AVMEDIA_TYPE_AUDIO, -1, -1, nullptr, 0);
+    if (streamIndex < 0) {
+        av_frame_free(&frame);
+        avformat_close_input(&formatContext);
+        RW_ERROR("Could not find any audio stream in the file ");
+        return;
+    }
+
+    AVStream* audioStream = formatContext->streams[streamIndex];
+    AVCodec* codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
+
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57,5,0)
+    AVCodecContext* codecContext = audioStream->codec;
+    codecContext->codec = codec;
+
+    // Open the codec
+    if (avcodec_open2(codecContext, codecContext->codec, nullptr) != 0) {
+        av_frame_free(&frame);
+        avformat_close_input(&formatContext);
+        RW_ERROR("Couldn't open the audio codec context");
+        return;
+    }
+#else
+    // Initialize codec context for the decoder.
+    AVCodecContext* codecContext = avcodec_alloc_context3(codec);
+    if (!codecContext) {
+        av_frame_free(&frame);
+        avformat_close_input(&formatContext);
+        RW_ERROR("Couldn't allocate a decoding context.");
+        return;
+    }
+
+    // Fill the codecCtx with the parameters of the codec used in the read file.
+    if (avcodec_parameters_to_context(codecContext, audioStream->codecpar) != 0) {
+        avcodec_close(codecContext);
+        avcodec_free_context(&codecContext);
+        avformat_close_input(&formatContext);
+        RW_ERROR("Couldn't find parametrs for context");
+    }
+
+    // Initialize the decoder.
+    if (avcodec_open2(codecContext, codec, nullptr) != 0) {
+        avcodec_close(codecContext);
+        avcodec_free_context(&codecContext);
+        avformat_close_input(&formatContext);
+        RW_ERROR("Couldn't open the audio codec context");
+        return;
+    }
+#endif
+
+    // Expose audio metadata
+    channels = codecContext->channels;
+    sampleRate =loader.assetInfo.sampleRate;
+
+    // OpenAL only supports mono or stereo, so error on more than 2 channels
+    if(channels > 2) {
+        RW_ERROR("Audio has more than two channels");
+        av_frame_free(&frame);
+        avcodec_close(codecContext);
+        avformat_close_input(&formatContext);
+        return;
+    }
+
+    // Start reading audio packets
+    AVPacket readingPacket;
+    av_init_packet(&readingPacket);
+
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57,37,100)
+
+    while (av_read_frame(formatContext, &readingPacket) == 0) {
+        if (readingPacket.stream_index == audioStream->index) {
+            AVPacket decodingPacket = readingPacket;
+
+            while (decodingPacket.size > 0) {
+                // Decode audio packet
+                int gotFrame = 0;
+                int len = avcodec_decode_audio4(codecContext, frame, &gotFrame, &decodingPacket);
+
+                if (len >= 0 && gotFrame) {
+                    // Write samples to audio buffer
+
+                    for(size_t i = 0; i < static_cast<size_t>(frame->nb_samples); i++) {
+                        // Interleave left/right channels
+                        for(size_t channel = 0; channel < channels; channel++) {
+                            int16_t sample = reinterpret_cast<int16_t *>(frame->data[channel])[i];
+                            data.push_back(sample);
+                        }
+                    }
+
+                    decodingPacket.size -= len;
+                    decodingPacket.data += len;
+                }
+                else {
+                    decodingPacket.size = 0;
+                    decodingPacket.data = nullptr;
+                }
+            }
+        }
+        av_free_packet(&readingPacket);
+    }
+#else
+
+    while (av_read_frame(formatContext, &readingPacket) == 0) {
+        if (readingPacket.stream_index == audioStream->index) {
+            AVPacket decodingPacket = readingPacket;
+
+            int sendPacket = avcodec_send_packet(codecContext, &decodingPacket);
+            int receiveFrame = 0;
+
+            while ((receiveFrame = avcodec_receive_frame(codecContext, frame)) == 0) {
+                // Decode audio packet
+
+                if (receiveFrame == 0 && sendPacket == 0) {
+                    // Write samples to audio buffer
+
+                    for(size_t i = 0; i < static_cast<size_t>(frame->nb_samples); i++) {
+                        // Interleave left/right channels
+                        for(size_t channel = 0; channel < channels; channel++) {
+                            int16_t sample = reinterpret_cast<int16_t *>(frame->data[channel])[i];
+                            data.push_back(sample);
+                        }
+                    }
+                }
+            }
+        }
+        av_packet_unref(&readingPacket);
+    }
+
+#endif
+
+    // Cleanup
+    /// Free all data used by the frame.
+    av_frame_free(&frame);
+
+    /// Close the context and free all data associated to it, but not the context itself.
+    avcodec_close(codecContext);
+
+    /// Free the context itself.
+    avcodec_free_context(&codecContext);
+
+    /// Free our custom AVIO.
+    av_free(formatContext->pb->buffer);
+    avio_context_free(&formatContext->pb);
+
+    /// We are done here. Close the input.
+    avformat_close_input(&formatContext);
+}
+
+bool SoundBuffer::isPlaying() const {
+    ALint sourceState;
+    alCheck(alGetSourcei(source, AL_SOURCE_STATE,
+                         &sourceState));
+    return AL_PLAYING == sourceState;
+}
+
+bool SoundBuffer::isPaused() const {
+    ALint sourceState;
+    alCheck(alGetSourcei(source, AL_SOURCE_STATE,
+                         &sourceState));
+    return AL_PAUSED == sourceState;
+}
+
+bool SoundBuffer::isStoped() const {
+    ALint sourceState;
+    alCheck(alGetSourcei(source, AL_SOURCE_STATE,
+                         &sourceState));
+    return AL_STOPPED  == sourceState;
+}
+
+void SoundBuffer::play() {
+    alCheck(alSourcePlay(source));
+}
+void SoundBuffer::pause() {
+    alCheck(alSourcePause(source));
+}
+void SoundBuffer::stop() {
+    alCheck(alSourceStop(source));
+}
+
+void SoundBuffer::setPosition(const glm::vec3 position) {
+    alCheck(alSource3f(source, AL_POSITION, position.x, position.y, position.z));
+}
+
+void SoundBuffer::setLooping(const bool  looping) {
+    if(looping) {
+        alCheck(alSourcei(source, AL_LOOPING, AL_TRUE));
+    }
+    else {
+        alCheck(alSourcei(source, AL_LOOPING, AL_FALSE));
+    }
+}
+
+void SoundBuffer::setPitch(const float  pitch) {
+    alCheck(alSourcef(source, AL_PITCH, pitch));
+}
+void SoundBuffer::setGain(const float  gain) {
+    alCheck(alSourcef(source, AL_GAIN, gain));
+}
+void SoundBuffer::setMaxDistance(const float  maxDist) {
+    alCheck(alSourcef(source, AL_MAX_DISTANCE, maxDist));
+}
+
+

--- a/rwengine/src/audio/Sound.cpp
+++ b/rwengine/src/audio/Sound.cpp
@@ -246,7 +246,7 @@ void SoundSource::loadFromFile(const std::string& filename) {
     avformat_close_input(&formatContext);
 }
 
-void SoundSource::loadSfx(const std::string& path, const size_t& index) {
+void SoundSource::loadSfx(const rwfs::path& path, const size_t& index) {
     // Allocate audio frame
     AVFrame* frame = av_frame_alloc();
     if (!frame) {
@@ -257,7 +257,7 @@ void SoundSource::loadSfx(const std::string& path, const size_t& index) {
     // Allocate formatting context
     AVFormatContext* formatContext = nullptr;
     LoaderSDT loader{};
-    loader.load(path + "audio/sfx");
+    loader.load(path / "audio/sfx");
     formatContext = loader.loadSound(index);
 
     if (avformat_open_input(&formatContext, "nothint", nullptr, nullptr) != 0) {

--- a/rwengine/src/audio/Sound.hpp
+++ b/rwengine/src/audio/Sound.hpp
@@ -1,0 +1,125 @@
+#ifndef _RWENGINE_SOUND_HPP_
+#define _RWENGINE_SOUND_HPP_
+
+#include <memory>
+#include <vector>
+#include <string>
+#include <mutex>
+
+#include <al.h>
+#include <alc.h>
+#include <glm/glm.hpp>
+
+#include "loaders/LoaderSDT.hpp"
+#include "rw/defines.hpp"
+
+/// Opaque for raw sound,
+/// cooperate with ffmpeg
+/// (loading and decoding sound)
+class SoundSource {
+    friend class SoundManager;
+    friend class SoundBuffer;
+
+public:
+    /// Load sound from mp3/wav file
+    void loadFromFile(const std::string& filename);
+
+    /// Load sound from sdt file
+    void loadSfx(const std::string& path, const size_t& index);
+
+private:
+    /// Raw data
+    std::vector<int16_t> data;
+
+    size_t channels;
+    size_t sampleRate;
+};
+
+/// OpenAL tool for playing
+/// sound instance.
+class SoundBuffer {
+    friend class SoundManager;
+
+public:
+    SoundBuffer();
+    bool bufferData(SoundSource& soundSource);
+
+    bool isPlaying() const;
+    bool isPaused() const;
+    bool isStoped() const;
+
+    void play();
+    void pause();
+    void stop();
+
+    void setPosition(const glm::vec3 position);
+    void setLooping(const bool  looping);
+    void setPitch(const float  pitch);
+    void setGain(const float  gain);
+    void setMaxDistance(const float  maxDist);
+
+private:
+    ALuint source;
+    ALuint buffer;
+};
+
+/// Wrapper for SoundBuffer and SoundSource.
+/// Each command connected
+/// with playment is passed to SoundBuffer
+struct Sound {
+    std::unique_ptr<std::mutex> soundMutex = std::make_unique<std::mutex>(); // mutexes can't be copied
+    size_t id = 0;
+    std::shared_ptr<SoundSource> source = nullptr;
+    std::unique_ptr<SoundBuffer> buffer = nullptr;
+    bool isLoaded = false;
+
+    Sound() = default;
+
+    bool isPlaying() const {
+        return buffer->isPlaying();
+    }
+
+    bool isPaused() const {
+        return buffer->isPaused();
+    }
+    bool isStoped() const {
+        return buffer->isStoped();
+    }
+
+    void play()  {
+        buffer->play();
+    }
+
+    void pause() {
+        buffer->pause();
+    }
+
+    void stop() {
+        buffer->stop();
+    }
+
+    void setPosition(const glm::vec3 position) {
+        buffer->setPosition(position);
+    }
+
+    void setLooping(const bool  looping) {
+        buffer->setLooping(looping);
+    }
+
+    void setPitch(const float  pitch) {
+        buffer->setPitch(pitch);
+    }
+
+    void setGain(const float  gain) {
+        buffer->setGain(gain);
+    }
+
+    void setMaxDistance(const float  maxDist) {
+        buffer->setMaxDistance(maxDist);
+    }
+
+    int getScriptObjectID() const {
+        return id;
+    }
+};
+#endif

--- a/rwengine/src/audio/Sound.hpp
+++ b/rwengine/src/audio/Sound.hpp
@@ -12,6 +12,7 @@
 
 #include "loaders/LoaderSDT.hpp"
 #include "rw/defines.hpp"
+#include <rw/filesystem.hpp>
 
 /// Opaque for raw sound,
 /// cooperate with ffmpeg
@@ -25,7 +26,7 @@ public:
     void loadFromFile(const std::string& filename);
 
     /// Load sound from sdt file
-    void loadSfx(const std::string& path, const size_t& index);
+    void loadSfx(const rwfs::path& path, const size_t& index);
 
 private:
     /// Raw data

--- a/rwengine/src/audio/Sound.hpp
+++ b/rwengine/src/audio/Sound.hpp
@@ -67,7 +67,6 @@ private:
 /// Each command connected
 /// with playment is passed to SoundBuffer
 struct Sound {
-    std::unique_ptr<std::mutex> soundMutex = std::make_unique<std::mutex>(); // mutexes can't be copied
     size_t id = 0;
     std::shared_ptr<SoundSource> source = nullptr;
     std::unique_ptr<SoundBuffer> buffer = nullptr;

--- a/rwengine/src/audio/Sound.hpp
+++ b/rwengine/src/audio/Sound.hpp
@@ -47,7 +47,7 @@ public:
 
     bool isPlaying() const;
     bool isPaused() const;
-    bool isStoped() const;
+    bool isStopped() const;
 
     void play();
     void pause();
@@ -82,8 +82,8 @@ struct Sound {
     bool isPaused() const {
         return buffer->isPaused();
     }
-    bool isStoped() const {
-        return buffer->isStoped();
+    bool isStopped() const {
+        return buffer->isStopped();
     }
 
     void play()  {

--- a/rwengine/src/audio/SoundManager.cpp
+++ b/rwengine/src/audio/SoundManager.cpp
@@ -128,7 +128,7 @@ size_t SoundManager::createSfxInstance(const size_t& index) {
 
     //Let's try reuse buffor
     for(auto& sound : buffers) {
-        if (sound.second.buffer && sound.second.isStoped())  { //Let's use this buffor
+        if (sound.second.buffer && sound.second.isStopped())  { //Let's use this buffor
             sound.second.buffer = std::make_unique<SoundBuffer>();
             sound.second.source = soundRef->second.source;
             sound.second.isLoaded = sound.second.buffer->bufferData(*sound.second.source);
@@ -166,10 +166,10 @@ bool SoundManager::isPlaying(const std::string& name) {
     return false;
 }
 
-bool SoundManager::isStoped(const std::string& name) {
+bool SoundManager::isStopped(const std::string& name) {
     auto sound = sounds.find(name);
     if (sound != sounds.end()) {
-        return sound->second.isStoped();
+        return sound->second.isStopped();
     }
     return false;
 }

--- a/rwengine/src/audio/SoundManager.cpp
+++ b/rwengine/src/audio/SoundManager.cpp
@@ -71,8 +71,6 @@ bool SoundManager::initializeOpenAL() {
 }
 
 bool SoundManager::initializeAVCodec() {
-    av_register_all();
-
 #if RW_DEBUG && RW_VERBOSE_DEBUG_MESSAGES
     av_log_set_level(AV_LOG_WARNING);
 #else

--- a/rwengine/src/audio/SoundManager.cpp
+++ b/rwengine/src/audio/SoundManager.cpp
@@ -106,7 +106,7 @@ bool SoundManager::loadSound(const std::string& name,
     return sound->isLoaded;
 }
 
-void SoundManager::loadSfxSounds(const std::string& path) {
+void SoundManager::loadSfxSounds(const rwfs::path& path) {
     sfx.reserve(kNrOfAllSfx);
     for(size_t i = 0; i < kNrOfAllSfx; i++) {
         Sound* sound = nullptr;

--- a/rwengine/src/audio/SoundManager.cpp
+++ b/rwengine/src/audio/SoundManager.cpp
@@ -6,27 +6,30 @@
 #include <rw/defines.hpp>
 
 int SoundManager::convertScriptIndexIntoSfx(const int scriptId) {
-    for(const auto &data : sfxData) {
-        if(scriptId == data.id ) {
-            return data.sfx;
-        }
-    }
-    return 0;
+    const auto finded = std::find_if(std::begin(sfxData), std::end(sfxData),
+                                     [&scriptId](const SoundInstanceData data){return data.id == scriptId;});
+    return finded->sfx;
 }
 
-Sound& SoundManager::getSoundRef( const size_t& name) {
+Sound& SoundManager::getSoundRef(const size_t& name) {
+    auto ref = buffers.find(name);
+    if(ref != buffers.end()) {
+        return ref->second;
+    } else {    // Hmm, we should reload this
+        createSfxInstance(name);
+    }
     return buffers[name];
 }
 
-Sound& SoundManager::getSoundRef( const std::string& name) {
-    return sounds[name];
+Sound& SoundManager::getSoundRef(const std::string& name) {
+    return sounds[name]; // todo reloading, how to check is it wav/mp3?
 }
 
 int SoundManager::getScriptRange(const int scriptId) {
-    for(const auto &data : sfxData) {
-        if(scriptId == data.id ) {
-            return data.range;
-        }
+    const auto finded = std::find_if(std::begin(sfxData), std::end(sfxData),
+                                     [&scriptId](const SoundInstanceData data){return data.id == scriptId;});
+    if(finded != std::end(sfxData)) {
+        return finded->sfx;
     }
     return -1;
 }
@@ -105,7 +108,7 @@ bool SoundManager::loadSound(const std::string& name,
 
 void SoundManager::loadSfxSounds(const std::string& path) {
     sfx.reserve(kNrOfAllSfx);
-    for(size_t i = 0; i < kNrOfAllSfx; i++) { //3032 is number of all sfx sounds in gta3
+    for(size_t i = 0; i < kNrOfAllSfx; i++) {
         Sound* sound = nullptr;
 
         auto emplaced = sfx.emplace(std::piecewise_construct,

--- a/rwengine/src/audio/SoundManager.cpp
+++ b/rwengine/src/audio/SoundManager.cpp
@@ -128,7 +128,6 @@ size_t SoundManager::createSfxInstance(const size_t& index) {
 
     //Let's try reuse buffor
     for(auto& sound : buffers) {
-        std::lock_guard<std::mutex> lock(*sound.second.soundMutex);
         if (sound.second.buffer && sound.second.isStoped())  { //Let's use this buffor
             sound.second.buffer = std::make_unique<SoundBuffer>();
             sound.second.source = soundRef->second.source;
@@ -140,7 +139,6 @@ size_t SoundManager::createSfxInstance(const size_t& index) {
     auto emplaced = buffers.emplace(std::piecewise_construct,
                                     std::forward_as_tuple(bufforNr),
                                     std::forward_as_tuple());
-    std::lock_guard<std::mutex> lock(*emplaced.first->second.soundMutex);
     sound = &emplaced.first->second;
 
     sound->id = bufforNr;

--- a/rwengine/src/audio/SoundManager.hpp
+++ b/rwengine/src/audio/SoundManager.hpp
@@ -1,6 +1,10 @@
 #ifndef _RWENGINE_SOUNDMANAGER_HPP_
 #define _RWENGINE_SOUNDMANAGER_HPP_
 
+#include "audio/Sound.hpp"
+
+#include <rw/filesystem.hpp>
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -13,8 +17,6 @@
 
 #include <al.h>
 #include <alc.h>
-
-#include "audio/Sound.hpp"
 
 /// Script is using different numeration of sounds
 /// than postion index in sfx file.
@@ -159,7 +161,7 @@ public:
     bool loadSound(const std::string& name, const std::string& fileName);
 
     /// Load all sfx sounds
-    void loadSfxSounds(const std::string& path);
+    void loadSfxSounds(const rwfs::path& path);
 
     /// Get position index in sdt file
     int convertScriptIndexIntoSfx(const int scriptId);

--- a/rwengine/src/audio/SoundManager.hpp
+++ b/rwengine/src/audio/SoundManager.hpp
@@ -1,6 +1,7 @@
 #ifndef _RWENGINE_SOUNDMANAGER_HPP_
 #define _RWENGINE_SOUNDMANAGER_HPP_
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <map>

--- a/rwengine/src/audio/SoundManager.hpp
+++ b/rwengine/src/audio/SoundManager.hpp
@@ -35,36 +35,36 @@ struct SoundInstanceData {
 /// see comment in second column
 constexpr SoundInstanceData sfxData[] = {
     /// for opcodes 018c
-    {78, 2857/*-2871*/, -1}, /// male pain soft
-    {79, 2857/*-2871*/, -1}, /// male pain loud
-    {80, 2290/*-2300*/, -1}, /// female pain soft
-    {81, 2290/*-2300*/, -1}, /// female pain loud
-    {82, 161/*-162*/, -1}, /// item pickup
-    {83, 161/*-162*/, -1}, /// item pickup
-    {92, 147, 40}, /// gate start
-    {93, 147, 40}, /// gate stop
-    {94, 337, -1}, /// checkpoint
-    {97, 336, -1}, /// countdown timer 3
-    {98, 336, -1}, /// countdown timer 2
-    {99, 336, -1}, /// countdown timer 1
-    {100, 337, -1}, /// countdown finish
+    {78, 2857/*-2871*/, -1},        /// male pain soft
+    {79, 2857/*-2871*/, -1},        /// male pain loud
+    {80, 2290/*-2300*/, -1},        /// female pain soft
+    {81, 2290/*-2300*/, -1},        /// female pain loud
+    {82, 161/*-162*/, -1},          /// item pickup
+    {83, 161/*-162*/, -1},          /// item pickup
+    {92, 147, 40},                  /// gate start
+    {93, 147, 40},                  /// gate stop
+    {94, 337, -1},                  /// checkpoint
+    {97, 336, -1},                  /// countdown timer 3
+    {98, 336, -1},                  /// countdown timer 2
+    {99, 336, -1},                  /// countdown timer 1
+    {100, 337, -1},                 /// countdown finish
     {106/*-108*/, 176/*-178*/, 50}, /// bullet hit ground
-    {110/*-111*/, 389, 80},  /// silent, replace the SFX or edit the memory to a different SFX to make this useful
-    {112, 283, 80}, /// payphone
-    {114/*-115*/, 151, 60}, /// glass break
-    {116, 150, 60}, /// glass damage
-    {117, 152/*-155*/, 55}, /// glass shards
-    {118, 327, 60}, /// boxes destroyed
-    {119, 328, 60}, /// boxes destroyed
-    {120, 140/*-144*/, 60}, /// car collision
-    {121, 29, 60}, /// tire collision
-    {122, 167/*-168*/, 20}, /// gun shell drop, dependent on what collision the player is currently standing on
-    {123, 168, 20}, /// gun shell drop soft
+    {110/*-111*/, 389, 80},         /// silent, replace the SFX or edit the memory to a different SFX to make this useful
+    {112, 283, 80},                 /// payphone
+    {114/*-115*/, 151, 60},         /// glass break
+    {116, 150, 60},                 /// glass damage
+    {117, 152/*-155*/, 55},         /// glass shards
+    {118, 327, 60},                 /// boxes destroyed
+    {119, 328, 60},                 /// boxes destroyed
+    {120, 140/*-144*/, 60},         /// car collision
+    {121, 29, 60},                  /// tire collision
+    {122, 167/*-168*/, 20},         /// gun shell drop, dependent on what collision the player is currently standing on
+    {123, 168, 20},                 /// gun shell drop soft
     /// for opcodes 018d
     {4, 390, 30},
-    {5, 390, 80}, /// 	Hepburn Heights southwest tower
+    {5, 390, 80},                   /// Hepburn Heights southwest tower
     {6, 391, 30},
-    {7, 391, 80}, /// 	Hepburn Heights north tower
+    {7, 391, 80},                   /// Hepburn Heights north tower
     {8, 392, 30},
     {9, 392, 80},
     {10, 393, 30},
@@ -87,61 +87,61 @@ constexpr SoundInstanceData sfxData[] = {
     {27, 391, 80},
     {28, 392, 30},
     {29, 392, 80},
-    {30, 403, 30}, /// Meeouch Sex Kitten Club
+    {30, 403, 30},                  /// Meeouch Sex Kitten Club
     {31, 403, 80},
-    {32, 404, 30}, /// 	Sex Club Seven
+    {32, 404, 30},                  /// Sex Club Seven
     {33, 404, 80},
     {34, 405, 30},
     {35, 405, 30},
-    {36, 407/*-408*/, 30}, /// 		407 plays continuously while 408 plays intermittently
-    {37, 407/*-408*/, 30}, /// 	Liberty City Sawmills/Bitch'N' Dog Food
+    {36, 407/*-408*/, 30},          /// 407 plays continuously while 408 plays intermittently
+    {37, 407/*-408*/, 30},          /// Liberty City Sawmills/Bitch'N' Dog Food
     {38, 409, 30},
     {39, 409, 80},
-    {40, 410/*-411*/, 30}, /// 		Both plays continuously
-    {41, 410/*-411*/, 30}, /// 	Mr. Wong's Laundrette
-    {42, 412, 30}, /// 	Roast Peking Duck
+    {40, 410/*-411*/, 30},          /// Both plays continuously
+    {41, 410/*-411*/, 30},          /// Mr. Wong's Laundrette
+    {42, 412, 30},                  /// Roast Peking Duck
     {43, 412, 80},
-    {44, 413, 30}, /// 	Cipriani's Ristorante
+    {44, 413, 30},                  /// Cipriani's Ristorante
     {45, 413, 80},
     {46, 414, 30},
     {47, 414, 30},
-    {48, 415, 30}, /// 	Marco's Bistro (no sound)
+    {48, 415, 30},                  ///	Marco's Bistro (no sound)
     {49, 415, 80},
-    {50, 416/*-419*/, 30}, /// 		Plays separately and intermittently
-    {51, 416/*-419*/, 80}, /// 	Francis International Terminal B
+    {50, 416/*-419*/, 30},          /// Plays separately and intermittently
+    {51, 416/*-419*/, 80},          /// Francis International Terminal B
     {52, 420/*-422*/, 30},
-    {53, 420/*-422*/, 30}, /// Chinatown (no sound)
-    {54, 423/*-425*/, 30}, /// 		Plays separately and intermittently
+    {53, 420/*-422*/, 30},          /// Chinatown (no sound)
+    {54, 423/*-425*/, 30},          /// Plays separately and intermittently
     {55, 423/*-425*/, 80},
     {56, 426, 30},
-    {57, 426, 80}, /// 	Portland Docks (no sound)
-    {58, 427/*-431*/, 30}, /// 		Plays separately and intermittently
-    {59, 427/*-431*/, 80}, /// Left side of Misty's apartment
-    {60, 406, 30}, /// 	Salvatore's place
+    {57, 426, 80},                  /// Portland Docks (no sound)
+    {58, 427/*-431*/, 30},          /// Plays separately and intermittently
+    {59, 427/*-431*/, 80},          /// Left side of Misty's apartment
+    {60, 406, 30},                  /// Salvatore's place
     {61, 406, 80},
-    {62, 432/*-434*/, 20},  /// South of Sex Club Seven 	432 plays continuously while 433-434 plays separately and intermittently
+    {62, 432/*-434*/, 20},          /// South of Sex Club Seven 	432 plays continuously while 433-434 plays separately and intermittently
     {63, 432/*-434*/, 80},
-    {64, 435/*-437*/, 20}, /// 	East of Portland Pay 'N' Spray 	435 plays continuously while 436-437 plays separately and intermittently
+    {64, 435/*-437*/, 20},          /// East of Portland Pay 'N' Spray 	435 plays continuously while 436-437 plays separately and intermittently
     {65, 435/*-437*/, 80},
-    {66, 438/*-440*/, 20}, /// 	Executive Relief 	438 plays continuously while 439-440 plays separately and intermittently
+    {66, 438/*-440*/, 20},          /// Executive Relief 	438 plays continuously while 439-440 plays separately and intermittently
     {67, 438/*-440*/, 80},
     {68, 442, 30},
-    {69, 442, 80}, /// 	Bank of Liberty/Staunton police HQ alarm
+    {69, 442, 80},                  /// Bank of Liberty/Staunton police HQ alarm
     {70, 441, 30},
-    {71, 441, 80}, /// 	Old school hall
+    {71, 441, 80},                  /// Old school hall
     {72, 443, 30},
-    {73, 443, 80}, /// 	Warehouse rave
-    {76, 179/*-184*/, 30}, /// 		Plays separately and intermittently
-    {77, 179/*-184*/, 80}, /// 	Staunton police HQ
+    {73, 443, 80},                  ///	Warehouse rave
+    {76, 179/*-184*/, 30},          /// Plays separately and intermittently
+    {77, 179/*-184*/, 80},          /// Staunton police HQ
     {84, 444, 30},
     {85, 444, 80},
     {86, 444, 30},
     {87, 444, 80},
     {88, 445, 30},
     {89, 445, 80},
-    {90, 433/*-434*/, 20}, /// 		Plays separately and intermittently
-    {91, 433/*-434*/, 80}, /// 	Right side of Misty's apartment
-    {102, 157, 50} /// 	Callahan Bridge fire
+    {90, 433/*-434*/, 20},          /// Plays separately and intermittently
+    {91, 433/*-434*/, 80},          /// Right side of Misty's apartment
+    {102, 157, 50}                  /// Callahan Bridge fire
 };
 /// Nr of existing sfx sounds
 constexpr size_t kNrOfAllSfx = 3032;
@@ -180,7 +180,7 @@ public:
     bool isPlaying(const std::string& name);
 
     /// Checking is selected sound playing.
-    bool isStoped(const std::string& name);
+    bool isStopped(const std::string& name);
 
     /// Checking is selected sound playing.
     bool isPaused(const std::string& name);

--- a/rwengine/src/audio/SoundManager.hpp
+++ b/rwengine/src/audio/SoundManager.hpp
@@ -4,77 +4,235 @@
 #include <cstddef>
 #include <cstdint>
 #include <map>
+#include <memory>
+#include <unordered_map>
 #include <string>
 #include <vector>
+#include <glm/glm.hpp>
 
 #include <al.h>
 #include <alc.h>
 
+#include "audio/Sound.hpp"
+
+/// Script is using different numeration of sounds
+/// than postion index in sfx file.
+/// Also it is needed to store range of sound.
+/// Struct is used by opcodes 018c, 018d.
+struct SoundInstanceData {
+    int id;
+    int sfx;
+    int range;
+};
+/// Hardcoded array for translation script index into sfx index
+/// (In origin it also had been hardcoded)
+/// (-1 means unlimited)
+/// @todo some of them should return
+/// random(?) number in range
+/// see comment in second column
+constexpr SoundInstanceData sfxData[] = {
+    /// for opcodes 018c
+    {78, 2857/*-2871*/, -1}, /// male pain soft
+    {79, 2857/*-2871*/, -1}, /// male pain loud
+    {80, 2290/*-2300*/, -1}, /// female pain soft
+    {81, 2290/*-2300*/, -1}, /// female pain loud
+    {82, 161/*-162*/, -1}, /// item pickup
+    {83, 161/*-162*/, -1}, /// item pickup
+    {92, 147, 40}, /// gate start
+    {93, 147, 40}, /// gate stop
+    {94, 337, -1}, /// checkpoint
+    {97, 336, -1}, /// countdown timer 3
+    {98, 336, -1}, /// countdown timer 2
+    {99, 336, -1}, /// countdown timer 1
+    {100, 337, -1}, /// countdown finish
+    {106/*-108*/, 176/*-178*/, 50}, /// bullet hit ground
+    {110/*-111*/, 389, 80},  /// silent, replace the SFX or edit the memory to a different SFX to make this useful
+    {112, 283, 80}, /// payphone
+    {114/*-115*/, 151, 60}, /// glass break
+    {116, 150, 60}, /// glass damage
+    {117, 152/*-155*/, 55}, /// glass shards
+    {118, 327, 60}, /// boxes destroyed
+    {119, 328, 60}, /// boxes destroyed
+    {120, 140/*-144*/, 60}, /// car collision
+    {121, 29, 60}, /// tire collision
+    {122, 167/*-168*/, 20}, /// gun shell drop, dependent on what collision the player is currently standing on
+    {123, 168, 20}, /// gun shell drop soft
+    /// for opcodes 018d
+    {4, 390, 30},
+    {5, 390, 80}, /// 	Hepburn Heights southwest tower
+    {6, 391, 30},
+    {7, 391, 80}, /// 	Hepburn Heights north tower
+    {8, 392, 30},
+    {9, 392, 80},
+    {10, 393, 30},
+    {11, 393, 80},
+    {12, 394, 30},
+    {13, 394, 80},
+    {14, 395, 30},
+    {15, 395, 80},
+    {16, 396, 30},
+    {17, 396, 80},
+    {18, 397, 30},
+    {19, 397, 80},
+    {20, 398, 30},
+    {21, 398, 80},
+    {22, 399, 30},
+    {23, 399, 80},
+    {24, 390, 30},
+    {25, 390, 80},
+    {26, 391, 30},
+    {27, 391, 80},
+    {28, 392, 30},
+    {29, 392, 80},
+    {30, 403, 30}, /// Meeouch Sex Kitten Club
+    {31, 403, 80},
+    {32, 404, 30}, /// 	Sex Club Seven
+    {33, 404, 80},
+    {34, 405, 30},
+    {35, 405, 30},
+    {36, 407/*-408*/, 30}, /// 		407 plays continuously while 408 plays intermittently
+    {37, 407/*-408*/, 30}, /// 	Liberty City Sawmills/Bitch'N' Dog Food
+    {38, 409, 30},
+    {39, 409, 80},
+    {40, 410/*-411*/, 30}, /// 		Both plays continuously
+    {41, 410/*-411*/, 30}, /// 	Mr. Wong's Laundrette
+    {42, 412, 30}, /// 	Roast Peking Duck
+    {43, 412, 80},
+    {44, 413, 30}, /// 	Cipriani's Ristorante
+    {45, 413, 80},
+    {46, 414, 30},
+    {47, 414, 30},
+    {48, 415, 30}, /// 	Marco's Bistro (no sound)
+    {49, 415, 80},
+    {50, 416/*-419*/, 30}, /// 		Plays separately and intermittently
+    {51, 416/*-419*/, 80}, /// 	Francis International Terminal B
+    {52, 420/*-422*/, 30},
+    {53, 420/*-422*/, 30}, /// Chinatown (no sound)
+    {54, 423/*-425*/, 30}, /// 		Plays separately and intermittently
+    {55, 423/*-425*/, 80},
+    {56, 426, 30},
+    {57, 426, 80}, /// 	Portland Docks (no sound)
+    {58, 427/*-431*/, 30}, /// 		Plays separately and intermittently
+    {59, 427/*-431*/, 80}, /// Left side of Misty's apartment
+    {60, 406, 30}, /// 	Salvatore's place
+    {61, 406, 80},
+    {62, 432/*-434*/, 20},  /// South of Sex Club Seven 	432 plays continuously while 433-434 plays separately and intermittently
+    {63, 432/*-434*/, 80},
+    {64, 435/*-437*/, 20}, /// 	East of Portland Pay 'N' Spray 	435 plays continuously while 436-437 plays separately and intermittently
+    {65, 435/*-437*/, 80},
+    {66, 438/*-440*/, 20}, /// 	Executive Relief 	438 plays continuously while 439-440 plays separately and intermittently
+    {67, 438/*-440*/, 80},
+    {68, 442, 30},
+    {69, 442, 80}, /// 	Bank of Liberty/Staunton police HQ alarm
+    {70, 441, 30},
+    {71, 441, 80}, /// 	Old school hall
+    {72, 443, 30},
+    {73, 443, 80}, /// 	Warehouse rave
+    {76, 179/*-184*/, 30}, /// 		Plays separately and intermittently
+    {77, 179/*-184*/, 80}, /// 	Staunton police HQ
+    {84, 444, 30},
+    {85, 444, 80},
+    {86, 444, 30},
+    {87, 444, 80},
+    {88, 445, 30},
+    {89, 445, 80},
+    {90, 433/*-434*/, 20}, /// 		Plays separately and intermittently
+    {91, 433/*-434*/, 80}, /// 	Right side of Misty's apartment
+    {102, 157, 50} /// 	Callahan Bridge fire
+};
+/// Nr of existing sfx sounds
+constexpr size_t kNrOfAllSfx = 3032;
+
+/// Game's sound manager.
+/// It handles all staff conntected with sounds.
+/// Worth noted: there are three types of sounds,
+/// these containg raw source and openAL buffer for playing (only one instance simultaneously),
+/// these containg only source or buffer.
+/// (It allows multiple instances simultaneously without duplicating raw source).
 class SoundManager {
 public:
     SoundManager();
     ~SoundManager();
 
+    /// Load sound from file and store it with selected name
     bool loadSound(const std::string& name, const std::string& fileName);
-    bool isLoaded(const std::string& name);
-    void playSound(const std::string& name);
-    void pauseSound(const std::string& name);
 
-    bool isPaused(const std::string& name);
+    /// Load all sfx sounds
+    void loadSfxSounds(const std::string& path);
+
+    /// Get position index in sdt file
+    int convertScriptIndexIntoSfx(const int scriptId);
+    Sound& getSoundRef(const size_t& name);
+    Sound& getSoundRef(const std::string& name);
+
+    /// Get range of sound.
+    /// (arg must be script id)
+    int getScriptRange(const int scriptId);
+    size_t  createSfxInstance(const size_t& index);
+
+    /// Checking is selected sound loaded.
+    bool isLoaded(const std::string& name);
+
+    /// Checking is selected sound playing.
     bool isPlaying(const std::string& name);
+
+    /// Checking is selected sound playing.
+    bool isStoped(const std::string& name);
+
+    /// Checking is selected sound playing.
+    bool isPaused(const std::string& name);
+
+    /// Play sound with selected name
+    void playSound(const std::string& name);
+
+    /// Effect same as playSound with one parametr,
+    /// but this function works for sfx and
+    /// allows also for setting position,
+    /// looping and max Distance.
+    /// -1 means no limit of max distance.
+    void playSfx(const size_t& name, const glm::vec3 position, const bool looping = false, const int maxDist = -1);
 
     void pauseAllSounds();
     void resumeAllSounds();
 
+    /// Play background from selected file.
     bool playBackground(const std::string& fileName);
 
     bool loadMusic(const std::string& name, const std::string& fileName);
     void playMusic(const std::string& name);
     void stopMusic(const std::string& name);
 
+    /// Setting position of listener for openAL.
+    void setListenerPosition(const glm::vec3 position);
+
+    /// Setting velocity of velocity for openAL.
+    void setListenerVelocity(const glm::vec3 vel);
+
+    /// Setting orientation of listener for openAL.
+    /// Worth noted v = { at.x, at.y, at.z, up.x, up.y, up.z}
+    void setListenerOrientation(const glm::vec3 at);
+
+    /// Setting position of sound source in buffer.
+    void setSoundPosition(const std::string name,const glm::vec3 position);
+
     void pause(bool p);
 
 private:
-    class SoundSource {
-        friend class SoundManager;
-        friend class SoundBuffer;
-
-    public:
-        void loadFromFile(const std::string& filename);
-
-    private:
-        std::vector<int16_t> data;
-
-        size_t channels;
-        size_t sampleRate;
-    };
-
-    class SoundBuffer {
-        friend class SoundManager;
-
-    public:
-        SoundBuffer();
-        bool bufferData(SoundSource& soundSource);
-
-    private:
-        ALuint source;
-        ALuint buffer;
-    };
-
-    struct Sound {
-        SoundSource source;
-        SoundBuffer buffer;
-        bool isLoaded = false;
-    };
-
     bool initializeOpenAL();
     bool initializeAVCodec();
 
     ALCcontext* alContext = nullptr;
     ALCdevice* alDevice = nullptr;
 
-    std::map<std::string, Sound> sounds;
+    /// Containers for sounds
+    std::unordered_map<std::string, Sound> sounds;
+    std::unordered_map<size_t, Sound> sfx;
+    std::unordered_map<size_t, Sound> buffers;
+
     std::string backgroundNoise;
+
+    /// Nr of already created buffers
+    size_t bufforNr = 0;
 };
 
 #endif

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -71,7 +71,7 @@ GameWorld::GameWorld(Logger* log, GameData* dat)
     gContactProcessedCallback = ContactProcessedCallback;
     dynamicsWorld->setInternalTickCallback(PhysicsTickCallback, this);
 
-    sound.loadSfxSounds(data->getDataPath().string());
+    sound.loadSfxSounds(data->getDataPath());
 }
 
 GameWorld::~GameWorld() {

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -70,6 +70,8 @@ GameWorld::GameWorld(Logger* log, GameData* dat)
         _overlappingPairCallback.get());
     gContactProcessedCallback = ContactProcessedCallback;
     dynamicsWorld->setInternalTickCallback(PhysicsTickCallback, this);
+
+    sound.loadSfxSounds(data->getDataPath().string());
 }
 
 GameWorld::~GameWorld() {

--- a/rwengine/src/script/ScriptTypes.cpp
+++ b/rwengine/src/script/ScriptTypes.cpp
@@ -219,6 +219,15 @@ ScriptObjectType<GarageInfo> ScriptArguments::getScriptObject(
     }
     return {param.handleValue(), garage};
 }
+
+template <>
+ScriptObjectType<Sound> ScriptArguments::getScriptObject(
+    unsigned int arg) const {
+    auto& param = (*this)[arg];
+    RW_CHECK(param.isLvalue(), "Non lvalue passed as object");
+    return {param.handleValue(), &getWorld()->sound.getSoundRef(arg)};
+}
+
 template <>
 ScriptObjectType<Payphone> ScriptArguments::getScriptObject(
     unsigned int arg) const {

--- a/rwengine/src/script/ScriptTypes.hpp
+++ b/rwengine/src/script/ScriptTypes.hpp
@@ -10,6 +10,7 @@
 #include <glm/glm.hpp>
 
 #include <rw/defines.hpp>
+#include "audio/SoundManager.hpp"
 
 class CharacterObject;
 class CutsceneObject;
@@ -107,9 +108,9 @@ using ScriptVehicleGenerator = ScriptObjectType<VehicleGenerator>;
 using ScriptBlip = ScriptObjectType<BlipData>;
 using ScriptGarage = ScriptObjectType<GarageInfo>;
 using ScriptPayphone = ScriptObjectType<Payphone>;
+using ScriptSound = ScriptObjectType<Sound>;
 
 /// @todo replace these with real types for sounds etc.
-using ScriptSound = ScriptObjectType<int>;
 using ScriptFire = ScriptObjectType<int>;
 using ScriptSphere = ScriptObjectType<int>;
 
@@ -347,6 +348,10 @@ ScriptObjectType<VehicleGenerator> ScriptArguments::getScriptObject(
 template <>
 ScriptObjectType<GarageInfo> ScriptArguments::getScriptObject(
     unsigned int arg) const;
+template <>
+ScriptObjectType<Sound> ScriptArguments::getScriptObject(
+    unsigned int arg) const;
+
 
 typedef std::function<void(const ScriptArguments&)> ScriptFunction;
 typedef std::function<bool(const ScriptArguments&)> ScriptFunctionBoolean;

--- a/rwengine/src/script/modules/GTA3ModuleImpl.inl
+++ b/rwengine/src/script/modules/GTA3ModuleImpl.inl
@@ -11339,9 +11339,9 @@ void opcode_03d6(const ScriptArguments& args, const ScriptString gxtEntry) {
     @arg coord Coordinates
 */
 void opcode_03d7(const ScriptArguments& args, ScriptVec3 coord) {
-    RW_UNIMPLEMENTED_OPCODE(0x03d7);
-    RW_UNUSED(coord);
-    RW_UNUSED(args);
+    auto world = args.getWorld();
+    auto& wav = world->sound.getSoundRef(world->missionAudio);
+    wav.setPosition(coord);
 }
 
 /**

--- a/rwengine/src/script/modules/GTA3ModuleImpl.inl
+++ b/rwengine/src/script/modules/GTA3ModuleImpl.inl
@@ -17,6 +17,8 @@
 #include <data/CutsceneData.hpp>
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <string>
+#include <iostream>
 
 /**
     @brief NOP
@@ -4263,10 +4265,9 @@ void opcode_018b(const ScriptArguments& args, const ScriptBlip blip, const Scrip
     @arg sound 
 */
 void opcode_018c(const ScriptArguments& args, ScriptVec3 coord, const ScriptSoundType sound) {
-    RW_UNIMPLEMENTED_OPCODE(0x018c);
-    RW_UNUSED(coord);
-    RW_UNUSED(sound);
-    RW_UNUSED(args);
+    auto world = args.getWorld();
+    auto name = world->sound.createSfxInstance(world->sound.convertScriptIndexIntoSfx(sound));
+    world->sound.playSfx(name, coord, false, world->sound.getScriptRange(sound)/2);
 }
 
 /**
@@ -4278,11 +4279,10 @@ void opcode_018c(const ScriptArguments& args, ScriptVec3 coord, const ScriptSoun
     @arg sound1 
 */
 void opcode_018d(const ScriptArguments& args, ScriptVec3 coord, const ScriptSoundType sound0, ScriptSound& sound1) {
-    RW_UNIMPLEMENTED_OPCODE(0x018d);
-    RW_UNUSED(coord);
-    RW_UNUSED(sound0);
-    RW_UNUSED(sound1);
-    RW_UNUSED(args);
+    auto world = args.getWorld();
+    auto bufferName = world->sound.createSfxInstance(world->sound.convertScriptIndexIntoSfx(sound0));
+    world->sound.playSfx(bufferName, coord, true, world->sound.getScriptRange(sound0)/2);
+    sound1 = &world->sound.getSoundRef(bufferName);
 }
 
 /**
@@ -4291,10 +4291,9 @@ void opcode_018d(const ScriptArguments& args, ScriptVec3 coord, const ScriptSoun
     opcode 018e
     @arg sound 
 */
-void opcode_018e(const ScriptArguments& args, const ScriptSound sound) {
-    RW_UNIMPLEMENTED_OPCODE(0x018e);
-    RW_UNUSED(sound);
+void opcode_018e(const ScriptArguments& args, ScriptSound& sound) {
     RW_UNUSED(args);
+    sound->stop();
 }
 
 /**
@@ -10398,7 +10397,7 @@ void opcode_0394(const ScriptArguments& args, const ScriptInt arg1) {
     }
     else if (args.getWorld()->missionAudio.length() > 0)
     {
-    	args.getWorld()->sound.playSound(args.getWorld()->missionAudio);
+        args.getWorld()->sound.playSound(args.getWorld()->missionAudio);
     }
 }
 

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -599,6 +599,12 @@ void RWGame::render(float alpha, float time) {
         viewCam.frustum.fov *= viewCam.frustum.aspectRatio;
     }
 
+    //Update Listener parameters
+    // @todo ShFil119 it should be improved
+    world->sound.setListenerPosition(currentCam.position);
+    world->sound.setListenerOrientation(glm::vec3(currentCam.rotation.x, currentCam.rotation.y, currentCam.rotation.z));
+    world->sound.setListenerVelocity(glm::vec3());
+
     glEnable(GL_DEPTH_TEST);
     glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
 

--- a/rwlib/CMakeLists.txt
+++ b/rwlib/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries(rwlib
     PUBLIC
         glm::glm
         openrw::interface
+        ffmpeg::ffmpeg
     PRIVATE
         OpenGL::GL
     )

--- a/rwlib/source/loaders/LoaderSDT.cpp
+++ b/rwlib/source/loaders/LoaderSDT.cpp
@@ -52,6 +52,7 @@ bool LoaderSDT::load(const rwfs::path& path) {
         m_archive = rawName;
         return true;
     } else {
+        RW_ERROR("Error cannot find " << path);
         return false;
     }
 }

--- a/rwlib/source/loaders/LoaderSDT.cpp
+++ b/rwlib/source/loaders/LoaderSDT.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <cstdio>
 #include <string>
+#include <libavutil/file.h>
 
 #include "rw/defines.hpp"
 
@@ -113,6 +114,46 @@ char* LoaderSDT::loadToMemory(size_t index, bool asWave) {
         return raw_data;
     } else
         return nullptr;
+}
+
+static int read_packet(void *opaque, uint8_t *buf, int buf_size) {
+    auto* bd = reinterpret_cast<bufferData*>(opaque);
+    buf_size = FFMIN(buf_size, bd->size);
+    /* copy internal buffer data to buf */
+    memcpy(buf, bd->ptr, buf_size);
+    bd->ptr  += buf_size;
+    bd->size -= buf_size;
+    return buf_size;
+}
+
+AVFormatContext* LoaderSDT::loadSound(size_t index, bool asWave) {
+    raw_sound = loadToMemory(index, asWave);
+    if (!raw_sound) {
+        return nullptr;
+    }
+
+    bool found = findAssetInfo(index, assetInfo);
+    if (!found || !raw_sound) {
+        RW_ERROR("Error loading sound");
+        return nullptr;
+    }
+    ioBuffer = reinterpret_cast<uint8_t*>(av_malloc(ioBufferSize)); /// Will be freeded in SoundManager after buffering
+
+    bd = std::make_unique<bufferData>();
+    av_register_all();
+
+    bd->size = sizeof(WaveHeader) + assetInfo.size;
+    bdDataStart = std::make_unique<uint8_t[]>(bd->size); /// Store start ptr of data to be able freed memory later
+    bd->ptr = bdDataStart.get();
+
+    memcpy(bd->ptr, raw_sound, bd->size);
+
+
+    AVIOContext* avioContext = avio_alloc_context(ioBuffer, ioBufferSize, 0, &*bd, &read_packet, nullptr, nullptr); /// Will be freeded in SoundManager
+    AVFormatContext* container = avformat_alloc_context();
+    container->pb = avioContext;
+
+    return container;
 }
 
 /// Writes the contents of assetname to filename

--- a/rwlib/source/loaders/LoaderSDT.cpp
+++ b/rwlib/source/loaders/LoaderSDT.cpp
@@ -140,7 +140,6 @@ AVFormatContext* LoaderSDT::loadSound(size_t index, bool asWave) {
     ioBuffer = reinterpret_cast<uint8_t*>(av_malloc(ioBufferSize)); /// Will be freeded in SoundManager after buffering
 
     bd = std::make_unique<bufferData>();
-    av_register_all();
 
     bd->size = sizeof(WaveHeader) + assetInfo.size;
     bdDataStart = std::make_unique<uint8_t[]>(bd->size); /// Store start ptr of data to be able freed memory later

--- a/rwlib/source/loaders/LoaderSDT.cpp
+++ b/rwlib/source/loaders/LoaderSDT.cpp
@@ -29,9 +29,9 @@ typedef struct {
     } data;
 } WaveHeader;
 
-bool LoaderSDT::load(const std::string& filename) {
-    const auto sdtName = filename + ".SDT";
-    const auto rawName = filename + ".RAW";
+bool LoaderSDT::load(const rwfs::path& path) {
+    const auto sdtName = path.string() + ".SDT";
+    const auto rawName = path.string() + ".RAW";
 
     FILE* fp = fopen(sdtName.c_str(), "rb");
     if (fp) {

--- a/rwlib/source/loaders/LoaderSDT.cpp
+++ b/rwlib/source/loaders/LoaderSDT.cpp
@@ -3,7 +3,6 @@
 #include <cstring>
 #include <cstdio>
 #include <string>
-#include <libavutil/file.h>
 
 #include "rw/defines.hpp"
 

--- a/rwlib/source/loaders/LoaderSDT.hpp
+++ b/rwlib/source/loaders/LoaderSDT.hpp
@@ -1,6 +1,8 @@
 #ifndef _LIBRW_LOADERSDT_HPP_
 #define _LIBRW_LOADERSDT_HPP_
 
+#include <rw/filesystem.hpp>
+
 #include <cstdint>
 #include <cstddef>
 #include <memory>
@@ -64,7 +66,7 @@ public:
 
     /// Load the structure of the archive
     /// Omit the extension in filename
-    bool load(const std::string& filename);
+    bool load(const rwfs::path& path);
 
     /// Load a file from the archive to memory and pass a pointer to it
     /// Warning: Please delete[] the memory in the end.

--- a/rwlib/source/loaders/LoaderSDT.hpp
+++ b/rwlib/source/loaders/LoaderSDT.hpp
@@ -8,10 +8,13 @@
 #include <vector>
 
 extern "C" {
+#include <libavutil/opt.h>
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
-#include <libavutil/avutil.h>
 #include <libavformat/avio.h>
+#include <libavutil/avutil.h>
+#include <libavutil/opt.h>
+#include <libswresample/swresample.h>
 }
 
 // Rename some functions for older libavcodec/ffmpeg versions (e.g. Ubuntu Trusty)


### PR DESCRIPTION
A lot of changes after #372.
To do: 
- [x]  fix memory leaks, It's hard to determine when should/can I remove bd and ioBuffer.
- [x] ScriptSoundType isn't sound's position in sfx file, so sounds are mixed,
- [x] fix build,
- [x] setting type ScriptSound(opcodes 018d, 018e),
- [x] drop deprecated methods,
- [x] cleanup, div code in commits (done?),
- [x] stl algorithms 
- [x] drop av_register_all()
- [x] opcode 03d7
- [x] remove mutexes,
- [ ] cleanup 2.
- [x] rwfs::path

To do (after?)
- [ ] updating listener position,
- [ ] RE calculating sound volume,
- [ ] some continuous sounds have break time (how long?), 
- [ ] resampling sfx.

As always feedback and criticism are welcome.

#edit1 implemented hardcoded table for translating between script and sfx numeration.
#edit2 plugged leaks.
#edit3 fixed build system.