### PR TITLE
Fix pausing issues

### DIFF
--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -415,9 +415,9 @@ int RWGame::run() {
         auto now = chrono::steady_clock::now();
         auto deltaTime = chrono::duration<float>(now - lastFrame).count();
         lastFrame = now;
-        accumulatedTime += deltaTime;
 
         if(!world->isPaused()) {
+            accumulatedTime += deltaTime;
             world->dynamicsWorld->stepSimulation(deltaTime * timescale, kMaxPhysicsSubSteps, kPhysicsTimeStep);
         }
 


### PR DESCRIPTION
Fixes issue #380 

Behavior described in the above issue was not limited only to cutscenes. In any case the game was paused, it "catch" up the time it was paused after unpausing. This can be noticed most easily by checking the in-game clock before pausing the game, waiting for a while and after unpausing the game clock fast forwarded regarding the time it was paused. This PR fixes that issue.