### PR TITLE
Fix mac build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
     osx_image: xcode9.2
     install:
       - brew update
+      - /usr/bin/yes | pip2 uninstall numpy  # see https://github.com/travis-ci/travis-ci/issues/6688
       - brew upgrade python
       - brew upgrade
       - brew install boost cmake bullet ffmpeg glm openal-soft qt5 sdl2 jack


### PR DESCRIPTION
There's problem of two dependency systems. (pip2 and brew)
Easiest way to fix is to remove pip2's  numpy before upgrading python.

Ref:
https://github.com/travis-ci/travis-ci/issues/6688