### PR TITLE
[Ready] Respawn functionality

### DIFF
--- a/rwengine/src/ai/PlayerController.hpp
+++ b/rwengine/src/ai/PlayerController.hpp
@@ -1,18 +1,32 @@
 #ifndef _RWENGINE_PLAYERCONTROLLER_HPP_
 #define _RWENGINE_PLAYERCONTROLLER_HPP_
 
+#include <ai/CharacterController.hpp>
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
-#include <ai/CharacterController.hpp>
 
 class PlayerController : public CharacterController {
-    glm::quat cameraRotation{1.0f,0.0f,0.0f,0.0f};
+    glm::quat cameraRotation{1.0f, 0.0f, 0.0f, 0.0f};
 
     glm::vec3 direction{};
 
     glm::quat lastRotation;
 
+    bool missionRestartRequired;
+
     bool _enabled;
+
+    enum RestartState {
+        Alive,
+        FadingIn,
+        Restarting,
+        FadingOut,
+    } restartState;
+
+    // handles player respawn logic
+    void restartLogic();
+
+    void restart();
 
 public:
     PlayerController();
@@ -32,6 +46,14 @@ public:
     void exitVehicle();
 
     void enterNearestVehicle();
+
+    void requestMissionRestart();
+
+    bool isMissionRestartRequired() const;
+
+    bool isWasted() const;
+    // @todo not implemented yet
+    bool isBusted() const;
 
     void update(float dt) override;
 

--- a/rwengine/src/engine/GameState.hpp
+++ b/rwengine/src/engine/GameState.hpp
@@ -2,8 +2,8 @@
 #define _RWENGINE_GAMESTATE_HPP_
 #include <bitset>
 #include <cstdint>
-#include <string>
 #include <map>
+#include <string>
 #include <vector>
 
 #include <glm/glm.hpp>
@@ -11,7 +11,9 @@
 
 #include <data/GameTexts.hpp>
 #include <data/VehicleGenerator.hpp>
+#include <engine/GameData.hpp>
 #include <engine/GameInputState.hpp>
+#include <engine/GameWorld.hpp>
 #include <engine/ScreenText.hpp>
 #include <objects/ObjectTypes.hpp>
 
@@ -191,7 +193,7 @@ struct BlipData {
 
     uint16_t size = 3;  // Only used if texture is empty
 
-    uint8_t brightness = 1; // Don't really know how it is used 
+    uint8_t brightness = 1;  // Don't really know how it is used
 
     enum DisplayMode { Hide = 0, MarkerOnly = 1, RadarOnly = 2, ShowBoth = 3 };
 
@@ -323,14 +325,31 @@ public:
     /** Objects created by the current mission */
     std::vector<GameObject*> missionObjects;
 
-    bool overrideNextStart;
+    bool overrideNextRestart;
     glm::vec4 nextRestartLocation;
+    std::vector<glm::vec4> hospitalRestarts, policeRestarts;
+    int hospitalIslandOverride, policeIslandOverride;
+
+    void addHospitalRestart(const glm::vec4 location);
+    void addPoliceRestart(const glm::vec4 location);
+    void overrideRestart(const glm::vec4 location);
+    void cancelRestartOverride();
+
+    enum RestartType { Hospital, Police };
+
+    const glm::vec4 getClosestRestart(RestartType type,
+                                      const glm::vec3 playerPosition) const;
 
     bool fadeOut;
     float fadeStart;
     float fadeTime;
     bool fadeSound;
     glm::u16vec3 fadeColour;
+
+    // @todo fadeOut should be replaced with enum?
+    void fade(float time, bool f);
+    bool isFading() const;
+    void setFadeColour(glm::i32vec3 colour);
 
     std::string currentSplash;
 
@@ -393,7 +412,7 @@ public:
      */
     ScriptMachine* script;
 
-    std::array<ScriptContactData, 16> scriptContacts = { };
+    std::array<ScriptContactData, 16> scriptContacts = {};
 
     GameState();
 

--- a/rwengine/src/objects/CharacterObject.hpp
+++ b/rwengine/src/objects/CharacterObject.hpp
@@ -7,8 +7,8 @@
 #include <cstdint>
 #include <string>
 
-#include <glm/gtc/constants.hpp>
 #include <glm/glm.hpp>
+#include <glm/gtc/constants.hpp>
 
 #include <rw/forward.hpp>
 
@@ -37,6 +37,8 @@ struct CharacterWeaponSlot {
 struct CharacterState {
     float health = 100.f;
     float armour = 0.f;
+    bool isDying = false;
+    bool isDead = false;
     std::array<CharacterWeaponSlot, kMaxInventorySlots> weapons;
     uint16_t currentWeapon = 0;
     uint32_t lastFireTimeMS = 0;
@@ -129,7 +131,13 @@ public:
 
     bool isPlayer() const;
 
+    bool isDying() const;
+    bool isDead() const;
     bool isAlive() const;
+
+    void Die();
+    void SetDead();
+
     bool takeDamage(const DamageInfo& damage) override;
 
     bool enterVehicle(VehicleObject* vehicle, size_t seat);
@@ -186,7 +194,8 @@ public:
     glm::vec3 getLookDirection() const {
         float theta = m_look.y - glm::half_pi<float>();
         return glm::vec3(std::sin(-m_look.x) * std::cos(theta),
-                         std::cos(-m_look.x) * std::cos(theta), std::sin(theta));
+                         std::cos(-m_look.x) * std::cos(theta),
+                         std::sin(theta));
     }
 
     /**
@@ -250,6 +259,8 @@ public:
     void useItem(bool active, bool primary = true);
 
     void cycleInventory(bool up);
+
+    void clearInventory();
 };
 
 #endif

--- a/rwengine/src/script/modules/GTA3ModuleImpl.inl
+++ b/rwengine/src/script/modules/GTA3ModuleImpl.inl
@@ -3175,10 +3175,8 @@ void opcode_0114(const ScriptArguments& args, const ScriptCharacter character, c
     @arg player Player
 */
 bool opcode_0117(const ScriptArguments& args, const ScriptPlayer player) {
-    RW_UNIMPLEMENTED_OPCODE(0x0117);
-    RW_UNUSED(player);
     RW_UNUSED(args);
-    return false;
+    return player->isWasted();
 }
 
 /**


### PR DESCRIPTION
Respawning is now handled, related opcodes seemed to work.

Closes #48

- [x] Respawning to closest place
- [x] Island overrides for hospitals and jails
- [x] Raw position overrides
- [x] Handling money
- [x] Free health care
- [x] Getting out of jail free
- [x] Penalty calculation based on number of wanted stars
- [x] Fading with correct timing and colours
- [x] Advancing time
- [x] Clearing weapons
- [x] Improve dying state for character object
- [x] Opcodes
- [x] Refactor? fading stuff, so you can fade by calling a function
- [x] Show wasted / busted text
- [x] ~~~Camera flying away~~~ (not going to do now)
- [x] Increment death/jail stat
- [x] Mission override restart fixed