### PR TITLE
Don't draw asterisks in subtitles

### DIFF
--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -163,6 +163,9 @@ void TextRenderer::renderText(const TextRenderer::TextInfo& ti,
     for (size_t i = 0; i < text.length(); ++i) {
         char16_t c = text[i];
 
+        if (c == '*')
+           break;
+
         // Handle any markup changes.
         if (c == '~' && text.length() > i + 1) {
             switch (text[i + 1]) {


### PR DESCRIPTION
![img](https://i.imgur.com/0V4IegK.png)

In English version GTA 3 some subtitles missing and replaced with asterisks, which original game don't draw