### PR TITLE
ci: echo APPVEYOR_REPO_COMMIT and COMMIT_HASH + do not exit on mismatch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,7 +40,8 @@ init:
 install:
   - cd "%APPVEYOR_BUILD_FOLDER%"
   - for /f %%i in ('git rev-parse HEAD') do set COMMIT_HASH=%%i
-  - if NOT "%APPVEYOR_REPO_COMMIT%" == "%COMMIT_HASH%" echo "Appveyor hash does not match checkout out hash" && exit 1
+  - echo APPVEYOR_REPO_COMMIT=%APPVEYOR_REPO_COMMIT%, COMMIT_HASH=%COMMIT_HASH%
+  - if NOT "%APPVEYOR_REPO_COMMIT%" == "%COMMIT_HASH%" echo "Appveyor git hash does not match git checkout hash"
 
 build_script:
   - ctest -VV -S "%APPVEYOR_BUILD_FOLDER%/cmake/ctest/script_ci.ctest"


### PR DESCRIPTION
Don't fail appveyor ci build when git hashes do not match.
This happens on the first build of a pull request.