### PR TITLE
Remove old style casts

### DIFF
--- a/cmake_configure.cmake
+++ b/cmake_configure.cmake
@@ -12,7 +12,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang
             "-Wextra"
             "-Wdouble-promotion"
             "-Wpedantic"
-            "-pthread"
+            "$<IF:$<COMPILE_LANGUAGE:CXX>,-Wold-style-cast,>"
         )
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_definitions(rw_interface

--- a/rwengine/src/TextureArchive.cpp
+++ b/rwengine/src/TextureArchive.cpp
@@ -21,7 +21,8 @@ std::unique_ptr<TextureArchive> TextureArchive::create(
 
     // Struct
     section = section->next;
-    textureArchive->numTextures = ((uint16_t *)section->data)[0];
+    textureArchive->numTextures =
+        reinterpret_cast<uint16_t *>(section->data)[0];
 
     for (size_t i = 0; i < textureArchive->numTextures; i++) {
         section = section->next;  // Texture Native

--- a/rwengine/src/ai/AIGraph.cpp
+++ b/rwengine/src/ai/AIGraph.cpp
@@ -79,7 +79,7 @@ void AIGraph::createPathNodes(const glm::vec3& position,
 
     for (size_t pn = 0; pn < path.nodes.size(); ++pn) {
         if (path.nodes[pn].next >= 0 &&
-            (unsigned)path.nodes[pn].next < pathNodes.size()) {
+            static_cast<unsigned>(path.nodes[pn].next) < pathNodes.size()) {
             auto node = pathNodes[pn];
             auto next = pathNodes[path.nodes[pn].next];
 
@@ -109,7 +109,7 @@ void AIGraph::gatherExternalNodesNear(const glm::vec3& center,
     for (int x = minGrid.x; x <= maxGrid.x; ++x) {
         for (int y = minGrid.y; y <= maxGrid.y; ++y) {
             int i = (x * WORLD_GRID_WIDTH) + y;
-            if (i < 0 || i >= (int)gridNodes.size()) {
+            if (i < 0 || i >= static_cast<int>(gridNodes.size())) {
                 continue;
             }
             auto& external = gridNodes[i];

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -201,13 +201,17 @@ bool CharacterController::checkForObstacles()
     // Try to stop before pedestrians
     for (const auto &obj : character->engine->pedestrianPool.objects) {
         // Verify that the character isn't the driver and is walking
-        if (obj.second != character && ((CharacterObject*)obj.second)->getCurrentVehicle() == nullptr) {
+        if (obj.second != character &&
+            static_cast<CharacterObject *>(obj.second)->getCurrentVehicle() ==
+                nullptr) {
             // Only check characters that are near our vehicle
-            if (glm::distance(vehicle->getPosition(), obj.second->getPosition()) <= minColDist) {
+            if (glm::distance(vehicle->getPosition(),
+                              obj.second->getPosition()) <= minColDist) {
                 // Check if the character is in front of us and in our way
-                if ( vehicle->isInFront(obj.second->getPosition()) > -3.f 
-                    && vehicle->isInFront(obj.second->getPosition()) < 10.f 
-                    && glm::abs(vehicle->isOnSide(obj.second->getPosition())) < 3.f ) {
+                if (vehicle->isInFront(obj.second->getPosition()) > -3.f &&
+                    vehicle->isInFront(obj.second->getPosition()) < 10.f &&
+                    glm::abs(vehicle->isOnSide(obj.second->getPosition())) <
+                        3.f) {
                     return true;
                 }
             }
@@ -219,38 +223,46 @@ bool CharacterController::checkForObstacles()
         // Verify that the vehicle isn't our vehicle
         if (obj.second != vehicle) {
             // Only check vehicles that are near our vehicle
-            if (glm::distance(vehicle->getPosition(), obj.second->getPosition()) <= minColDist) {
+            if (glm::distance(vehicle->getPosition(),
+                              obj.second->getPosition()) <= minColDist) {
                 // Check if the vehicle is in front of us and in our way
-                if ( vehicle->isInFront(obj.second->getPosition()) > 0.f 
-                    && vehicle->isInFront(obj.second->getPosition()) < 10.f 
-                    && glm::abs(vehicle->isOnSide(obj.second->getPosition())) < 2.5f ) {
+                if (vehicle->isInFront(obj.second->getPosition()) > 0.f &&
+                    vehicle->isInFront(obj.second->getPosition()) < 10.f &&
+                    glm::abs(vehicle->isOnSide(obj.second->getPosition())) <
+                        2.5f) {
                     // Check if the road has more than one lane
-                    // @todo we don't know the direction of the road, so for now, choose the bigger value
-                    int maxLanes = targetNode->rightLanes > targetNode->leftLanes ?
-                                    targetNode->rightLanes : targetNode->leftLanes;
+                    // @todo we don't know the direction of the road, so for
+                    // now, choose the bigger value
+                    int maxLanes =
+                        targetNode->rightLanes > targetNode->leftLanes
+                            ? targetNode->rightLanes
+                            : targetNode->leftLanes;
                     if (maxLanes > 1) {
-                        // Change the lane, firstly check if there is an occupant
-                        if (((VehicleObject *)obj.second)->getDriver() !=
-                            nullptr) {
-                            // @todo for now we don't know the lane where the player is currently driving
-                            // so just slow down, in the future calculate the lane
-                            if (((VehicleObject *)obj.second)
+                        // Change the lane, firstly check if there is an
+                        // occupant
+                        if (static_cast<VehicleObject *>(obj.second)
+                                ->getDriver() != nullptr) {
+                            // @todo for now we don't know the lane where the
+                            // player is currently driving so just slow down, in
+                            // the future calculate the lane
+                            if (static_cast<VehicleObject *>(obj.second)
                                     ->getDriver()
                                     ->isPlayer()) {
                                 return true;
-                            }
-                            else {
-                                int avoidLane = ((VehicleObject *)obj.second)
-                                                    ->getDriver()
-                                                    ->controller->getLane();
+                            } else {
+                                int avoidLane =
+                                    static_cast<VehicleObject *>(obj.second)
+                                        ->getDriver()
+                                        ->controller->getLane();
 
                                 // @todo for now just two lanes
-                                if (avoidLane == 1) character->controller->setLane(2);
-                                else character->controller->setLane(1);
+                                if (avoidLane == 1)
+                                    character->controller->setLane(2);
+                                else
+                                    character->controller->setLane(1);
                             }
-                        }					
-                    }
-                    else {
+                        }
+                    } else {
                         return true;
                     }
                 }
@@ -670,7 +682,7 @@ bool Activities::UseItem::update(CharacterObject *character,
 
     if (state.bulletsClip == 0 && state.bulletsTotal > 0) {
         state.bulletsClip +=
-            std::min(int(state.bulletsTotal), weapon->clipSize);
+            std::min(static_cast<int>(state.bulletsTotal), weapon->clipSize);
         state.bulletsTotal -= state.bulletsClip;
     }
     bool hasammo = state.bulletsClip > 0;

--- a/rwengine/src/data/Chase.cpp
+++ b/rwengine/src/data/Chase.cpp
@@ -43,21 +43,27 @@ bool ChaseKeyframe::load(const std::string &filePath,
 
     for (size_t i = 0; i < recordCount; ++i) {
         ChaseEntryRecord rec;
-        chaseFile.read((char *)&rec, sizeof(ChaseEntryRecord));
+        chaseFile.read(reinterpret_cast<char *>(&rec),
+                       sizeof(ChaseEntryRecord));
         glm::vec3 velocity{
-            rec.velocity[0] / 16383.5f, rec.velocity[1] / 16383.5f,
+            rec.velocity[0] / 16383.5f,
+            rec.velocity[1] / 16383.5f,
             rec.velocity[2] / 16383.5f,
         };
         glm::vec3 right{
-            rec.right[0] / 127.5f, rec.right[1] / 127.5f, rec.right[2] / 127.5f,
+            rec.right[0] / 127.5f,
+            rec.right[1] / 127.5f,
+            rec.right[2] / 127.5f,
         };
         glm::vec3 up{
-            rec.up[0] / 127.5f, rec.up[1] / 127.5f, rec.up[2] / 127.5f,
+            rec.up[0] / 127.5f,
+            rec.up[1] / 127.5f,
+            rec.up[2] / 127.5f,
         };
         glm::mat3 rotation(right, up, glm::cross(right, up));
         frames.emplace_back(velocity, rec.steering, rec.driving, rec.braking,
-                          !!rec.handbrake, rec.position,
-                          glm::quat_cast(rotation));
+                            !!rec.handbrake, rec.position,
+                            glm::quat_cast(rotation));
     }
 
     return true;

--- a/rwengine/src/dynamics/CollisionInstance.cpp
+++ b/rwengine/src/dynamics/CollisionInstance.cpp
@@ -110,10 +110,10 @@ bool CollisionInstance::createPhysicsBody(GameObject* object,
     auto& faces = collision->faces;
     if (!verts.empty() && !faces.empty()) {
         m_vertArray = new btTriangleIndexVertexArray(
-            faces.size(), (int*)faces.data(), sizeof(CollisionModel::Triangle),
-            verts.size(), (float*)verts.data(), sizeof(glm::vec3));
+                    faces.size(), reinterpret_cast<int*>(faces.data()), sizeof(CollisionModel::Triangle),
+                    verts.size(), reinterpret_cast<float*>(verts.data()), sizeof(glm::vec3));
         btBvhTriangleMeshShape* trishape =
-            new btBvhTriangleMeshShape(m_vertArray, false);
+                new btBvhTriangleMeshShape(m_vertArray, false);
         trishape->setMargin(0.05f);
         cmpShape->addChildShape(t, trishape);
 

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -701,10 +701,10 @@ void GameData::loadSplash(const std::string& name) {
 }
 
 int GameData::getWaterIndexAt(const glm::vec3& ws) const {
-    auto wX = (int)((ws.x + WATER_WORLD_SIZE / 2.f) /
-                    (WATER_WORLD_SIZE / WATER_HQ_DATA_SIZE));
-    auto wY = (int)((ws.y + WATER_WORLD_SIZE / 2.f) /
-                    (WATER_WORLD_SIZE / WATER_HQ_DATA_SIZE));
+    auto wX = static_cast<int>((ws.x + WATER_WORLD_SIZE / 2.f) /
+                               (WATER_WORLD_SIZE / WATER_HQ_DATA_SIZE));
+    auto wY = static_cast<int>((ws.y + WATER_WORLD_SIZE / 2.f) /
+                               (WATER_WORLD_SIZE / WATER_HQ_DATA_SIZE));
 
     if (wX >= 0 && wX < WATER_HQ_DATA_SIZE && wY >= 0 &&
         wY < WATER_HQ_DATA_SIZE) {

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -351,7 +351,7 @@ PickupObject* GameWorld::createPickup(const glm::vec3& pos, int id, int type) {
     }
 
     PickupObject* pickup = nullptr;
-    auto pickuptype = (PickupObject::PickupType)type;
+    auto pickuptype = static_cast<PickupObject::PickupType>(type);
 
     auto it = std::find_if(
         data->weaponData.begin(), data->weaponData.end(),
@@ -839,7 +839,8 @@ VehicleObject* GameWorld::tryToSpawnVehicle(VehicleGenerator& gen) {
     }
 
     /// @todo take into account maxDelay as well
-    if (gen.lastSpawnTime + gen.minDelay > int(state->basic.timeMS)) {
+    if (gen.lastSpawnTime + gen.minDelay >
+        static_cast<int>(state->basic.timeMS)) {
         return nullptr;
     }
 

--- a/rwengine/src/engine/SaveGame.cpp
+++ b/rwengine/src/engine/SaveGame.cpp
@@ -1216,8 +1216,9 @@ bool SaveGame::loadGame(GameState& state, const std::string& file) {
     // We keep track of the game time as a float for now
     state.gameTime = state.basic.timeMS / 1000.f;
 
-    state.scriptOnMissionFlag = (int32_t*)(state.script->getGlobals() +
-                                           (size_t)scriptData.onMissionOffset);
+    state.scriptOnMissionFlag = reinterpret_cast<int32_t*>(
+        state.script->getGlobals() +
+        static_cast<size_t>(scriptData.onMissionOffset));
 
     auto& threads = state.script->getThreads();
     for (size_t s = 0; s < numScripts; ++s) {

--- a/rwengine/src/loaders/GenericDATLoader.cpp
+++ b/rwengine/src/loaders/GenericDATLoader.cpp
@@ -160,8 +160,8 @@ void GenericDATLoader::loadHandling(const std::string& name,
             char dt, et;
             ss >> dt;
             ss >> et;
-            info.driveType = (VehicleHandlingInfo::DriveType)dt;
-            info.engineType = (VehicleHandlingInfo::EngineType)et;
+            info.driveType = static_cast<VehicleHandlingInfo::DriveType>(dt);
+            info.engineType = static_cast<VehicleHandlingInfo::EngineType>(et);
             ss >> info.brakeDeceleration;
             ss >> info.brakeBias;
             ss >> info.ABS;

--- a/rwengine/src/loaders/LoaderCOL.cpp
+++ b/rwengine/src/loaders/LoaderCOL.cpp
@@ -48,17 +48,17 @@ bool LoaderCOL::load(const std::string& path) {
         model->modelid = head.modelid;
 
         auto readFloat = [&]() {
-            auto f = (float*)d;
+            auto f = reinterpret_cast<float*>(d);
             d += sizeof(float);
             return *f;
         };
         auto readU8 = [&]() {
-            auto f = (uint8_t*)d;
+            auto f = reinterpret_cast<uint8_t*>(d);
             d += sizeof(uint8_t);
             return *f;
         };
         auto readU32 = [&]() {
-            auto f = (uint32_t*)d;
+            auto f = reinterpret_cast<uint32_t*>(d);
             d += sizeof(uint32_t);
             return *f;
         };

--- a/rwengine/src/loaders/LoaderGXT.cpp
+++ b/rwengine/src/loaders/LoaderGXT.cpp
@@ -14,14 +14,14 @@ void LoaderGXT::load(GameTexts &texts, const FileHandle &file) {
 
     data += 4;  // TKEY
 
-    std::uint32_t blocksize = *(std::uint32_t *)data;
+    std::uint32_t blocksize = *reinterpret_cast<std::uint32_t *>(data);
 
     data += 4;
 
     auto tdata = data + blocksize + 8;
 
     for (size_t t = 0; t < blocksize / 12; ++t) {
-        size_t offset = *(std::uint32_t *)(data + (t * 12 + 0));
+        size_t offset = *reinterpret_cast<std::uint32_t *>(data + (t * 12 + 0));
         std::string id(data + (t * 12 + 4));
 
         GameStringChar *stringSrc =

--- a/rwengine/src/objects/InstanceObject.cpp
+++ b/rwengine/src/objects/InstanceObject.cpp
@@ -77,9 +77,9 @@ void InstanceObject::tickPhysics(float dt) {
     // Only certain objects should float on water
     if (floating) {
         const glm::vec3& ws = getPosition();
-        auto wX = (int)((ws.x + WATER_WORLD_SIZE / 2.f) /
+        auto wX = static_cast<int>((ws.x + WATER_WORLD_SIZE / 2.f) /
                         (WATER_WORLD_SIZE / WATER_HQ_DATA_SIZE));
-        auto wY = (int)((ws.y + WATER_WORLD_SIZE / 2.f) /
+        auto wY = static_cast<int>((ws.y + WATER_WORLD_SIZE / 2.f) /
                         (WATER_WORLD_SIZE / WATER_HQ_DATA_SIZE));
         float vH = ws.z;  // - _collisionHeight/2.f;
         float wH = 0.f;

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -38,13 +38,13 @@ public:
                   btVehicleRaycasterResult& result) override {
         ClosestNotMeRayResultCallback rayCallback(
             _vehicle->collision->getBulletBody(), from, to);
-        const void* res = nullptr;
+        void* res = nullptr;
 
         _world->rayTest(from, to, rayCallback);
 
         if (rayCallback.hasHit()) {
-            const btRigidBody* body =
-                btRigidBody::upcast(rayCallback.m_collisionObject);
+            btRigidBody* body = const_cast<btRigidBody*>(
+                btRigidBody::upcast(rayCallback.m_collisionObject));
 
             if (body && body->hasContactResponse()) {
                 result.m_hitPointInWorld = rayCallback.m_hitPointWorld;
@@ -55,7 +55,7 @@ public:
             }
         }
 
-        return (void*)res;
+        return reinterpret_cast<void*>(res);
     }
 };
 
@@ -407,9 +407,9 @@ void VehicleObject::tickPhysics(float dt) {
         }
 
         const auto& ws = getPosition();
-        auto wX = (int)((ws.x + WATER_WORLD_SIZE / 2.f) /
+        auto wX = static_cast<int>((ws.x + WATER_WORLD_SIZE / 2.f) /
                         (WATER_WORLD_SIZE / WATER_HQ_DATA_SIZE));
-        auto wY = (int)((ws.y + WATER_WORLD_SIZE / 2.f) /
+        auto wY = static_cast<int>((ws.y + WATER_WORLD_SIZE / 2.f) /
                         (WATER_WORLD_SIZE / WATER_HQ_DATA_SIZE));
         btVector3 bbmin, bbmax;
         // This is in world space.

--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -129,8 +129,8 @@ GameRenderer::GameRenderer(Logger* log, GameData* _data)
 
     size_t segments = skydomeSegments, rows = skydomeRows;
 
-    float R = 1.f / (float)(rows - 1);
-    float S = 1.f / (float)(segments - 1);
+    float R = 1.f / static_cast<float>(rows - 1);
+    float S = 1.f / static_cast<float>(segments - 1);
     std::vector<VertexP3> skydomeVerts;
     skydomeVerts.resize(rows * segments);
     for (size_t r = 0, i = 0; r < rows; ++r) {

--- a/rwengine/src/render/MapRenderer.cpp
+++ b/rwengine/src/render/MapRenderer.cpp
@@ -83,7 +83,7 @@ void MapRenderer::draw(GameWorld* world, const MapInfo& mi) {
     // World out the number of units per tile
     glm::vec2 worldSize(GAME_MAP_SIZE);
     const int mapBlockLine = 8;
-    glm::vec2 tileSize = worldSize / (float)mapBlockLine;
+    glm::vec2 tileSize = worldSize / static_cast<float>(mapBlockLine);
     // Determine the scale to show the right number of world units on the screen
     float worldScale = mi.screenSize / mi.worldSize;
 

--- a/rwengine/src/render/OpenGLRenderer.cpp
+++ b/rwengine/src/render/OpenGLRenderer.cpp
@@ -97,8 +97,8 @@ GLuint compileProgram(const char* vertex, const char* fragment) {
 void Renderer::setViewport(const glm::ivec2& vp) {
     viewport = vp;
 
-    projection2D =
-        glm::ortho(0.f, (float)viewport.x, (float)viewport.y, 0.f, -1.f, 1.f);
+    projection2D = glm::ortho(0.f, static_cast<float>(viewport.x),
+                              static_cast<float>(viewport.y), 0.f, -1.f, 1.f);
 }
 
 void Renderer::swap() {
@@ -303,7 +303,7 @@ void OpenGLRenderer::draw(const glm::mat4& model, DrawBuffer* draw,
     setDrawState(model, draw, p);
 
     glDrawElements(draw->getFaceType(), p.count, GL_UNSIGNED_INT,
-                   (void*)(sizeof(RenderIndex) * p.start));
+                   reinterpret_cast<void*>(sizeof(RenderIndex) * p.start));
 }
 
 void OpenGLRenderer::drawArrays(const glm::mat4& model, DrawBuffer* draw,
@@ -353,7 +353,7 @@ void OpenGLRenderer::drawBatched(const RenderList& list) {
 			}
 
 			glDrawElements(draw.dbuff->getFaceType(), draw.drawInfo.count, GL_UNSIGNED_INT,
-						   (void*) (sizeof(RenderIndex) * draw.drawInfo.start));
+                           reinterpret_cast<void*>(sizeof(RenderIndex) * draw.drawInfo.start));
 		}
 	}
 #else

--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -19,8 +19,8 @@ int charToIndex(uint16_t g) {
 }
 
 glm::vec4 indexToCoord(int font, int index) {
-    float x = int(index % 16);
-    float y = int(index / 16) + 0.01f;
+    float x = static_cast<int>(index % 16);
+    float y = static_cast<int>(index / 16) + 0.01f;
     float fontHeight = ((font == 0) ? 16.f : 13.f);
     glm::vec2 gsize(1.f / 16.f, 1.f / fontHeight);
     return glm::vec4(x, y, x + 1, y + 0.98f) * glm::vec4(gsize, gsize);

--- a/rwengine/src/script/ScriptMachine.hpp
+++ b/rwengine/src/script/ScriptMachine.hpp
@@ -152,7 +152,8 @@ public:
     }
 
     uint32_t getGlobalOffset(ScriptInt& global) const {
-        return uint32_t((SCMByte*)(&global) - globalData.data());
+        return static_cast<uint32_t>(reinterpret_cast<SCMByte*>(&global) -
+                                     globalData.data());
     }
 
     bool getDebugFlag() const {

--- a/rwengine/src/script/ScriptTypes.cpp
+++ b/rwengine/src/script/ScriptTypes.cpp
@@ -256,5 +256,5 @@ template <>
 ScriptObjectType<int> ScriptArguments::getScriptObject(unsigned int arg) const {
     auto& param = (*this)[arg];
     RW_CHECK(param.isLvalue(), "Non lvalue passed as object");
-    return {param.handleValue(), (int*)nullptr};
+    return {param.handleValue(), static_cast<int*>(nullptr)};
 }

--- a/rwengine/src/script/modules/GTA3ModuleImpl.inl
+++ b/rwengine/src/script/modules/GTA3ModuleImpl.inl
@@ -9940,15 +9940,15 @@ void opcode_0376(const ScriptArguments& args, ScriptVec3 coord,
     auto world = args.getWorld();
     auto state = args.getState();
     auto data = world->data;
-    auto zone = data->findZoneAt(
-        world->getPlayer()->getCharacter()->getPosition());
+    auto zone =
+        data->findZoneAt(world->getPlayer()->getCharacter()->getPosition());
     const bool day =
         (state->basic.gameHour >= 8 && state->basic.gameHour <= 19);
     const int groupId =
         zone ? (day ? zone->pedGroupDay : zone->pedGroupNight) : 0;
     const auto& pedGroup = data->pedgroups.at(groupId);
-    const auto model = pedGroup.at(
-        args.getVM()->getRandomNumber((std::size_t)0, pedGroup.size() - 1));
+    const auto model = pedGroup.at(args.getVM()->getRandomNumber(
+        static_cast<std::size_t>(0), pedGroup.size() - 1));
     character = world->createPedestrian(model, coord + script::kSpawnOffset);
 }
 
@@ -11502,7 +11502,7 @@ void opcode_03e6(const ScriptArguments& args) {
     @arg arg1 
 */
 void opcode_03e7(const ScriptArguments& args, const ScriptHudFlash arg1) {
-    args.getState()->hudFlash = (HudFlash)arg1;
+    args.getState()->hudFlash = static_cast<HudFlash>(arg1);
 }
 
 /**

--- a/rwgame/DrawUI.cpp
+++ b/rwgame/DrawUI.cpp
@@ -155,7 +155,8 @@ void drawPlayerInfo(PlayerController* player, GameWorld* world,
             .25f) {  // UI: Blinking health indicator if health is low
         std::stringstream ss;
         ss << std::setw(3) << std::setfill('0')
-           << (int)player->getCharacter()->getCurrentState().health;
+           << static_cast<int>(
+                  player->getCharacter()->getCurrentState().health);
         ti.text = GameSymbols::Heart + GameStringUtil::fromString(ss.str());
 
         ti.baseColour = ui_shadowColour;
@@ -171,7 +172,8 @@ void drawPlayerInfo(PlayerController* player, GameWorld* world,
     if (player->getCharacter()->getCurrentState().armour > 0) {
         std::stringstream ss;
         ss << std::setw(3) << std::setfill('0')
-           << (int)player->getCharacter()->getCurrentState().armour;
+           << static_cast<int>(
+                  player->getCharacter()->getCurrentState().armour);
         ti.text = GameSymbols::Armour + GameStringUtil::fromString(ss.str());
 
         ti.baseColour = ui_shadowColour;
@@ -309,8 +311,8 @@ void drawOnScreenText(GameWorld* world, GameRenderer* renderer) {
 
             // Check for the background type
             if (t.colourBG.a == 0) {
-                glm::vec2 shadowPosition((int8_t)t.colourBG.x,
-                                         (int8_t)t.colourBG.y);
+                glm::vec2 shadowPosition(static_cast<int8_t>(t.colourBG.x),
+                                         static_cast<int8_t>(t.colourBG.y));
 
                 ti.baseColour = glm::vec3(0.f);
                 ti.screenPosition += shadowPosition;

--- a/rwgame/GameWindow.cpp
+++ b/rwgame/GameWindow.cpp
@@ -46,10 +46,10 @@ void GameWindow::create(const std::string& title, size_t w, size_t h,
     bmask = 0x00ff0000;
     amask = 0xff000000;
 #endif
-    icon = SDL_CreateRGBSurfaceFrom((void*)windowIconData,
-                                    windowIconWidth, windowIconHeight,
-                                    32, windowIconWidth * (32 / 8),
-                                    rmask, gmask, bmask, amask);
+    icon = SDL_CreateRGBSurfaceFrom(
+        static_cast<void*>(const_cast<unsigned char*>(windowIconData)),
+        windowIconWidth, windowIconHeight, 32, windowIconWidth * (32 / 8),
+        rmask, gmask, bmask, amask);
     SDL_SetWindowIcon(window, icon);
 
     SDL_ShowWindow(window);

--- a/rwgame/MenuSystem.hpp
+++ b/rwgame/MenuSystem.hpp
@@ -105,7 +105,7 @@ public:
         glm::vec2 basis(offset);
         for (size_t i = 0; i < entries.size(); ++i) {
             bool active = false;
-            if (activeEntry >= 0 && i == (unsigned)activeEntry) {
+            if (activeEntry >= 0 && i == static_cast<unsigned>(activeEntry)) {
                 active = true;
             }
             entries[i].draw(font, size, active, r, basis);
@@ -138,14 +138,15 @@ public:
 
     // Activates the menu entry at the current active index.
     void activate() {
-        if (activeEntry >= 0 && (unsigned)activeEntry < entries.size()) {
+        if (activeEntry >= 0 &&
+            static_cast<unsigned>(activeEntry) < entries.size()) {
             entries[activeEntry].activate(0.f, 0.f);
         }
     }
 
     void move(int movement) {
         activeEntry += movement;
-        if (activeEntry >= int(entries.size())) {
+        if (activeEntry >= static_cast<int>(entries.size())) {
             activeEntry = 0;
         } else if (activeEntry < 0) {
             activeEntry = entries.size() - 1;

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -301,8 +301,8 @@ void IngameState::handleEvent(const SDL_Event& event) {
                     }
                     break;
                 case SDLK_c:
-                    camMode =
-                        CameraMode((camMode + (CameraMode)1) % CAMERA_MAX);
+                    camMode = static_cast<CameraMode>(
+                        (camMode + static_cast<CameraMode>(1)) % CAMERA_MAX);
                     break;
                 default:
                     break;
@@ -435,7 +435,7 @@ const ViewCamera& IngameState::getCamera(float alpha) {
     lookTargetPosition += glm::vec3(0.f, 0.f, 0.5f);
 
     if (target->type() == GameObject::Vehicle) {
-        auto vehicle = (VehicleObject*)target;
+        auto vehicle = static_cast<VehicleObject*>(target);
         auto model = vehicle->getModel();
         auto maxDist = model->getBoundingRadius() * 2.f;
         viewDistance = viewDistance + maxDist;
@@ -510,7 +510,8 @@ GameObject* IngameState::getCameraTarget() const {
 
     // If the target is a character in a vehicle, make the vehicle the target
     if (target && target->type() == GameObject::Character) {
-        auto vehicle = ((CharacterObject*)target)->getCurrentVehicle();
+        auto vehicle =
+            (static_cast<CharacterObject*>(target))->getCurrentVehicle();
         if (vehicle) {
             target = vehicle;
         }

--- a/rwlib/source/loaders/LoaderDFF.cpp
+++ b/rwlib/source/loaders/LoaderDFF.cpp
@@ -59,21 +59,22 @@ LoaderDFF::FrameList LoaderDFF::readFrameList(const RWBStream &stream) {
 
     char *headerPtr = listStream.getCursor();
 
-    unsigned int numFrames = *(std::uint32_t *)headerPtr;
+    unsigned int numFrames = *reinterpret_cast<std::uint32_t *>(headerPtr);
     headerPtr += sizeof(std::uint32_t);
 
     FrameList framelist;
     framelist.reserve(numFrames);
 
     for (size_t f = 0; f < numFrames; ++f) {
-        auto data = (RWBSFrame *)headerPtr;
+        auto data = reinterpret_cast<RWBSFrame *>(headerPtr);
         headerPtr += sizeof(RWBSFrame);
         auto frame =
             std::make_shared<ModelFrame>(f, data->rotation, data->position);
 
-        RW_CHECK(data->index < int(framelist.size()),
+        RW_CHECK(data->index < static_cast<int>(framelist.size()),
                  "Frame parent out of bounds");
-        if (data->index != -1 && data->index < int(framelist.size())) {
+        if (data->index != -1 &&
+            data->index < static_cast<int>(framelist.size())) {
             framelist[data->index]->addChild(frame);
         }
 

--- a/rwviewer/AnimationListModel.cpp
+++ b/rwviewer/AnimationListModel.cpp
@@ -2,7 +2,8 @@
 
 QVariant AnimationListModel::data(const QModelIndex& index, int role) const {
     if (role == Qt::DisplayRole) {
-        if (index.row() >= 0 && (unsigned)index.row() < animations.size()) {
+        if (index.row() >= 0 &&
+            static_cast<unsigned>(index.row()) < animations.size()) {
             auto& f = animations.at(index.row());
             if (index.column() == 0) {
                 return QString(f.first.c_str());

--- a/rwviewer/AnimationListWidget.cpp
+++ b/rwviewer/AnimationListWidget.cpp
@@ -35,7 +35,8 @@ void AnimationListWidget::setAnimations(const AnimationList& archive) {
 
 void AnimationListWidget::selectedIndexChanged(const QModelIndex& current) {
     auto mts = filter->mapToSource(current);
-    if (mts.row() >= 0 && (unsigned)mts.row() < model->getAnimations().size()) {
+    if (mts.row() >= 0 &&
+        static_cast<unsigned>(mts.row()) < model->getAnimations().size()) {
         auto& f = model->getAnimations().at(mts.row());
         emit selectedAnimationChanged(f.second);
     }

--- a/rwviewer/IMGArchiveModel.cpp
+++ b/rwviewer/IMGArchiveModel.cpp
@@ -3,7 +3,7 @@
 QVariant IMGArchiveModel::data(const QModelIndex& index, int role) const {
     if (role == Qt::DisplayRole) {
         if (index.row() >= 0 &&
-            (unsigned)index.row() < archive.getAssetCount()) {
+            static_cast<unsigned>(index.row()) < archive.getAssetCount()) {
             auto& f = archive.getAssetInfoByIndex(index.row());
             if (index.column() == 0) {
                 return QString(f.name);

--- a/rwviewer/models/DFFFramesTreeModel.cpp
+++ b/rwviewer/models/DFFFramesTreeModel.cpp
@@ -72,7 +72,7 @@ bool DFFFramesTreeModel::setData(const QModelIndex& index,
 
     if (role == Qt::CheckStateRole) {
         if (index.column() == 0) {
-            if ((Qt::CheckState)value.toInt() == Qt::Checked) {
+            if (static_cast<Qt::CheckState>(value.toInt()) == Qt::Checked) {
                 RW_UNIMPLEMENTED("Hiding Frames");
             } else {
             }

--- a/rwviewer/widgets/ModelFramesWidget.cpp
+++ b/rwviewer/widgets/ModelFramesWidget.cpp
@@ -16,8 +16,8 @@ void ModelFramesWidget::updateInfoBox(ClumpPtr, ModelFrame* f) {
 
 void ModelFramesWidget::selectedModelChanged(const QModelIndex& n,
                                              const QModelIndex&) {
-    updateInfoBox(gmodel, (ModelFrame*)n.internalPointer());
-    selectedFrameChanged((ModelFrame*)n.internalPointer());
+    updateInfoBox(gmodel, static_cast<ModelFrame*>(n.internalPointer()));
+    selectedFrameChanged(static_cast<ModelFrame*>(n.internalPointer()));
 }
 
 ModelFramesWidget::ModelFramesWidget(QWidget* parent, Qt::WindowFlags flags)

--- a/tests/test_Globals.hpp
+++ b/tests/test_Globals.hpp
@@ -58,7 +58,7 @@ template <>
 struct print_log_value<GameString> {
     void operator()(std::ostream& s, GameString const& v) {
         for (GameString::size_type i = 0u; i < v.size(); ++i) {
-            s << (char)v[i];
+            s << static_cast<char>(v[i]);
         }
     }
 };

--- a/tests/test_Input.cpp
+++ b/tests/test_Input.cpp
@@ -18,13 +18,15 @@ BOOST_AUTO_TEST_CASE(TestStateUpdate) {
 
         // Check that the correct inputs report pressed
         for (int c = 0; c < GameInputState::_MaxControls; ++c) {
-            switch ((GameInputState::Control)c) {
+            switch (static_cast<GameInputState::Control>(c)) {
                 case GameInputState::Jump:
                 case GameInputState::Handbrake:
-                    BOOST_CHECK(state.pressed((GameInputState::Control)c));
+                    BOOST_CHECK(
+                        state.pressed(static_cast<GameInputState::Control>(c)));
                     break;
                 default:
-                    BOOST_CHECK(!state.pressed((GameInputState::Control)c));
+                    BOOST_CHECK(!state.pressed(
+                        static_cast<GameInputState::Control>(c)));
                     break;
             }
         }

--- a/tests/test_RWBStream.cpp
+++ b/tests/test_RWBStream.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(iterate_stream_test) {
         auto innerCursor = inner.getCursor();
 
         // This is a value inside in the Clump's struct header section.
-        BOOST_CHECK_EQUAL(*(std::uint32_t*)innerCursor, 0x10);
+        BOOST_CHECK_EQUAL(*reinterpret_cast<std::uint32_t*>(innerCursor), 0x10);
     }
 }
 #endif


### PR DESCRIPTION
Cleanup. ;) All old casts are removed.

To do:
- [x] reformat
- [x] if possible, remove now revealed nasty code. (done?)
- [x] add flag `-Wold-style-cast` on CI, actually there's problem `cc1: warning: command line option ‘-Wold-style-cast’ is valid for C++/ObjC++ but not for C [enabled by default]`