### PR TITLE
Fixed one line help messages background too small

### DIFF
--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -156,7 +156,7 @@ void TextRenderer::renderText(const TextRenderer::TextInfo& ti,
     std::vector<TextVertex> geo;
 
     float maxWidth = 0.f;
-    float maxHeight = 0.f;
+    float maxHeight = ss.y;
 
     auto text = ti.text;
 


### PR DESCRIPTION
Default text background height is 0 and it changes only if text contains 2 or more line of text. So if text contain only one line then background height will be too small


![img](https://i.imgur.com/k6PdG0w.png)

After fix:
![img](https://i.imgur.com/7jGgVGI.png)