### PR TITLE
Fixed loading ZoneCylinder texture

### DIFF
--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -409,6 +409,15 @@ ClumpPtr GameData::loadClump(const std::string& name) {
     return m;
 }
 
+ClumpPtr GameData::loadClump(const std::string& name, const std::string& textureSlot) {
+    std::string currentSlot = currenttextureslot;
+    if (textureSlot.size()>0)
+        currenttextureslot = textureSlot;
+    ClumpPtr result = loadClump(name);
+    currenttextureslot = currentSlot;
+    return result;
+}
+
 void GameData::loadModelFile(const std::string& name) {
     auto file = index.openFilePath(name);
     if (!file) {

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -411,7 +411,7 @@ ClumpPtr GameData::loadClump(const std::string& name) {
 
 ClumpPtr GameData::loadClump(const std::string& name, const std::string& textureSlot) {
     std::string currentSlot = currenttextureslot;
-    if (textureSlot.size()>0)
+    if (!textureSlot.empty())
         currenttextureslot = textureSlot;
     ClumpPtr result = loadClump(name);
     currenttextureslot = currentSlot;

--- a/rwengine/src/engine/GameData.hpp
+++ b/rwengine/src/engine/GameData.hpp
@@ -143,6 +143,11 @@ public:
     ClumpPtr loadClump(const std::string& name);
 
     /**
+     * Loads an archived model and returns it directly
+     */
+    ClumpPtr loadClump(const std::string& name, const std::string& textureSlot);
+
+    /**
      * Loads a DFF and associates its atomics with models.
      */
     void loadModelFile(const std::string& name);

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -26,7 +26,7 @@
 #include <iomanip>
 #include <iostream>
 
-std::map<GameRenderer::SpecialModel, std::pair<std::string,std::string>> kSpecialModels = {
+const std::map<GameRenderer::SpecialModel, std::pair<std::string,std::string>> kSpecialModels = {
     {GameRenderer::ZoneCylinderA, std::pair<std::string,std::string>("zonecyla.dff", "particle")},
     {GameRenderer::ZoneCylinderB, std::pair<std::string,std::string>("zonecylb.dff", "particle")},
     {GameRenderer::Arrow,         std::pair<std::string,std::string>("arrow.dff",    "")}};

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -26,10 +26,10 @@
 #include <iomanip>
 #include <iostream>
 
-std::map<GameRenderer::SpecialModel, std::string> kSpecialModels = {
-    {GameRenderer::ZoneCylinderA, "zonecyla.dff"},
-    {GameRenderer::ZoneCylinderB, "zonecylb.dff"},
-    {GameRenderer::Arrow, "arrow.dff"}};
+std::map<GameRenderer::SpecialModel, std::pair<std::string,std::string>> kSpecialModels = {
+    {GameRenderer::ZoneCylinderA, std::pair<std::string,std::string>("zonecyla.dff", "particle")},
+    {GameRenderer::ZoneCylinderB, std::pair<std::string,std::string>("zonecylb.dff", "particle")},
+    {GameRenderer::Arrow,         std::pair<std::string,std::string>("arrow.dff",    "")}};
 
 namespace {
   constexpr float kPhysicsTimeStep = 1.0f/30.0f;
@@ -61,7 +61,7 @@ RWGame::RWGame(Logger& log, int argc, char* argv[])
     data.load();
 
     for (const auto& p : kSpecialModels) {
-        auto model = data.loadClump(p.second);
+        auto model = data.loadClump(p.second.first, p.second.second);
         renderer.setSpecialModel(p.first, model);
     }
 


### PR DESCRIPTION
It seems like that texture for ZoneCylinder loaded correctly but `texturelookup ` can't find texture because wrong texture slot is set. So in `loadClump` we should set it manually