### PR TITLE
Fix UB in gamestate

### DIFF
--- a/rwengine/src/engine/GameState.cpp
+++ b/rwengine/src/engine/GameState.cpp
@@ -103,8 +103,8 @@ GameState::GameState()
     , nextRestartLocation{}
     , hospitalRestarts{}
     , policeRestarts{}
-    , hospitalIslandOverride(false)
-    , policeIslandOverride(false)
+    , hospitalIslandOverride(0)
+    , policeIslandOverride(0)
     , fadeIn(true)
     , fadeStart(0.f)
     , fadeTime(0.f)


### PR DESCRIPTION
Should be `0` is `false`.

UBsan says:
`/home/filip/Projekty/bullet/openrw/fix/openrw/rwengine/src/engine/GameState.hpp:248:7: runtime error: load of value 64, which is not a valid value for type 'bool'`