### PR TITLE
ci: use hash of checked out git repo instead of appveyor hash

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,10 +36,15 @@ init:
   - cmake --version
   - msbuild /version
 
+install:
+  - cd "%APPVEYOR_BUILD_FOLDER%"
+  - for /f %%i in ('git rev-parse HEAD') do set COMMIT_HASH=%%i
+  - if NOT "%APPVEYOR_REPO_COMMIT%" == "%COMMIT_HASH%" echo "Appveyor hash does not match checkout out hash" && exit 1
+
 build_script:
   - ctest -VV -S cmake/ctest/script_ci.ctest
 
 after_build:
   - cd "%APPVEYOR_BUILD_FOLDER%\build"
   - cpack -C Release -G TXZ
-  - appveyor PushArtifact OpenRW-%APPVEYOR_REPO_COMMIT:~0,8%.tar.xz
+  - appveyor PushArtifact OpenRW-%COMMIT_HASH:~0,8%.tar.xz


### PR DESCRIPTION
Fixes this: https://ci.appveyor.com/project/danhedron/openrw/build/1.0.499#L1722

Race condition:
- user1 pushes a commit to github branch `bbb` named `xxx`(=`APPVEYOR_REPO_COMMIT`)
- appveyor gets notified by github that a new commit named `xxx` is available
- appveyor fetches `.appveyor.yml`
- user1 pushes a new commit to github branch `bbb` named `yyy`
- appveyor wants to build `xxx`. Between the `init` steps and the `install` steps, appveyor fetches the repo with the commands
```
git clone -q --depth=1 https://github.com/rwengine/openrw.git C:\projects\openrw
git fetch -q origin +refs/pull/420/merge:
git checkout -qf FETCH_HEAD
```
- so now appveyor thinks it is testing commit `xxx` but has actually checked out commit `yyy`

Fixes this by not using `APPVEYOR_REPO_COMMIT` (=`xxx`)

Also, detect this situation and fail the build.