### PR TITLE
Update cmake minimum required version to 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2.2)
+cmake_minimum_required(VERSION 3.8)
 
 project(OpenRW)
 


### PR DESCRIPTION
OpenRW uses OpenGL::GL imported targets that introduced in CMake 3.8, so we [need](https://github.com/rwengine/openrw/issues/544#issuecomment-403313168) to update `cmake_minimum_required` to 3.8.
Also as said @madebr in IRC the findBoost package also has imported targets since that cmake version.

For Debian Stretch users:
In Debian repositories cmake version still lower than 3.8, so to build OpenRW you will [need](https://github.com/rwengine/openrw/issues/544#issuecomment-403395680) to install newer version of cmake from stretch-backports