### PR TITLE
Replace std::ptr_fun with lambda

### DIFF
--- a/rwengine/src/loaders/LoaderIDE.cpp
+++ b/rwengine/src/loaders/LoaderIDE.cpp
@@ -33,7 +33,7 @@ bool LoaderIDE::load(const std::string &filename, const PedStatsList &stats) {
         std::string line;
         getline(str, line);
         line.erase(std::find_if(line.rbegin(), line.rend(),
-                                std::not1(std::ptr_fun<int, int>(std::isspace)))
+                                [](auto c) { return !std::isspace(c); })
                        .base(),
                    line.end());
 

--- a/rwengine/src/loaders/LoaderIPL.cpp
+++ b/rwengine/src/loaders/LoaderIPL.cpp
@@ -29,7 +29,7 @@ bool LoaderIPL::load(const std::string& filename) {
         std::string line;
         getline(str, line);
         line.erase(std::find_if(line.rbegin(), line.rend(),
-                                std::not1(std::ptr_fun<int, int>(std::isspace)))
+                                [](auto c) { return !std::isspace(c); })
                        .base(),
                    line.end());
 


### PR DESCRIPTION
It is deprecated in c++11, and removed in c++17. (It also breaks compilation on MSVC with c++17)