### PR TITLE
rwgame: remove undefined behavior in CharacterObjects

### DIFF
--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -198,11 +198,9 @@ glm::vec3 CharacterObject::updateMovementAnimation(float dt) {
         }
     }
 
-    if (controller) {
-        if (static_cast<PlayerController*>(controller)->isAdrenalineActive() &&
-            movementAnimation == animations->animation(AnimCycle::WalkStart)) {
-            animationSpeed *= 2;
-        }
+    if (isPlayer() && static_cast<PlayerController*>(controller)->isAdrenalineActive() &&
+        movementAnimation == animations->animation(AnimCycle::WalkStart)) {
+        animationSpeed *= 2;
     }
 
     // Check if we need to change the animation or change speed


### PR DESCRIPTION
Fixes this warning:
```
/home/maarten/programming/openrw/rwengine/src/objects/CharacterObject.cpp:202:54: runtime error: downcast of address 0x00000ae11d00 which does not point to an object of type 'PlayerController'
0x00000ae11d00: note: object is of type 'DefaultAIController'
 00 00 00 00  58 91 ca 00 00 00 00 00  e0 2e 90 0b 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'DefaultAIController'
/home/maarten/programming/openrw/rwengine/src/objects/CharacterObject.cpp:202:75: runtime error: member call on address 0x00000ae11d00 which does not point to an object of type 'PlayerController'
0x00000ae11d00: note: object is of type 'DefaultAIController'
 00 00 00 00  58 91 ca 00 00 00 00 00  e0 2e 90 0b 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'DefaultAIController'
/home/maarten/programming/openrw/rwengine/src/ai/PlayerController.hpp:66:16: runtime error: member access within address 0x00000ae11d00 which does not point to an object of type 'PlayerController'
0x00000ae11d00: note: object is of type 'DefaultAIController'
 00 00 00 00  58 91 ca 00 00 00 00 00  e0 2e 90 0b 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'DefaultAIController'
```