### PR TITLE
Fix data test `test_activities`

### DIFF
--- a/tests/test_Character.cpp
+++ b/tests/test_Character.cpp
@@ -51,8 +51,10 @@ BOOST_AUTO_TEST_CASE(test_activities) {
             Global::get().e->dynamicsWorld->stepSimulation(1.f / 60.f);
         }
 
-        BOOST_CHECK_LT(
-            glm::distance(character->getPosition(), {10.f, 10.f, 0.f}), 0.1f);
+        // Actually GoTo ignores z axis (up)
+        BOOST_CHECK_LT(glm::distance(glm::vec2{character->getPosition()},
+                                        {10.f, 10.f}),
+                                        0.1f);
 
         Global::get().e->destroyObject(character);
     }


### PR DESCRIPTION
Actually GoTo ignores z axis (up), looks position which is targeted by is some kind of hole or slope.
And z axis is included (wrongly) into calculation of distance. So input data is ok.

Example log of character's position in test: https://gist.github.com/ShFil119/cb21d8d34ad1593c24493fa49b47c19d
Increasing time for activity is causing that z value goes into negative values.

fixes #459 