### PR TITLE
Fix: terminate only mission scripts when starting new mission via debug menu

### DIFF
--- a/rwengine/src/engine/SaveGame.cpp
+++ b/rwengine/src/engine/SaveGame.cpp
@@ -1223,7 +1223,7 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
     for (size_t s = 0; s < numScripts; ++s) {
         state.script->startThread(scripts[s].programCounter);
         SCMThread& thread = threads.back();
-        // thread.baseAddress // ??
+        // no baseAddress in III and VC
         strncpy(thread.name, scripts[s].name, sizeof(SCMThread::name) - 1);
         thread.conditionResult = scripts[s].ifFlag;
         thread.conditionCount = scripts[s].ifNumber;

--- a/rwgame/states/DebugState.cpp
+++ b/rwgame/states/DebugState.cpp
@@ -317,18 +317,22 @@ std::shared_ptr<Menu> DebugState::createMissionsMenu() {
 
             if (vm) {
                 std::list<SCMThread>& threads = vm->getThreads();
+                const auto& offsets = vm->getFile()->getMissionOffsets();
+
+                RW_ASSERT(!offsets.empty());
 
                 for (auto& thread : threads) {
-                    if (thread.isMission) {
+                    if (thread.baseAddress >= offsets[0]) {
                         thread.wakeCounter = -1;
                         thread.finished = true;
                     }
                 }
 
-                RW_ASSERT(i < vm->getFile()->getMissionOffsets().size());
+                game->getState()->radarBlips.clear();
 
-                auto offset = vm->getFile()->getMissionOffsets()[i];
-                vm->startThread(offset, true);
+                RW_ASSERT(i < offsets.size());
+
+                vm->startThread(offsets[i], true);
             }
         });
     }


### PR DESCRIPTION
and clear unnecessary blips