### PR TITLE
Added transparency for pickups

### DIFF
--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -341,7 +341,6 @@ void GameRenderer::renderWorld(GameWorld* world, const ViewCamera& camera,
     culled += objectRenderer.culled;
     renderer->pushDebugGroup("Objects");
     renderer->pushDebugGroup("RenderList");
-
     // Also parallelizable
     RW_PROFILE_BEGIN("Sort");
     // Earlier position in the array means earlier object's rendering
@@ -349,12 +348,11 @@ void GameRenderer::renderWorld(GameWorld* world, const ViewCamera& camera,
     std::sort(renderList.begin(), renderList.end(),
               [](const Renderer::RenderInstruction& a,
                  const Renderer::RenderInstruction& b) {
-                    if (!a.drawInfo.blend && b.drawInfo.blend) return true;
-                    if (a.drawInfo.blend && !b.drawInfo.blend) return false;
+                    if (a.drawInfo.blendMode==BLEND_NONE && b.drawInfo.blendMode!=BLEND_NONE) return true;
+                    if (a.drawInfo.blendMode!=BLEND_NONE && b.drawInfo.blendMode==BLEND_NONE) return false;
                     return (a.sortKey > b.sortKey);
               });
     RW_PROFILE_END();
-
     RW_PROFILE_BEGIN("Draw");
     renderer->drawBatched(renderList);
     RW_PROFILE_END();
@@ -519,8 +517,7 @@ void GameRenderer::renderEffects(GameWorld* world) {
         dp.colour = glm::u8vec4(particle.colour * 255.f);
         dp.start = 0;
         dp.count = 4;
-        dp.blend = true;
-        dp.blendMode = 1;
+        dp.blendMode = BLEND_ADDITIVE;
         dp.diffuse = 1.f;
 
         renderer->drawArrays(transformMat, &particleDraw, dp);

--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -348,8 +348,8 @@ void GameRenderer::renderWorld(GameWorld* world, const ViewCamera& camera,
     std::sort(renderList.begin(), renderList.end(),
               [](const Renderer::RenderInstruction& a,
                  const Renderer::RenderInstruction& b) {
-                    if (a.drawInfo.blendMode==BLEND_NONE && b.drawInfo.blendMode!=BLEND_NONE) return true;
-                    if (a.drawInfo.blendMode!=BLEND_NONE && b.drawInfo.blendMode==BLEND_NONE) return false;
+                    if (a.drawInfo.blendMode==BlendMode::BLEND_NONE && b.drawInfo.blendMode!=BlendMode::BLEND_NONE) return true;
+                    if (a.drawInfo.blendMode!=BlendMode::BLEND_NONE && b.drawInfo.blendMode==BlendMode::BLEND_NONE) return false;
                     return (a.sortKey > b.sortKey);
               });
     RW_PROFILE_END();
@@ -517,7 +517,7 @@ void GameRenderer::renderEffects(GameWorld* world) {
         dp.colour = glm::u8vec4(particle.colour * 255.f);
         dp.start = 0;
         dp.count = 4;
-        dp.blendMode = BLEND_ADDITIVE;
+        dp.blendMode = BlendMode::BLEND_ADDITIVE;
         dp.diffuse = 1.f;
 
         renderer->drawArrays(transformMat, &particleDraw, dp);

--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -408,6 +408,8 @@ void GameRenderer::renderWorld(GameWorld* world, const ViewCamera& camera,
 
     float fadeTimer = world->getGameTime() - world->state->fadeStart;
     if (fadeTimer < world->state->fadeTime || !world->state->fadeOut) {
+        /// @todo rewrite this render code to use renderer class
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         glUseProgram(ssRectProgram);
         glUniform2f(ssRectOffset, 0.f, 0.f);
         glUniform2f(ssRectSize, 1.f, 1.f);
@@ -542,7 +544,9 @@ void GameRenderer::drawTexture(TextureData* texture, glm::vec4 extents) {
     extents.y -= .5f;
     extents *= glm::vec4(2.f, -2.f, 1.f, 1.f);
 
+    /// @todo rewrite this render code to use renderer class
     glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glUniform2f(ssRectOffset, extents.x, extents.y);
     glUniform2f(ssRectSize, extents.z, extents.w);
 
@@ -572,7 +576,9 @@ void GameRenderer::drawColour(const glm::vec4& colour, glm::vec4 extents) {
     extents.y -= .5f;
     extents *= glm::vec4(2.f, -2.f, 1.f, 1.f);
 
+    /// @todo rewrite this render code to use renderer class
     glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glUniform2f(ssRectOffset, extents.x, extents.y);
     glUniform2f(ssRectSize, extents.z, extents.w);
 
@@ -672,7 +678,9 @@ void GameRenderer::renderPaths() {
 }
 
 void GameRenderer::renderLetterbox() {
+    /// @todo rewrite this render code to use renderer class
     glUseProgram(ssRectProgram);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     const float cinematicExperienceSize = 0.15f;
     glUniform2f(ssRectOffset, 0.f, -1.f * (1.f - cinematicExperienceSize));
     glUniform2f(ssRectSize, 1.f, cinematicExperienceSize);

--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -520,6 +520,7 @@ void GameRenderer::renderEffects(GameWorld* world) {
         dp.start = 0;
         dp.count = 4;
         dp.blend = true;
+        dp.blendMode = 1;
         dp.diffuse = 1.f;
 
         renderer->drawArrays(transformMat, &particleDraw, dp);

--- a/rwengine/src/render/MapRenderer.cpp
+++ b/rwengine/src/render/MapRenderer.cpp
@@ -77,7 +77,7 @@ void MapRenderer::draw(GameWorld* world, const MapInfo& mi) {
 
     Renderer::DrawParameters dp { };
     dp.start = 0;
-    dp.blend = true;
+    dp.blendMode = BLEND_ALPHA;
     dp.depthWrite = false;
 
     // World out the number of units per tile

--- a/rwengine/src/render/MapRenderer.cpp
+++ b/rwengine/src/render/MapRenderer.cpp
@@ -77,7 +77,7 @@ void MapRenderer::draw(GameWorld* world, const MapInfo& mi) {
 
     Renderer::DrawParameters dp { };
     dp.start = 0;
-    dp.blendMode = BLEND_ALPHA;
+    dp.blendMode = BlendMode::BLEND_ALPHA;
     dp.depthWrite = false;
 
     // World out the number of units per tile

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -100,7 +100,7 @@ void ObjectRenderer::renderGeometry(Geometry* geom,
             dp.ambient = mat.ambientIntensity;
         }
 
-        dp.blend = isTransparent;
+        dp.blendMode = isTransparent ? BLEND_ALPHA : BLEND_NONE;
 
         glm::vec3 position(modelMatrix[3]);
         float distance = glm::length(m_camera.position - position);

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -100,7 +100,7 @@ void ObjectRenderer::renderGeometry(Geometry* geom,
             dp.ambient = mat.ambientIntensity;
         }
 
-        dp.blendMode = isTransparent ? BLEND_ALPHA : BLEND_NONE;
+        dp.blendMode = isTransparent ? BlendMode::BLEND_ALPHA : BlendMode::BLEND_NONE;
 
         glm::vec3 position(modelMatrix[3]);
         float distance = glm::length(m_camera.position - position);

--- a/rwengine/src/render/OpenGLRenderer.cpp
+++ b/rwengine/src/render/OpenGLRenderer.cpp
@@ -280,7 +280,7 @@ void OpenGLRenderer::setDrawState(const glm::mat4& model, DrawBuffer* draw,
         useTexture(u, p.textures[u]);
     }
 
-    setBlend(p.blend);
+    setBlend(p.blend,p.blendMode);
     setDepthWrite(p.depthWrite);
 
     ObjectUniformData objectData{model,

--- a/rwengine/src/render/OpenGLRenderer.cpp
+++ b/rwengine/src/render/OpenGLRenderer.cpp
@@ -280,7 +280,7 @@ void OpenGLRenderer::setDrawState(const glm::mat4& model, DrawBuffer* draw,
         useTexture(u, p.textures[u]);
     }
 
-    setBlend(p.blend,p.blendMode);
+    setBlend(p.blendMode);
     setDepthWrite(p.depthWrite);
 
     ObjectUniformData objectData{model,
@@ -368,8 +368,7 @@ void OpenGLRenderer::invalidate() {
     currentProgram = nullptr;
     currentTextures.clear();
     currentUBO = 0;
-    blendEnabled = false;
-    glDisable(GL_BLEND);
+    setBlend(BLEND_NONE);
 }
 
 bool OpenGLRenderer::createUBO(Buffer &out, GLsizei size, GLsizei entrySize)

--- a/rwengine/src/render/OpenGLRenderer.cpp
+++ b/rwengine/src/render/OpenGLRenderer.cpp
@@ -368,7 +368,7 @@ void OpenGLRenderer::invalidate() {
     currentProgram = nullptr;
     currentTextures.clear();
     currentUBO = 0;
-    setBlend(BLEND_NONE);
+    setBlend(BlendMode::BLEND_NONE);
 }
 
 bool OpenGLRenderer::createUBO(Buffer &out, GLsizei size, GLsizei entrySize)

--- a/rwengine/src/render/OpenGLRenderer.hpp
+++ b/rwengine/src/render/OpenGLRenderer.hpp
@@ -75,6 +75,8 @@ public:
         Textures textures;
         /// Alpha blending state
         bool blend;
+        /// Blending mode 0 - glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); 1 - glBlendFunc(GL_ONE, GL_ONE);
+        size_t blendMode;
         // Depth writing state
         bool depthWrite;
         /// Material
@@ -89,6 +91,7 @@ public:
         // Default state -- should be moved to materials
         DrawParameters()
             : blend(false)
+            , blendMode(0)
             , depthWrite(true)
             , ambient(1.f)
             , diffuse(1.f)
@@ -339,17 +342,33 @@ private:
     DrawBuffer* currentDbuff = nullptr;
     OpenGLShaderProgram* currentProgram = nullptr;
     bool blendEnabled = false;
+    size_t blendMode = 0;
     bool depthWriteEnabled = false;
     GLuint currentUBO = 0;
     GLuint currentUnit = 0;
     std::map<GLuint, GLuint> currentTextures;
 
+    void setBlendMode(size_t mode) {
+        switch (mode) {
+            default:
+            case 0:
+                glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+                break;
+            case 1:
+                glBlendFunc(GL_ONE, GL_ONE);
+                break;
+        }
+        blendMode = mode;
+    }
+
     // Set state
-    void setBlend(bool enable) {
+    void setBlend(bool enable, size_t mode) {
         if (enable && !blendEnabled) {
             glEnable(GL_BLEND);
-            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            setBlendMode(mode);
             blendEnabled = enable;
+        } else if (enable && blendEnabled && blendMode!=mode) {
+            setBlendMode(mode);
         } else if(!enable && blendEnabled) {
             glDisable(GL_BLEND);
             blendEnabled = enable;

--- a/rwengine/src/render/OpenGLRenderer.hpp
+++ b/rwengine/src/render/OpenGLRenderer.hpp
@@ -97,7 +97,7 @@ public:
 
         // Default state -- should be moved to materials
         DrawParameters()
-            : blendMode(BLEND_NONE)
+            : blendMode(BlendMode::BLEND_NONE)
             , depthWrite(true)
             , ambient(1.f)
             , diffuse(1.f)
@@ -347,7 +347,7 @@ private:
     // State Cache
     DrawBuffer* currentDbuff = nullptr;
     OpenGLShaderProgram* currentProgram = nullptr;
-    BlendMode blendMode = BLEND_NONE;
+    BlendMode blendMode = BlendMode::BLEND_NONE;
     bool depthWriteEnabled = false;
     GLuint currentUBO = 0;
     GLuint currentUnit = 0;
@@ -355,7 +355,7 @@ private:
 
     // Set state
     void setBlend(BlendMode mode) {
-        if (mode!=BLEND_NONE && blendMode==BLEND_NONE)//To don't call glEnable again when it already enabled
+        if (mode!=BlendMode::BLEND_NONE && blendMode==BlendMode::BLEND_NONE)//To don't call glEnable again when it already enabled
             glEnable(GL_BLEND);
 
         if (mode!=blendMode) {
@@ -363,13 +363,13 @@ private:
                 default:
                     assert(false);
                     break;
-                case BLEND_NONE:
+                case BlendMode::BLEND_NONE:
                     glDisable(GL_BLEND);
                     break;
-                case BLEND_ALPHA:
+                case BlendMode::BLEND_ALPHA:
                     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
                     break;
-                case BLEND_ADDITIVE:
+                case BlendMode::BLEND_ADDITIVE:
                     glBlendFunc(GL_ONE, GL_ONE);
                     break;
 

--- a/rwengine/src/render/OpenGLRenderer.hpp
+++ b/rwengine/src/render/OpenGLRenderer.hpp
@@ -56,7 +56,7 @@ struct VertexP3 {
 /**
  * Enum used to determine which blending mode to use
  */
-enum BlendMode {
+enum class BlendMode {
     BLEND_NONE,
     BLEND_ALPHA,
     BLEND_ADDITIVE
@@ -361,6 +361,8 @@ private:
         if (mode!=blendMode) {
             switch (mode) {
                 default:
+                    assert(false);
+                    break;
                 case BLEND_NONE:
                     glDisable(GL_BLEND);
                     break;

--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -294,7 +294,7 @@ void TextRenderer::renderText(const TextRenderer::TextInfo& ti,
 
     Renderer::DrawParameters dp;
     dp.start = 0;
-    dp.blendMode = BLEND_ALPHA;
+    dp.blendMode = BlendMode::BLEND_ALPHA;
     dp.count = gb.getCount();
     auto ftexture = renderer->getData()->findSlotTexture("fonts", fonts[ti.font]);
     dp.textures = {ftexture->getName()};

--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -294,7 +294,7 @@ void TextRenderer::renderText(const TextRenderer::TextInfo& ti,
 
     Renderer::DrawParameters dp;
     dp.start = 0;
-    dp.blend = true;
+    dp.blendMode = BLEND_ALPHA;
     dp.count = gb.getCount();
     auto ftexture = renderer->getData()->findSlotTexture("fonts", fonts[ti.font]);
     dp.textures = {ftexture->getName()};


### PR DESCRIPTION
It seems code of changing weapon corona color in master written to use additive blending
<p><details><summary>Also in GTA 3 and VC(at least in VC) using additive blending for weapon coronas(clickable)</summary><p>

 ---
  So there is a directx code that i got with MS PIX(part of directx sdk):
  ![image](https://i.imgur.com/wmBQ9d1.png)
  As you can see GTA VC is using additive blending
  Also you might notice that in one moment corona look the same as in GTA 3, so we can make a conclusion that in it used almost the same render code:
  ![image](https://i.imgur.com/v7ji1fm.png)

  [Here](http://www.mediafire.com/file/f38uonxzkr8c3bj/VC.PIXRun) is output of PIX for more detail researching

 Also I tried to do the same for GTA 3 but all my tries(I tried to use MS PIX and apitrace) were unsuccessful

 ---

  </p></details></p>

So I added choosing of blending mode in setBlend and DisplayParameters: default(alpha-blending) and additive blending
But here are some problems:
1. Almost everywhere used DisplayParameters and setBlend, but in some places instead of they direcrly used glEnable(GL_BLEND) that causing problems with adding multiply blend modes
2. Also in some places render code expects that alpha-blending enabled
3. Also we have OpenGLRenderer class so I think is better to place all OpenGL-dependend code into it and add some wrappers to use it in GameRenderer, MapRenderer and other classes instead of using direct OpenGL calls, because if later we will decide to add other graphical backend it will create some additional difficulties(May be should add this to issues as improvement?)

To do:
- [x] Fix render bugs caused by 1 and 2

___

Special thanks to @JayFoxRox for [help](https://github.com/rwengine/openrw/pull/422#issuecomment-385413791)