### PR TITLE
Rwlib changes

### DIFF
--- a/rwengine/src/BinaryStream.cpp
+++ b/rwengine/src/BinaryStream.cpp
@@ -2,7 +2,7 @@
 
 #include <cstring>
 #include <fstream>
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 namespace RW {
 

--- a/rwengine/src/TextureArchive.cpp
+++ b/rwengine/src/TextureArchive.cpp
@@ -4,7 +4,7 @@
 #include <cstring>
 #include <memory>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 #include "BinaryStream.hpp"
 

--- a/rwengine/src/ai/AIGraph.cpp
+++ b/rwengine/src/ai/AIGraph.cpp
@@ -7,7 +7,7 @@
 #include "ai/AIGraphNode.hpp"
 #include "data/PathData.hpp"
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 #include <rw/types.hpp>
 
 AIGraph::~AIGraph() {

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -11,7 +11,7 @@
 
 #include <LinearMath/btScalar.h>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 #include "data/WeaponData.hpp"
 #include "engine/Animator.hpp"

--- a/rwengine/src/audio/SoundManager.cpp
+++ b/rwengine/src/audio/SoundManager.cpp
@@ -8,7 +8,7 @@ extern "C" {
 #include <libavutil/avutil.h>
 }
 //ab
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 // Rename some functions for older libavcodec/ffmpeg versions (e.g. Ubuntu Trusty)
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55,28,1)

--- a/rwengine/src/audio/SoundManager.cpp
+++ b/rwengine/src/audio/SoundManager.cpp
@@ -64,7 +64,7 @@ bool SoundManager::initializeAVCodec() {
     return true;
 }
 
-void SoundManager::SoundSource::loadFromFile(const std::string& filename) {
+void SoundManager::SoundSource::loadFromFile(const rwfs::path& filePath) {
     // Allocate audio frame
     AVFrame* frame = av_frame_alloc();
     if (!frame) {
@@ -74,9 +74,9 @@ void SoundManager::SoundSource::loadFromFile(const std::string& filename) {
 
     // Allocate formatting context
     AVFormatContext* formatContext = nullptr;
-    if (avformat_open_input(&formatContext, filename.c_str(), nullptr, nullptr) != 0) {
+    if (avformat_open_input(&formatContext, filePath.string().c_str(), nullptr, nullptr) != 0) {
         av_frame_free(&frame);
-        RW_ERROR("Error opening audio file (" << filename << ")");
+        RW_ERROR("Error opening audio file (" << filePath << ")");
         return;
     }
 
@@ -93,7 +93,7 @@ void SoundManager::SoundSource::loadFromFile(const std::string& filename) {
     if (streamIndex < 0) {
         av_frame_free(&frame);
         avformat_close_input(&formatContext);
-        RW_ERROR("Could not find any audio stream in the file " << filename);
+        RW_ERROR("Could not find any audio stream in the file " << filePath);
         return;
     }
 
@@ -196,7 +196,7 @@ bool SoundManager::SoundBuffer::bufferData(SoundSource& soundSource) {
 }
 
 bool SoundManager::loadSound(const std::string& name,
-                             const std::string& fileName) {
+                             const rwfs::path& path) {
     Sound* sound = nullptr;
     auto sound_iter = sounds.find(name);
 
@@ -208,7 +208,7 @@ bool SoundManager::loadSound(const std::string& name,
                                        std::forward_as_tuple());
         sound = &emplaced.first->second;
 
-        sound->source.loadFromFile(fileName);
+        sound->source.loadFromFile(path);
         sound->isLoaded = sound->buffer.bufferData(sound->source);
     }
 
@@ -280,8 +280,8 @@ bool SoundManager::playBackground(const std::string& fileName) {
 }
 
 bool SoundManager::loadMusic(const std::string& name,
-                             const std::string& fileName) {
-    return loadSound(name, fileName);
+                             const rwfs::path& path) {
+    return loadSound(name, path);
 }
 
 void SoundManager::playMusic(const std::string& name) {

--- a/rwengine/src/audio/SoundManager.hpp
+++ b/rwengine/src/audio/SoundManager.hpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include <rw/filesystem.hpp>
+
 #include <al.h>
 #include <alc.h>
 
@@ -15,7 +17,7 @@ public:
     SoundManager();
     ~SoundManager();
 
-    bool loadSound(const std::string& name, const std::string& fileName);
+    bool loadSound(const std::string& name, const rwfs::path& path);
     bool isLoaded(const std::string& name);
     void playSound(const std::string& name);
     void pauseSound(const std::string& name);
@@ -26,9 +28,9 @@ public:
     void pauseAllSounds();
     void resumeAllSounds();
 
-    bool playBackground(const std::string& fileName);
+    bool playBackground(const std::string& name);
 
-    bool loadMusic(const std::string& name, const std::string& fileName);
+    bool loadMusic(const std::string& name, const rwfs::path& path);
     void playMusic(const std::string& name);
     void stopMusic(const std::string& name);
 
@@ -40,7 +42,7 @@ private:
         friend class SoundBuffer;
 
     public:
-        void loadFromFile(const std::string& filename);
+        void loadFromFile(const rwfs::path& filePath);
 
     private:
         std::vector<int16_t> data;

--- a/rwengine/src/core/Profiler.hpp
+++ b/rwengine/src/core/Profiler.hpp
@@ -9,7 +9,7 @@
 #include <vector>
 #define time_unit std::chrono::microseconds
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 namespace perf {
 

--- a/rwengine/src/data/AnimGroup.cpp
+++ b/rwengine/src/data/AnimGroup.cpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <vector>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 #include <rw/forward.hpp>
 
 // The default animations for every cycle

--- a/rwengine/src/data/Chase.cpp
+++ b/rwengine/src/data/Chase.cpp
@@ -4,7 +4,7 @@
 #include <cstddef>
 #include <fstream>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 #include "engine/GameWorld.hpp"
 #include "objects/GameObject.hpp"

--- a/rwengine/src/data/ModelData.hpp
+++ b/rwengine/src/data/ModelData.hpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include <data/Clump.hpp>
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 #include <rw/forward.hpp>
 
 #include <data/CollisionModel.hpp>

--- a/rwengine/src/engine/Animator.hpp
+++ b/rwengine/src/engine/Animator.hpp
@@ -3,7 +3,7 @@
 #include <map>
 #include <vector>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 #include <rw/forward.hpp>
 
 struct AnimationBone;

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -13,7 +13,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <data/Clump.hpp>
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 #include <rw/types.hpp>
 
 #include "core/Logger.hpp"

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -41,7 +41,6 @@ GameData::GameData(Logger* log, const rwfs::path& path)
 GameData::~GameData() = default;
 
 void GameData::load() {
-    index.indexGameDirectory(datpath);
     index.indexTree(datpath);
 
     loadIMG("models/gta3.img");
@@ -191,8 +190,7 @@ void GameData::loadCOL(const size_t zone, const std::string& name) {
 }
 
 void GameData::loadIMG(const std::string& name) {
-    auto syspath = index.findFilePath(name).string();
-    index.indexArchive(syspath);
+    index.indexArchive(name);
 }
 
 void GameData::loadIPL(const std::string& path) {
@@ -290,7 +288,7 @@ void GameData::loadHandling(const std::string& path) {
 }
 
 SCMFile* GameData::loadSCM(const std::string& path) {
-    auto scm_h = index.openFilePath(path);
+    auto scm_h = index.openFileRaw(path);
     SCMFile* scm = new SCMFile;
     scm->loadFile(scm_h->data, scm_h->length);
     scm_h.reset();
@@ -298,7 +296,7 @@ SCMFile* GameData::loadSCM(const std::string& path) {
 }
 
 void GameData::loadGXT(const std::string& name) {
-    auto file = index.openFilePath(name);
+    auto file = index.openFileRaw(name);
 
     LoaderGXT loader;
 
@@ -419,7 +417,7 @@ ClumpPtr GameData::loadClump(const std::string& name, const std::string& texture
 }
 
 void GameData::loadModelFile(const std::string& name) {
-    auto file = index.openFilePath(name);
+    auto file = index.openFileRaw(name);
     if (!file) {
         logger->log("Data", Logger::Error, "Failed to load model file " + name);
         return;

--- a/rwengine/src/engine/GameData.hpp
+++ b/rwengine/src/engine/GameData.hpp
@@ -14,7 +14,7 @@
 #include <glm/glm.hpp>
 
 #include <platform/FileIndex.hpp>
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 #include <rw/forward.hpp>
 
 #include <data/AnimGroup.hpp>

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -691,11 +691,7 @@ void GameWorld::PhysicsTickCallback(btDynamicsWorld* physWorld,
 }
 
 void GameWorld::loadCutscene(const std::string& name) {
-    std::string lowerName(name);
-    std::transform(lowerName.begin(), lowerName.end(), lowerName.begin(),
-                   ::tolower);
-
-    auto datfile = data->index.openFile(lowerName + ".dat");
+    auto datfile = data->index.openFile(name + ".dat");
 
     CutsceneData* cutscene = new CutsceneData;
 
@@ -704,7 +700,7 @@ void GameWorld::loadCutscene(const std::string& name) {
         loaderdat.load(cutscene->tracks, datfile);
     }
 
-    data->loadIFP(lowerName + ".ifp");
+    data->loadIFP(name + ".ifp");
 
     cutsceneAudioLoaded = data->loadAudioStream(name + ".mp3");
 

--- a/rwengine/src/engine/Garage.hpp
+++ b/rwengine/src/engine/Garage.hpp
@@ -1,9 +1,9 @@
-#ifndef _RWENGINE_Garage_HPP_
-#define _RWENGINE_Garage_HPP_
+#ifndef _RWENGINE_GARAGE_HPP_
+#define _RWENGINE_GARAGE_HPP_
 
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 class PlayerController;
 

--- a/rwengine/src/engine/Payphone.cpp
+++ b/rwengine/src/engine/Payphone.cpp
@@ -1,6 +1,6 @@
 #include "engine/Payphone.hpp"
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 #include "ai/PlayerController.hpp"
 

--- a/rwengine/src/engine/SaveGame.cpp
+++ b/rwengine/src/engine/SaveGame.cpp
@@ -12,7 +12,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 #include "data/ZoneData.hpp"
 #include "engine/GameData.hpp"

--- a/rwengine/src/engine/ScreenText.cpp
+++ b/rwengine/src/engine/ScreenText.cpp
@@ -1,6 +1,6 @@
 #include "engine/ScreenText.hpp"
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 void ScreenText::tick(float dt) {
     int millis = dt * 1000;

--- a/rwengine/src/loaders/GenericDATLoader.cpp
+++ b/rwengine/src/loaders/GenericDATLoader.cpp
@@ -6,7 +6,7 @@
 #include <iterator>
 #include <sstream>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 #include <data/ModelData.hpp>
 #include <data/WeaponData.hpp>

--- a/rwengine/src/loaders/LoaderCutsceneDAT.cpp
+++ b/rwengine/src/loaders/LoaderCutsceneDAT.cpp
@@ -7,7 +7,7 @@
 
 #include <glm/glm.hpp>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 #include "data/CutsceneData.hpp"
 #include "platform/FileHandle.hpp"

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -9,7 +9,7 @@
 #include <BulletDynamics/Character/btKinematicCharacterController.h>
 #include <btBulletDynamicsCommon.h>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 #include "ai/CharacterController.hpp"
 #include "ai/PlayerController.hpp"

--- a/rwengine/src/objects/GameObject.hpp
+++ b/rwengine/src/objects/GameObject.hpp
@@ -7,7 +7,7 @@
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 #include <rw/forward.hpp>
 
 #include <data/ModelData.hpp>

--- a/rwengine/src/objects/PickupObject.hpp
+++ b/rwengine/src/objects/PickupObject.hpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <glm/glm.hpp>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 #include <objects/GameObject.hpp>
 

--- a/rwengine/src/render/DebugDraw.cpp
+++ b/rwengine/src/render/DebugDraw.cpp
@@ -9,7 +9,7 @@
 #include <gl/DrawBuffer.hpp>
 #include <gl/GeometryBuffer.hpp>
 #include <gl/gl_core_3_3.h>
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 #include "render/GameRenderer.hpp"
 

--- a/rwengine/src/render/OpenGLRenderer.cpp
+++ b/rwengine/src/render/OpenGLRenderer.cpp
@@ -7,7 +7,7 @@
 #include <glm/gtc/type_ptr.hpp>
 
 #include <gl/DrawBuffer.hpp>
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 namespace {
 constexpr GLuint kUBOIndexScene = 1;

--- a/rwengine/src/render/WaterRenderer.cpp
+++ b/rwengine/src/render/WaterRenderer.cpp
@@ -4,7 +4,7 @@
 
 #include <glm/glm.hpp>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 #include <rw/types.hpp>
 
 #include "engine/GameData.hpp"

--- a/rwengine/src/script/SCMFile.hpp
+++ b/rwengine/src/script/SCMFile.hpp
@@ -1,12 +1,13 @@
 #ifndef _RWENGINE_SCMFILE_HPP_
 #define _RWENGINE_SCMFILE_HPP_
 
+#include "script/ScriptTypes.hpp"
+
+#include <rw/bit_cast.hpp>
+
 #include <cstdint>
 #include <string>
 #include <vector>
-
-#include "script/ScriptTypes.hpp"
-#include "rw/bit_cast.cpp"
 
 /**
  * @brief Handles in-memory SCM file data including section offsets.

--- a/rwengine/src/script/ScriptFunctions.hpp
+++ b/rwengine/src/script/ScriptFunctions.hpp
@@ -1,7 +1,7 @@
 #ifndef _RWENGINE_SCRIPTFUNCTIONS_HPP_
 #define _RWENGINE_SCRIPTFUNCTIONS_HPP_
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 #include <ai/AIGraphNode.hpp>
 #include <data/GameTexts.hpp>

--- a/rwengine/src/script/ScriptTypes.hpp
+++ b/rwengine/src/script/ScriptTypes.hpp
@@ -9,7 +9,7 @@
 
 #include <glm/glm.hpp>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 #include "engine/Garage.hpp"
 

--- a/rwgame/GameBase.cpp
+++ b/rwgame/GameBase.cpp
@@ -6,7 +6,7 @@
 
 #include <SDL.h>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 #include "GitSHA1.h"
 

--- a/rwgame/GameConfig.cpp
+++ b/rwgame/GameConfig.cpp
@@ -1,7 +1,7 @@
 #include "GameConfig.hpp"
 #include <algorithm>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 #include <rw/filesystem.hpp>
 
 #include <boost/property_tree/ini_parser.hpp>

--- a/rwgame/MenuSystem.hpp
+++ b/rwgame/MenuSystem.hpp
@@ -8,7 +8,7 @@
 #include <glm/glm.hpp>
 
 #include <render/GameRenderer.hpp>
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 
 /**
  * Default values for menus that should match the look and feel of the original

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -106,8 +106,8 @@ void IngameState::startTest() {
 void IngameState::startGame() {
     game->startScript("data/main.scm");
     game->getScriptVM()->startThread(0);
-    getWorld()->sound.playBackground(getWorld()->data->getDataPath().string() +
-                                     "/audio/City.wav");  // FIXME: use path
+    auto audioCityPath = getWorld()->data->index.findFilePath("audio/City.wav");
+    getWorld()->sound.playBackground(audioCityPath.string()); //FIXME: playBackground should just accept "audio/City.wav"
 }
 
 void IngameState::enter() {

--- a/rwgame/states/MenuState.cpp
+++ b/rwgame/states/MenuState.cpp
@@ -3,7 +3,7 @@
 #include "game.hpp"
 
 #include <engine/SaveGame.hpp>
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 #include "RWGame.hpp"
 
 MenuState::MenuState(RWGame* game) : State(game) {

--- a/rwlib/CMakeLists.txt
+++ b/rwlib/CMakeLists.txt
@@ -16,7 +16,7 @@ SET(RWLIB_SOURCES
     source/gl/TextureData.cpp
 
     source/rw/abort.cpp
-    source/rw/bit_cast.cpp
+    source/rw/bit_cast.hpp
     source/rw/filesystem.hpp
     source/rw/forward.hpp
     source/rw/types.hpp

--- a/rwlib/CMakeLists.txt
+++ b/rwlib/CMakeLists.txt
@@ -20,7 +20,7 @@ SET(RWLIB_SOURCES
     source/rw/filesystem.hpp
     source/rw/forward.hpp
     source/rw/types.hpp
-    source/rw/defines.hpp
+    source/rw/debug.hpp
 
     source/platform/FileHandle.hpp
     source/platform/FileIndex.hpp

--- a/rwlib/source/loaders/LoaderDFF.cpp
+++ b/rwlib/source/loaders/LoaderDFF.cpp
@@ -14,7 +14,7 @@
 #include "gl/gl_core_3_3.h"
 #include "loaders/RWBinaryStream.hpp"
 #include "platform/FileHandle.hpp"
-#include "rw/defines.hpp"
+#include "rw/debug.hpp"
 
 enum DFFChunks {
     CHUNK_STRUCT = 0x0001,

--- a/rwlib/source/loaders/LoaderIMG.cpp
+++ b/rwlib/source/loaders/LoaderIMG.cpp
@@ -3,7 +3,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <cstdio>
 
-#include "rw/defines.hpp"
+#include "rw/debug.hpp"
 
 LoaderIMG::LoaderIMG() : m_version(GTAIIIVC), m_assetCount(0) {
 }

--- a/rwlib/source/loaders/LoaderSDT.cpp
+++ b/rwlib/source/loaders/LoaderSDT.cpp
@@ -4,7 +4,7 @@
 #include <cstdio>
 #include <string>
 
-#include "rw/defines.hpp"
+#include "rw/debug.hpp"
 
 LoaderSDT::LoaderSDT() : m_version(GTAIIIVC), m_assetCount(0) {
 }

--- a/rwlib/source/loaders/LoaderTXD.cpp
+++ b/rwlib/source/loaders/LoaderTXD.cpp
@@ -10,7 +10,7 @@
 #include "gl/gl_core_3_3.h"
 #include "loaders/RWBinaryStream.hpp"
 #include "platform/FileHandle.hpp"
-#include "rw/defines.hpp"
+#include "rw/debug.hpp"
 
 GLuint gErrorTextureData[] = {0xFFFF00FF, 0xFF000000, 0xFF000000, 0xFFFF00FF};
 GLuint gDebugTextureData[] = {0xFF0000FF, 0xFF00FF00};

--- a/rwlib/source/loaders/RWBinaryStream.hpp
+++ b/rwlib/source/loaders/RWBinaryStream.hpp
@@ -7,7 +7,7 @@
 #include <cstddef>
 
 #include "rw/debug.hpp"
-#include "rw/bit_cast.cpp"
+#include "rw/bit_cast.hpp"
 
 /**
  * @brief Class for working with RenderWare binary streams.

--- a/rwlib/source/loaders/RWBinaryStream.hpp
+++ b/rwlib/source/loaders/RWBinaryStream.hpp
@@ -6,7 +6,7 @@
 
 #include <cstddef>
 
-#include "rw/defines.hpp"
+#include "rw/debug.hpp"
 #include "rw/bit_cast.cpp"
 
 /**

--- a/rwlib/source/platform/FileHandle.hpp
+++ b/rwlib/source/platform/FileHandle.hpp
@@ -1,13 +1,11 @@
 #ifndef _LIBRW_FILEHANDLE_HPP_
 #define _LIBRW_FILEHANDLE_HPP_
 
-#include <memory>
-
 /**
  * @brief Contains a pointer to a file's contents.
  */
 struct FileContentsInfo {
-    char* data;
+    char *data;
     size_t length;
 
     FileContentsInfo(char* mem, size_t len) : data(mem), length(len) {

--- a/rwlib/source/rw/bit_cast.cpp
+++ b/rwlib/source/rw/bit_cast.cpp
@@ -4,7 +4,7 @@
 //Based on https://gist.github.com/socantre/3472964
 #include <cstring> // memcpy
 #include <type_traits> // is_trivially_copyable
-#include "rw/defines.hpp" // RW_ASSERT
+#include "rw/debug.hpp" // RW_ASSERT
 
 template <class Dest, class Source>
 inline Dest bit_cast(Source const &source) {

--- a/rwlib/source/rw/bit_cast.hpp
+++ b/rwlib/source/rw/bit_cast.hpp
@@ -1,10 +1,9 @@
-#ifndef _LIBRW_BIT_CAST_CPP_
-#define _LIBRW_BIT_CAST_CPP_
+#ifndef _LIBRW_BIT_CAST_HPP_
+#define _LIBRW_BIT_CAST_HPP_
 
 //Based on https://gist.github.com/socantre/3472964
 #include <cstring> // memcpy
 #include <type_traits> // is_trivially_copyable
-#include "rw/debug.hpp" // RW_ASSERT
 
 template <class Dest, class Source>
 inline Dest bit_cast(Source const &source) {

--- a/rwlib/source/rw/debug.hpp
+++ b/rwlib/source/rw/debug.hpp
@@ -1,5 +1,5 @@
-#ifndef _LIBRW_DEFINES_HPP_
-#define _LIBRW_DEFINES_HPP_
+#ifndef _LIBRW_DEBUG_HPP_
+#define _LIBRW_DEBUG_HPP_
 
 #if RW_DEBUG
 #include <cstdlib>

--- a/rwlib/source/rw/types.hpp
+++ b/rwlib/source/rw/types.hpp
@@ -5,7 +5,7 @@
 #include <glm/glm.hpp>
 #include <map>
 #include <memory>
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 #include <string>
 
 #define RW_USING(feature) 1 == feature

--- a/tests/test_Config.cpp
+++ b/tests/test_Config.cpp
@@ -8,7 +8,7 @@
 #include <fstream>
 #include <map>
 
-#include <rw/defines.hpp>
+#include <rw/debug.hpp>
 #include <rw/filesystem.hpp>
 
 namespace pt = boost::property_tree;

--- a/tests/test_FileIndex.cpp
+++ b/tests/test_FileIndex.cpp
@@ -2,23 +2,35 @@
 #include <platform/FileIndex.hpp>
 #include "test_Globals.hpp"
 
-#include <rw/filesystem.hpp>
-namespace fs = rwfs;
-
 BOOST_AUTO_TEST_SUITE(FileIndexTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_directory_paths) {
-    FileIndex index;
+BOOST_AUTO_TEST_CASE(test_normalizeName) {
+    std::string ref = "a/b/c";
+    {
+        std::string dirty = "a\\b\\c";
+        BOOST_CHECK_EQUAL(ref, FileIndex::normalizeFilePath(dirty));
+    }
+    {
+        std::string dirty = "A/B/C";
+        BOOST_CHECK_EQUAL(ref, FileIndex::normalizeFilePath(dirty));
+    }
+    {
+        std::string dirty = "A\\B\\C";
+        BOOST_CHECK_EQUAL(ref, FileIndex::normalizeFilePath(dirty));
+    }
+}
 
-    index.indexGameDirectory(Global::getGamePath());
+#if RW_TEST_WITH_DATA
+BOOST_AUTO_TEST_CASE(test_indexTree) {
+    FileIndex index;
+    index.indexTree(Global::getGamePath());
 
     {
         std::string upperpath{"DATA/CULLZONE.DAT"};
         auto truepath = index.findFilePath(upperpath);
         BOOST_ASSERT(!truepath.empty());
         BOOST_CHECK(upperpath != truepath);
-        fs::path expected{Global::getGamePath()};
+        rwfs::path expected{Global::getGamePath()};
         expected /= "data/CULLZONE.DAT";
         BOOST_CHECK_EQUAL(truepath.string(), expected.string());
     }
@@ -27,28 +39,35 @@ BOOST_AUTO_TEST_CASE(test_directory_paths) {
         auto truepath = index.findFilePath(upperpath);
         BOOST_ASSERT(!truepath.empty());
         BOOST_CHECK(upperpath != truepath);
-        fs::path expected{Global::getGamePath()};
+        rwfs::path expected{Global::getGamePath()};
         expected /= "data/maps/comnbtm/comNbtm.ipl";
         BOOST_CHECK_EQUAL(truepath.string(), expected.string());
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_file) {
+BOOST_AUTO_TEST_CASE(test_openFile) {
     FileIndex index;
-
     index.indexTree(Global::getGamePath() + "/data");
 
     auto handle = index.openFile("cullzone.dat");
     BOOST_CHECK(handle != nullptr);
 }
 
-BOOST_AUTO_TEST_CASE(test_file_archive) {
+BOOST_AUTO_TEST_CASE(test_indexArchive) {
     FileIndex index;
+    index.indexTree(Global::getGamePath());
 
-    index.indexArchive(Global::getGamePath() + "/models/gta3.img");
+    {
+        auto handle = index.openFile("landstal.dff");
+        BOOST_CHECK(handle == nullptr);
+    }
 
-    auto handle = index.openFile("landstal.dff");
-    BOOST_CHECK(handle != nullptr);
+    index.indexArchive("models/gta3.img");
+
+    {
+        auto handle = index.openFile("landstal.dff");
+        BOOST_CHECK(handle != nullptr);
+    }
 }
 #endif
 

--- a/tests/test_Text.cpp
+++ b/tests/test_Text.cpp
@@ -11,7 +11,7 @@ BOOST_AUTO_TEST_SUITE(TextTests)
 #if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(load_test) {
     {
-        auto d = Global::get().e->data->index.openFilePath("text/english.gxt");
+        auto d = Global::get().e->data->index.openFileRaw("text/english.gxt");
 
         GameTexts texts;
 


### PR DESCRIPTION
- `rw/defines.hpp`  --> `rw/debug.hpp`
- `bit_cast` is a header, not a source file
- get the path to the background file from FileIndex
- refactor FileIndex a bit:
    - `rwfs::path` -> a path on the file system
       `std::string` -> a relative path, indexed by `FileIndex`
    - make `FileIndex` const correct (std::map::operator[] modifies the std::map)
    - use a single map internally
    - keys of this map are paths relative in the game data directory + filenames
      (so paths like "data/main.scm" can be found twice in the map: "data/main.scm" and "main.scm")
    - normalization of the file paths is done inside `FileIndex`,
      so there shouldn't be any ::tolower's used anywhere else anymore.
    - added a normalizer helper function `normalizeFilePath`
    - updated documentation
    - updated tests