### PR TITLE
Added window configs

### DIFF
--- a/rwgame/GameBase.cpp
+++ b/rwgame/GameBase.cpp
@@ -89,6 +89,16 @@ GameBase::GameBase(Logger &inlog, int argc, char *argv[]) :
         throw std::runtime_error(config.getParseResult().what());
     }
 
+    if (!vm.count("width")) {
+        w = config.getWindowWidth();
+    }
+    if (!vm.count("height")) {
+        h = config.getWindowHeight();
+    }
+    if (!vm.count("fullscreen")) {
+        fullscreen = config.getWindowFullscreen();
+    }
+
     if (SDL_Init(SDL_INIT_VIDEO) < 0)
         throw std::runtime_error("Failed to initialize SDL2!");
 

--- a/rwgame/GameConfig.cpp
+++ b/rwgame/GameConfig.cpp
@@ -218,6 +218,7 @@ GameConfig::ParseResult GameConfig::parseConfig(GameConfig::ParseType srcType,
     auto deft = StringTranslator();
     auto boolt = BoolTranslator();
     auto patht = PathTranslator();
+    auto intt = IntTranslator();
 
     // Add new configuration parameters here.
     // Additionally, add them to the unit test.
@@ -228,6 +229,10 @@ GameConfig::ParseResult GameConfig::parseConfig(GameConfig::ParseType srcType,
     read_config("game.language", this->m_gameLanguage, "american", deft);
 
     read_config("input.invert_y", this->m_inputInvertY, false, boolt);
+
+    read_config("window.width", this->m_windowWidth, 800, intt);
+    read_config("window.height", this->m_windowHeight, 600, intt);
+    read_config("window.fullscreen", this->m_windowFullscreen, false, boolt);
 
     // Build the unknown key/value map from the correct source
     switch (srcType) {

--- a/rwgame/GameConfig.hpp
+++ b/rwgame/GameConfig.hpp
@@ -222,6 +222,15 @@ public:
     bool getInputInvertY() const {
         return m_inputInvertY;
     }
+    int getWindowWidth() const {
+        return m_windowWidth;
+    }
+    int getWindowHeight() const {
+        return m_windowHeight;
+    }
+    bool getWindowFullscreen() const {
+        return m_windowFullscreen;
+    }
 
     static rwfs::path getDefaultConfigPath();
 private:
@@ -256,6 +265,13 @@ private:
 
     /// Invert the y axis for camera control.
     bool m_inputInvertY;
+
+    /// Size of the window
+    int m_windowWidth;
+    int m_windowHeight;
+    
+    /// Set the window to fullscreen
+    bool m_windowFullscreen;
 };
 
 #endif


### PR DESCRIPTION
As the configuration of OpenRW is rather basic, this commit extends the configuration file with a **[window]** section. It is now possible to set the **width** and **height** of the window and choose whether it should start in **fullscreen**.

This is the content of my openrw.ini file:

```
[game]
path=/path/to/game/data/
language=american
[input]
invert_y=0
[window]
width=1920
height=1080
fullscreen=0
```