### PR TITLE
Remove unneeded FileHandle (aka shared_ptr)

### DIFF
--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -292,8 +292,7 @@ void GameData::loadHandling(const std::string& path) {
 SCMFile* GameData::loadSCM(const std::string& path) {
     auto scm_h = index.openFileRaw(path);
     SCMFile* scm = new SCMFile;
-    scm->loadFile(scm_h->data, scm_h->length);
-    scm_h.reset();
+    scm->loadFile(scm_h.data, scm_h.length);
     return scm;
 }
 
@@ -371,7 +370,7 @@ void GameData::loadTXD(const std::string& name) {
 TextureArchive GameData::loadTextureArchive(const std::string& name) {
     /// @todo refactor loadTXD to use correct file locations
     auto file = index.openFile(name);
-    if (!file) {
+    if (!file.data) {
         logger->error("Data", "Failed to open txd: " + name);
         return {};
     }
@@ -397,7 +396,7 @@ void GameData::getNameAndLod(std::string& name, int& lod) {
 
 ClumpPtr GameData::loadClump(const std::string& name) {
     auto file = index.openFile(name);
-    if (!file) {
+    if (!file.data) {
         logger->error("Data", "Failed to load model " + name);
         return nullptr;
     }
@@ -420,7 +419,7 @@ ClumpPtr GameData::loadClump(const std::string& name, const std::string& texture
 
 void GameData::loadModelFile(const std::string& name) {
     auto file = index.openFileRaw(name);
-    if (!file) {
+    if (!file.data) {
         logger->log("Data", Logger::Error, "Failed to load model file " + name);
         return;
     }
@@ -486,7 +485,7 @@ bool GameData::loadModel(ModelID model) {
     loadTXD(slotname + ".txd");
 
     auto file = index.openFile(name + ".dff");
-    if (!file) {
+    if (!file.data) {
         logger->error("Data", "Failed to load model for " +
                                   std::to_string(model) + " [" + name + "]");
         return false;
@@ -523,9 +522,9 @@ bool GameData::loadModel(ModelID model) {
 void GameData::loadIFP(const std::string& name) {
     auto f = index.openFile(name);
 
-    if (f) {
+    if (f.data) {
         LoaderIFP loader;
-        if (loader.loadFromMemory(f->data)) {
+        if (loader.loadFromMemory(f.data)) {
             animations.insert(loader.animations.begin(),
                               loader.animations.end());
         }

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -292,7 +292,7 @@ void GameData::loadHandling(const std::string& path) {
 SCMFile* GameData::loadSCM(const std::string& path) {
     auto scm_h = index.openFileRaw(path);
     SCMFile* scm = new SCMFile;
-    scm->loadFile(scm_h.data, scm_h.length);
+    scm->loadFile(scm_h.data.get(), scm_h.length);
     return scm;
 }
 
@@ -524,7 +524,7 @@ void GameData::loadIFP(const std::string& name) {
 
     if (f.data) {
         LoaderIFP loader;
-        if (loader.loadFromMemory(f.data)) {
+        if (loader.loadFromMemory(f.data.get())) {
             animations.insert(loader.animations.begin(),
                               loader.animations.end());
         }

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -29,6 +29,8 @@
 #include "objects/PickupObject.hpp"
 #include "objects/VehicleObject.hpp"
 
+#include "platform/FileHandle.hpp"
+
 #include "render/ViewCamera.hpp"
 
 #ifdef RW_WINDOWS
@@ -695,7 +697,7 @@ void GameWorld::loadCutscene(const std::string& name) {
 
     CutsceneData* cutscene = new CutsceneData;
 
-    if (datfile) {
+    if (datfile.data) {
         LoaderCutsceneDAT loaderdat;
         loaderdat.load(cutscene->tracks, datfile);
     }

--- a/rwengine/src/loaders/LoaderCutsceneDAT.cpp
+++ b/rwengine/src/loaders/LoaderCutsceneDAT.cpp
@@ -12,8 +12,8 @@
 #include "data/CutsceneData.hpp"
 #include "platform/FileHandle.hpp"
 
-void LoaderCutsceneDAT::load(CutsceneTracks &tracks, const FileHandle& file) {
-    std::string dataStr(file->data, file->length);
+void LoaderCutsceneDAT::load(CutsceneTracks &tracks, const FileContentsInfo& file) {
+    std::string dataStr(file.data, file.length);
     std::stringstream ss(dataStr);
 
     int numZooms = 0;

--- a/rwengine/src/loaders/LoaderCutsceneDAT.cpp
+++ b/rwengine/src/loaders/LoaderCutsceneDAT.cpp
@@ -13,7 +13,7 @@
 #include "platform/FileHandle.hpp"
 
 void LoaderCutsceneDAT::load(CutsceneTracks &tracks, const FileContentsInfo& file) {
-    std::string dataStr(file.data, file.length);
+    std::string dataStr(file.data.get(), file.length);
     std::stringstream ss(dataStr);
 
     int numZooms = 0;

--- a/rwengine/src/loaders/LoaderCutsceneDAT.hpp
+++ b/rwengine/src/loaders/LoaderCutsceneDAT.hpp
@@ -7,7 +7,7 @@ struct CutsceneTracks;
 
 class LoaderCutsceneDAT {
 public:
-    void load(CutsceneTracks& tracks, const FileHandle& file);
+    void load(CutsceneTracks& tracks, const FileContentsInfo& file);
 };
 
 #endif

--- a/rwengine/src/loaders/LoaderGXT.cpp
+++ b/rwengine/src/loaders/LoaderGXT.cpp
@@ -8,8 +8,8 @@
 #include <fonts/GameTexts.hpp>
 #include <platform/FileHandle.hpp>
 
-void LoaderGXT::load(GameTexts &texts, const FileHandle &file) {
-    auto data = file->data;
+void LoaderGXT::load(GameTexts &texts, const FileContentsInfo &file) {
+    auto data = file.data;
 
     data += 4;  // TKEY
 

--- a/rwengine/src/loaders/LoaderGXT.cpp
+++ b/rwengine/src/loaders/LoaderGXT.cpp
@@ -9,7 +9,7 @@
 #include <platform/FileHandle.hpp>
 
 void LoaderGXT::load(GameTexts &texts, const FileContentsInfo &file) {
-    auto data = file.data;
+    auto data = file.data.get();
 
     data += 4;  // TKEY
 

--- a/rwengine/src/loaders/LoaderGXT.hpp
+++ b/rwengine/src/loaders/LoaderGXT.hpp
@@ -6,7 +6,7 @@ class GameTexts;
 
 class LoaderGXT {
 public:
-    void load(GameTexts& texts, const FileHandle& file);
+    void load(GameTexts& texts, const FileContentsInfo& file);
 };
 
 #endif

--- a/rwlib/source/loaders/LoaderDFF.cpp
+++ b/rwlib/source/loaders/LoaderDFF.cpp
@@ -458,7 +458,7 @@ AtomicPtr LoaderDFF::readAtomic(FrameList &framelist,
 ClumpPtr LoaderDFF::loadFromMemory(const FileContentsInfo& file) {
     auto model = std::make_shared<Clump>();
 
-    RWBStream rootStream(file.data, file.length);
+    RWBStream rootStream(file.data.get(), file.length);
 
     auto rootID = rootStream.getNextChunk();
     if (rootID != CHUNK_CLUMP) {

--- a/rwlib/source/loaders/LoaderDFF.cpp
+++ b/rwlib/source/loaders/LoaderDFF.cpp
@@ -455,10 +455,10 @@ AtomicPtr LoaderDFF::readAtomic(FrameList &framelist,
     return atomic;
 }
 
-ClumpPtr LoaderDFF::loadFromMemory(const FileHandle& file) {
+ClumpPtr LoaderDFF::loadFromMemory(const FileContentsInfo& file) {
     auto model = std::make_shared<Clump>();
 
-    RWBStream rootStream(file->data, file->length);
+    RWBStream rootStream(file.data, file.length);
 
     auto rootID = rootStream.getNextChunk();
     if (rootID != CHUNK_CLUMP) {

--- a/rwlib/source/loaders/LoaderDFF.hpp
+++ b/rwlib/source/loaders/LoaderDFF.hpp
@@ -31,7 +31,7 @@ public:
     using GeometryList = std::vector<GeometryPtr>;
     using FrameList = std::vector<ModelFramePtr>;
 
-    ClumpPtr loadFromMemory(const FileHandle& file);
+    ClumpPtr loadFromMemory(const FileContentsInfo& file);
 
     void setTextureLookupCallback(const TextureLookupCallback& tlc) {
         texturelookup = tlc;

--- a/rwlib/source/loaders/LoaderIMG.cpp
+++ b/rwlib/source/loaders/LoaderIMG.cpp
@@ -49,7 +49,7 @@ bool LoaderIMG::findAssetInfo(const std::string& assetname,
     return false;
 }
 
-char* LoaderIMG::loadToMemory(const std::string& assetname) {
+std::unique_ptr<char[]> LoaderIMG::loadToMemory(const std::string& assetname) {
     LoaderIMGFile assetInfo;
     bool found = findAssetInfo(assetname, assetInfo);
 
@@ -62,39 +62,37 @@ char* LoaderIMG::loadToMemory(const std::string& assetname) {
 
     FILE* fp = fopen(imgName.string().c_str(), "rb");
     if (fp) {
-        char* raw_data = new char[assetInfo.size * 2048];
+        auto raw_data = std::make_unique<char[]>(assetInfo.size * 2048);
 
         fseek(fp, assetInfo.offset * 2048, SEEK_SET);
-        if (fread(raw_data, 2048, assetInfo.size, fp) != assetInfo.size) {
+        if (fread(raw_data.get(), 2048, assetInfo.size, fp) != assetInfo.size) {
             RW_ERROR("Error reading asset " << assetInfo.name);
         }
 
         fclose(fp);
         return raw_data;
     } else
-        return 0;
+        return nullptr;
 }
 
 /// Writes the contents of assetname to filename
 bool LoaderIMG::saveAsset(const std::string& assetname,
                           const std::string& filename) {
-    char* raw_data = loadToMemory(assetname);
+    auto raw_data = loadToMemory(assetname);
     if (!raw_data) return false;
 
     FILE* dumpFile = fopen(filename.c_str(), "wb");
     if (dumpFile) {
         LoaderIMGFile asset;
         if (findAssetInfo(assetname, asset)) {
-            fwrite(raw_data, 2048, asset.size, dumpFile);
+            fwrite(raw_data.get(), 2048, asset.size, dumpFile);
             printf("=> IMG: Saved %s to disk with filename %s\n",
                    assetname.c_str(), filename.c_str());
         }
         fclose(dumpFile);
 
-        delete[] raw_data;
         return true;
     } else {
-        delete[] raw_data;
         return false;
     }
 }

--- a/rwlib/source/loaders/LoaderIMG.hpp
+++ b/rwlib/source/loaders/LoaderIMG.hpp
@@ -39,9 +39,8 @@ public:
     bool load(const rwfs::path& filename);
 
     /// Load a file from the archive to memory and pass a pointer to it
-    /// Warning: Please delete[] the memory in the end.
-    /// Warning: Returns NULL (0) if by any reason it can't load the file
-    char* loadToMemory(const std::string& assetname);
+    /// Warning: Returns nullptr if by any reason it can't load the file
+    std::unique_ptr<char[]> loadToMemory(const std::string& assetname);
 
     /// Writes the contents of assetname to filename
     bool saveAsset(const std::string& assetname, const std::string& filename);

--- a/rwlib/source/loaders/LoaderTXD.cpp
+++ b/rwlib/source/loaders/LoaderTXD.cpp
@@ -174,7 +174,7 @@ TextureData::Handle createTexture(RW::BSTextureNative& texNative,
 
 bool TextureLoader::loadFromMemory(const FileContentsInfo& file,
                                    TextureArchive& inTextures) {
-    auto data = file.data;
+    auto data = file.data.get();
     RW::BinaryStreamSection root(data);
     /*auto texDict =*/root.readStructure<RW::BSTextureDictionary>();
 

--- a/rwlib/source/loaders/LoaderTXD.cpp
+++ b/rwlib/source/loaders/LoaderTXD.cpp
@@ -172,9 +172,9 @@ TextureData::Handle createTexture(RW::BSTextureNative& texNative,
                                transparent);
 }
 
-bool TextureLoader::loadFromMemory(const FileHandle& file,
+bool TextureLoader::loadFromMemory(const FileContentsInfo& file,
                                    TextureArchive& inTextures) {
-    auto data = file->data;
+    auto data = file.data;
     RW::BinaryStreamSection root(data);
     /*auto texDict =*/root.readStructure<RW::BSTextureDictionary>();
 

--- a/rwlib/source/loaders/LoaderTXD.hpp
+++ b/rwlib/source/loaders/LoaderTXD.hpp
@@ -6,7 +6,7 @@
 
 class TextureLoader {
 public:
-    bool loadFromMemory(const FileHandle& file, TextureArchive& inTextures);
+    bool loadFromMemory(const FileContentsInfo& file, TextureArchive& inTextures);
 };
 
 #endif

--- a/rwlib/source/platform/FileHandle.hpp
+++ b/rwlib/source/platform/FileHandle.hpp
@@ -1,20 +1,29 @@
 #ifndef _LIBRW_FILEHANDLE_HPP_
 #define _LIBRW_FILEHANDLE_HPP_
+
 #include <cstddef>
+#include <memory>
 
 /**
  * @brief Contains a pointer to a file's contents.
  */
 struct FileContentsInfo {
-    char *data;
+    std::unique_ptr<char[]> data;
     size_t length;
 
-    FileContentsInfo(char* mem, size_t len) : data(mem), length(len) {
+    FileContentsInfo(std::unique_ptr<char[]> mem, size_t len)
+        : data(std::move(mem)), length(len) {
     }
 
-    ~FileContentsInfo() {
-        delete[] data;
+    FileContentsInfo(FileContentsInfo&& info)
+        : data(std::move(info.data)), length(info.length) {
+        info.data = nullptr;
     }
+
+    FileContentsInfo(FileContentsInfo& info) = delete;
+    FileContentsInfo& operator=(FileContentsInfo& info) = delete;
+
+    ~FileContentsInfo() = default;
 };
 
 #endif

--- a/rwlib/source/platform/FileHandle.hpp
+++ b/rwlib/source/platform/FileHandle.hpp
@@ -1,5 +1,6 @@
 #ifndef _LIBRW_FILEHANDLE_HPP_
 #define _LIBRW_FILEHANDLE_HPP_
+#include <cstddef>
 
 /**
  * @brief Contains a pointer to a file's contents.

--- a/rwlib/source/platform/FileIndex.cpp
+++ b/rwlib/source/platform/FileIndex.cpp
@@ -50,7 +50,7 @@ rwfs::path FileIndex::findFilePath(const std::string &filePath) const {
     return getIndexedDataAt(filePath)->path;
 }
 
-FileHandle FileIndex::openFileRaw(const std::string &filePath) const {
+FileContentsInfo FileIndex::openFileRaw(const std::string &filePath) const {
     const auto *indexData = getIndexedDataAt(filePath);
     std::ifstream dfile(indexData->path, std::ios::binary);
     if (!dfile.is_open()) {
@@ -69,7 +69,7 @@ FileHandle FileIndex::openFileRaw(const std::string &filePath) const {
     auto data = new char[length];
     dfile.read(data, length);
 
-    return std::make_shared<FileContentsInfo>(data, length);
+    return {data, static_cast<size_t>(length)};
 }
 
 void FileIndex::indexArchive(const std::string &archive) {
@@ -91,11 +91,12 @@ void FileIndex::indexArchive(const std::string &archive) {
     }
 }
 
-FileHandle FileIndex::openFile(const std::string &filePath) {
+FileContentsInfo FileIndex::openFile(const std::string &filePath) {
     auto cleanFilePath = normalizeFilePath(filePath);
     auto indexedDataPos = indexedData_.find(cleanFilePath);
+
     if (indexedDataPos == indexedData_.end()) {
-        return nullptr;
+        return {nullptr, 0};
     }
 
     const auto &indexedData = indexedDataPos->second;
@@ -129,9 +130,5 @@ FileHandle FileIndex::openFile(const std::string &filePath) {
         dfile.read(data, length);
     }
 
-    if (data == nullptr) {
-        return nullptr;
-    }
-
-    return std::make_shared<FileContentsInfo>(data, length);
+    return {data, length};
 }

--- a/rwlib/source/platform/FileIndex.cpp
+++ b/rwlib/source/platform/FileIndex.cpp
@@ -6,7 +6,7 @@
 #include <iterator>
 #include <sstream>
 
-#include "FileHandle.hpp"
+#include "platform/FileHandle.hpp"
 #include "loaders/LoaderIMG.hpp"
 
 #include "rw/debug.hpp"
@@ -66,10 +66,10 @@ FileContentsInfo FileIndex::openFileRaw(const std::string &filePath) const {
     dfile.seekg(0, std::ios::end);
     auto length = dfile.tellg();
     dfile.seekg(0);
-    auto data = new char[length];
-    dfile.read(data, length);
+    auto data = std::make_unique<char[]>(length);
+    dfile.read(data.get(), length);
 
-    return {data, static_cast<size_t>(length)};
+    return {std::move(data), static_cast<size_t>(length)};
 }
 
 void FileIndex::indexArchive(const std::string &archive) {
@@ -101,7 +101,7 @@ FileContentsInfo FileIndex::openFile(const std::string &filePath) {
 
     const auto &indexedData = indexedDataPos->second;
 
-    char *data = nullptr;
+    std::unique_ptr<char[]> data = nullptr;
     size_t length = 0;
 
     if (indexedData.type == IndexedDataType::ARCHIVE) {
@@ -126,9 +126,9 @@ FileContentsInfo FileIndex::openFile(const std::string &filePath) {
         dfile.seekg(0, std::ios::end);
         length = dfile.tellg();
         dfile.seekg(0);
-        data = new char[length];
-        dfile.read(data, length);
+        data = std::make_unique<char[]>(length);
+        dfile.read(data.get(), length);
     }
 
-    return {data, length};
+    return {std::move(data), length};
 }

--- a/rwlib/source/platform/FileIndex.hpp
+++ b/rwlib/source/platform/FileIndex.hpp
@@ -38,7 +38,7 @@ public:
      * @return FileHandle to the file
      * @throws if this FileIndex has not indexed the path
      */
-    FileHandle openFileRaw(const std::string &filePath) const;
+    FileContentsInfo openFileRaw(const std::string &filePath) const;
 
     /**
      * Adds the files contained within the given Archive file to the
@@ -54,7 +54,7 @@ public:
      * @param filePath name of the file to open
      * @return FileHandle to the file, nullptr if this FileINdexed has not indexed the path
      */
-    FileHandle openFile(const std::string &filePath);
+    FileContentsInfo openFile(const std::string &filePath);
 
 private:
     /**

--- a/rwlib/source/rw/forward.hpp
+++ b/rwlib/source/rw/forward.hpp
@@ -16,7 +16,6 @@ class Clump;
 
 // Pointer types
 using AnimationPtr = std::shared_ptr<Animation>;
-using FileHandle = std::shared_ptr<FileContentsInfo>;
 using ModelFramePtr = std::shared_ptr<ModelFrame>;
 using GeometryPtr = std::shared_ptr<Geometry>;
 using AtomicPtr = std::shared_ptr<Atomic>;

--- a/rwviewer/views/ModelViewer.cpp
+++ b/rwviewer/views/ModelViewer.cpp
@@ -3,6 +3,7 @@
 #include <engine/Animator.hpp>
 #include <fstream>
 #include <objects/GameObject.hpp>
+#include <platform/FileHandle.hpp>
 #include <widgets/ModelFramesWidget.hpp>
 #include "ViewerWidget.hpp"
 
@@ -47,7 +48,7 @@ void ModelViewer::showObject(uint16_t object) {
         });
 
     auto file = world()->data->index.openFile(modelName);
-    if (!file) {
+    if (!file.data) {
         RW_ERROR("Couldn't load " << modelName);
         return;
     }

--- a/rwviewer/views/TextViewer.cpp
+++ b/rwviewer/views/TextViewer.cpp
@@ -8,10 +8,11 @@
 #include <iomanip>
 #include <iostream>
 
+#include <boost/filesystem.hpp>
 #include <fonts/GameTexts.hpp>
 #include <loaders/LoaderGXT.hpp>
 #include <models/TextModel.hpp>
-#include <boost/filesystem.hpp>
+#include <platform/FileHandle.hpp>
 #include <render/GameRenderer.hpp>
 
 #include <QGroupBox>

--- a/tests/test_Cutscene.cpp
+++ b/tests/test_Cutscene.cpp
@@ -1,6 +1,7 @@
 #include <boost/test/unit_test.hpp>
 #include <data/CutsceneData.hpp>
 #include <loaders/LoaderCutsceneDAT.hpp>
+#include <platform/FileHandle.hpp>
 #include "test_Globals.hpp"
 
 BOOST_AUTO_TEST_SUITE(CutsceneTests)

--- a/tests/test_FileIndex.cpp
+++ b/tests/test_FileIndex.cpp
@@ -1,4 +1,5 @@
 #include <boost/test/unit_test.hpp>
+#include <platform/FileHandle.hpp>
 #include <platform/FileIndex.hpp>
 #include "test_Globals.hpp"
 
@@ -50,7 +51,7 @@ BOOST_AUTO_TEST_CASE(test_openFile) {
     index.indexTree(Global::getGamePath() + "/data");
 
     auto handle = index.openFile("cullzone.dat");
-    BOOST_CHECK(handle != nullptr);
+    BOOST_CHECK(handle.data != nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(test_indexArchive) {
@@ -59,14 +60,14 @@ BOOST_AUTO_TEST_CASE(test_indexArchive) {
 
     {
         auto handle = index.openFile("landstal.dff");
-        BOOST_CHECK(handle == nullptr);
+        BOOST_CHECK(handle.data == nullptr);
     }
 
     index.indexArchive("models/gta3.img");
 
     {
         auto handle = index.openFile("landstal.dff");
-        BOOST_CHECK(handle != nullptr);
+        BOOST_CHECK(handle.data != nullptr);
     }
 }
 #endif

--- a/tests/test_LoaderDFF.cpp
+++ b/tests/test_LoaderDFF.cpp
@@ -1,5 +1,6 @@
 #include <boost/test/unit_test.hpp>
 #include <data/Clump.hpp>
+#include <platform/FileHandle.hpp>
 #include "test_Globals.hpp"
 
 BOOST_AUTO_TEST_SUITE(LoaderDFFTests)

--- a/tests/test_RWBStream.cpp
+++ b/tests/test_RWBStream.cpp
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_CASE(iterate_stream_test) {
     {
         auto d = Global::get().e->data->index.openFile("landstal.dff");
 
-        RWBStream stream(d.data, d.length);
+        RWBStream stream(d.data.get(), d.length);
 
         RWBStream::ChunkID id = stream.getNextChunk();
 

--- a/tests/test_RWBStream.cpp
+++ b/tests/test_RWBStream.cpp
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_CASE(iterate_stream_test) {
     {
         auto d = Global::get().e->data->index.openFile("landstal.dff");
 
-        RWBStream stream(d->data, d->length);
+        RWBStream stream(d.data, d.length);
 
         RWBStream::ChunkID id = stream.getNextChunk();
 

--- a/tests/test_Text.cpp
+++ b/tests/test_Text.cpp
@@ -2,6 +2,7 @@
 #include <engine/ScreenText.hpp>
 #include <fonts/GameTexts.hpp>
 #include <loaders/LoaderGXT.hpp>
+#include <platform/FileHandle.hpp>
 #include "test_Globals.hpp"
 
 #define T(x) GameStringUtil::fromString(x, FONT_PRICEDOWN)


### PR DESCRIPTION
Been trying to convert shared_ptr to unique_ptr, but sometimes even there's no need for pointers.

Tested with address sanitizers in game, but brakes one data test:
https://gist.github.com/ShFil119/c82d46c5f548a5fd97d50194749c7770
(not sure how to fix/refactor it)
Edit:
Fixed