### PR TITLE
cmake: use OpenGL GLVND libraries by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ include("${PROJECT_SOURCE_DIR}/cmake_options.cmake")
 # Create a rw_interface TARGET that holds all compiler options
 include("${PROJECT_SOURCE_DIR}/cmake_configure.cmake")
 
+set(OpenGL_GL_PREFERENCE GLVND)
 find_package(OpenGL REQUIRED)
 find_package(OpenAL REQUIRED)
 find_package(Bullet REQUIRED)


### PR DESCRIPTION
Needed since CMake 3.11.0: CMP0072 policy

https://cmake.org/cmake/help/v3.11/policy/CMP0072.html

Silences this warning:
```
CMake Warning (dev) at /usr/share/cmake/Modules/FindOpenGL.cmake:270 (message):
  Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when
  available.  Run "cmake --help-policy CMP0072" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  FindOpenGL found both a legacy GL library:

    OPENGL_gl_LIBRARY: /usr/lib64/libGL.so

  and GLVND libraries for OpenGL and GLX:

    OPENGL_opengl_LIBRARY: /usr/lib64/libOpenGL.so
    OPENGL_glx_LIBRARY: /usr/lib64/libGLX.so

  OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
  compatibility with CMake 3.10 and below the legacy GL library will be used.
Call Stack (most recent call first):
  cmake/modules/FindOpenGL.cmake:4 (include)
  CMakeLists.txt:11 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

