### PR TITLE
Remove data dependency from LoaderIDE test suite

### DIFF
--- a/rwengine/src/data/ModelData.hpp
+++ b/rwengine/src/data/ModelData.hpp
@@ -172,7 +172,7 @@ public:
         loddistances_[n] = d;
     }
 
-    float getLodDistance(int n) {
+    float getLodDistance(int n) const {
         RW_CHECK(n < 3, "Lod Index out of range");
         return loddistances_[n];
     }

--- a/rwengine/src/loaders/LoaderIDE.cpp
+++ b/rwengine/src/loaders/LoaderIDE.cpp
@@ -172,7 +172,7 @@ bool LoaderIDE::load(std::istream& str, const PedStatsList& stats) {
                     getline(strstream, peds->animgroup_, ',');
 
                     getline(strstream, buff, ',');
-                    peds->carsmask_ = static_cast<int>(std::strtol(buff.c_str(), nullptr, 16));
+                    peds->carsmask_ = lexical_cast<int>(buff, 16);
 
                     objects.emplace(peds->id(), std::move(peds));
                     break;

--- a/rwengine/src/loaders/LoaderIDE.cpp
+++ b/rwengine/src/loaders/LoaderIDE.cpp
@@ -172,7 +172,7 @@ bool LoaderIDE::load(std::istream& str, const PedStatsList& stats) {
                     getline(strstream, peds->animgroup_, ',');
 
                     getline(strstream, buff, ',');
-                    peds->carsmask_ = lexical_cast<int>(buff);
+                    peds->carsmask_ = static_cast<int>(std::strtol(buff.c_str(), nullptr, 16));
 
                     objects.emplace(peds->id(), std::move(peds));
                     break;

--- a/rwengine/src/loaders/LoaderIDE.cpp
+++ b/rwengine/src/loaders/LoaderIDE.cpp
@@ -15,9 +15,11 @@
 
 bool LoaderIDE::load(const std::string &filename, const PedStatsList &stats) {
     std::ifstream str(filename);
-
     if (!str.is_open()) return false;
+    return load(str, stats);
+}
 
+bool LoaderIDE::load(std::istream& str, const PedStatsList& stats) {
     auto find_stat_id = [&](const std::string &name) {
         auto it =
             std::find_if(stats.begin(), stats.end(),

--- a/rwengine/src/loaders/LoaderIDE.hpp
+++ b/rwengine/src/loaders/LoaderIDE.hpp
@@ -24,6 +24,8 @@ public:
     // Load the IDE data into memory
     bool load(const std::string& filename, const PedStatsList& stats);
 
+    bool load(std::istream& data, const PedStatsList& stats);
+
     /**
      * @brief objects loaded during the call to load()
      */

--- a/rwlib/source/rw/casts.hpp
+++ b/rwlib/source/rw/casts.hpp
@@ -16,12 +16,20 @@ inline Dest bit_cast(Source const &source) {
 template <class T, class S>
 inline T lexical_cast(const S& s);
 
+template <class T, class S>
+inline T lexical_cast(const S& s, size_t base);
+
 template <>
-inline int lexical_cast(const std::string& source) {
+inline int lexical_cast(const std::string& source, size_t base) {
     char* end = nullptr; //for errors handling
-    int result = std::strtol(source.c_str(), &end, 10);
+    int result = std::strtol(source.c_str(), &end, base);
     RW_CHECK(end != source.c_str(), "Problem with conversion " << *end << " to int");
     return result;
+}
+
+template <>
+inline int lexical_cast(const std::string& source) {
+    return lexical_cast<int>(source, 10);
 }
 
 template <>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,11 +19,11 @@ set(TESTS
     Items
     Lifetime
     LoaderDFF
+    LoaderIDE
     LoaderIPL
     Logger
     Menu
     Object
-    ObjectData
     Payphone
     Pickup
     Renderer

--- a/tests/test_LoaderIDE.cpp
+++ b/tests/test_LoaderIDE.cpp
@@ -68,7 +68,7 @@ struct WithLoaderIDE {
     std::istringstream test_data_stream {kTestDataObjects};
 };
 
-BOOST_FIXTURE_TEST_SUITE(ObjectDataTests, WithLoaderIDE)
+BOOST_FIXTURE_TEST_SUITE(LoaderIDETests, WithLoaderIDE)
 
 BOOST_AUTO_TEST_CASE(objects_contains_modelID) {
     loader.load(test_data_stream, {});

--- a/tests/test_LoaderIDE.cpp
+++ b/tests/test_LoaderIDE.cpp
@@ -23,13 +23,13 @@ void ASSERT_INSTANCE_IS(BaseModelInfo& info, const char* model, const char* txd,
         const std::array<float, N>& lods, size_t flags) {
     BOOST_ASSERT(info.type() == SimpleModelInfo::kType);
     const auto& t = dynamic_cast<SimpleModelInfo&>(info);
-    BOOST_CHECK_EQUAL(t.name, model);
-    BOOST_CHECK_EQUAL(t.textureslot, txd);
-    BOOST_CHECK_EQUAL(t.getNumAtomics(), lods.size());
+    BOOST_TEST(t.name == model);
+    BOOST_TEST(t.textureslot == txd);
+    BOOST_TEST(t.getNumAtomics() == lods.size());
     for (auto i = 0u; i < lods.size(); ++i) {
-        BOOST_CHECK_EQUAL(t.getLodDistance(i), lods[i]);
+        BOOST_TEST(t.getLodDistance(i) == lods[i]);
     }
-    BOOST_CHECK_EQUAL(t.flags, flags);
+    BOOST_TEST(t.flags == flags);
 }
 
 void ASSERT_VEHICLE_IS(BaseModelInfo& info, const char* model, const char* txd,
@@ -37,15 +37,15 @@ void ASSERT_VEHICLE_IS(BaseModelInfo& info, const char* model, const char* txd,
         VehicleModelInfo::VehicleClass clas_, int frequency, ModelID wheel, float wheelScale) {
     BOOST_ASSERT(info.type() == VehicleModelInfo::kType);
     const auto& t = dynamic_cast<VehicleModelInfo&>(info);
-    BOOST_CHECK_EQUAL(t.name, model);
-    BOOST_CHECK_EQUAL(t.textureslot, txd);
-    BOOST_CHECK_EQUAL(t.vehicletype_, type);
-    BOOST_CHECK_EQUAL(t.handling_, handling);
-    BOOST_CHECK_EQUAL(t.vehiclename_, name);
-    BOOST_CHECK_EQUAL(t.vehicleclass_, clas_);
-    BOOST_CHECK_EQUAL(t.frequency_, frequency);
-    BOOST_CHECK_EQUAL(t.wheelmodel_, wheel);
-    BOOST_CHECK_EQUAL(t.wheelscale_, wheelScale);
+    BOOST_TEST(t.name == model);
+    BOOST_TEST(t.textureslot == txd);
+    BOOST_TEST(t.vehicletype_ == type);
+    BOOST_TEST(t.handling_ == handling);
+    BOOST_TEST(t.vehiclename_ == name);
+    BOOST_TEST(t.vehicleclass_ == clas_);
+    BOOST_TEST(t.frequency_ == frequency);
+    BOOST_TEST(t.wheelmodel_ == wheel);
+    BOOST_TEST(t.wheelscale_ == wheelScale);
 }
 
 void ASSERT_PED_IS(BaseModelInfo& info, const char* model, const char* txd,
@@ -53,12 +53,12 @@ void ASSERT_PED_IS(BaseModelInfo& info, const char* model, const char* txd,
                    size_t carmask) {
     BOOST_ASSERT(info.type() == PedModelInfo::kType);
     const auto& t = dynamic_cast<PedModelInfo&>(info);
-    BOOST_CHECK_EQUAL(t.name, model);
-    BOOST_CHECK_EQUAL(t.textureslot, txd);
-    BOOST_CHECK_EQUAL(t.pedtype_, type);
-    BOOST_CHECK_EQUAL(t.statindex_, statindex);
-    BOOST_CHECK_EQUAL(t.animgroup_, animgroup);
-    BOOST_CHECK_EQUAL(t.carsmask_, carmask);
+    BOOST_TEST(t.name == model);
+    BOOST_TEST(t.textureslot == txd);
+    BOOST_TEST(t.pedtype_ == type);
+    BOOST_TEST(t.statindex_ == statindex);
+    BOOST_TEST(t.animgroup_ == animgroup);
+    BOOST_TEST(t.carsmask_ == carmask);
 }
 }
 
@@ -72,7 +72,7 @@ BOOST_FIXTURE_TEST_SUITE(LoaderIDETests, WithLoaderIDE)
 
 BOOST_AUTO_TEST_CASE(objects_contains_modelID) {
     loader.load(test_data_stream, {});
-    BOOST_ASSERT(loader.objects.find(1100) != loader.objects.end());
+    BOOST_CHECK(loader.objects.find(1100) != loader.objects.end());
 }
 
 BOOST_AUTO_TEST_CASE(instance_data_is_correct) {

--- a/tests/test_ObjectData.cpp
+++ b/tests/test_ObjectData.cpp
@@ -3,10 +3,6 @@
 #include <loaders/LoaderIDE.hpp>
 #include "test_Globals.hpp"
 
-struct WithLoaderIDE {
-    LoaderIDE loader;
-};
-
 namespace {
 constexpr auto kTestDataObjects = R"(
 objs
@@ -49,11 +45,16 @@ void ASSERT_VEHICLE_IS(BaseModelInfo& info, const char* model, const char* txd,
 }
 }
 
+struct WithLoaderIDE {
+    LoaderIDE loader;
+
+    std::istringstream test_data_stream {kTestDataObjects};
+};
+
 BOOST_FIXTURE_TEST_SUITE(ObjectDataTests, WithLoaderIDE)
 
 BOOST_AUTO_TEST_CASE(parses_basic_instance) {
-    std::istringstream str {kTestDataObjects};
-    loader.load(str, {});
+    loader.load(test_data_stream, {});
 
     BOOST_ASSERT(loader.objects.find(1100) != loader.objects.end());
     auto info = loader.objects[1100].get();
@@ -62,8 +63,7 @@ BOOST_AUTO_TEST_CASE(parses_basic_instance) {
 }
 
 BOOST_AUTO_TEST_CASE(parses_vehicle) {
-    std::istringstream str {kTestDataObjects};
-    loader.load(str, {});
+    loader.load(test_data_stream, {});
 
     BOOST_ASSERT(loader.objects.find(90) != loader.objects.end());
     auto obj = loader.objects[90].get();

--- a/tests/test_ObjectData.cpp
+++ b/tests/test_ObjectData.cpp
@@ -12,6 +12,10 @@ end
 cars
 90, vehicle, texture, car, HANDLING, NAME, richfamily, 10, 7, 0, 164, 0.8
 end
+
+peds
+1, mod, txd, COP, STAT_COP, man, 7f
+end
 )";
 
 template<size_t N>
@@ -43,6 +47,19 @@ void ASSERT_VEHICLE_IS(BaseModelInfo& info, const char* model, const char* txd,
     BOOST_CHECK_EQUAL(t.wheelmodel_, wheel);
     BOOST_CHECK_EQUAL(t.wheelscale_, wheelScale);
 }
+
+void ASSERT_PED_IS(BaseModelInfo& info, const char* model, const char* txd,
+                   PedModelInfo::PedType type, int statindex, const char* animgroup,
+                   size_t carmask) {
+    BOOST_ASSERT(info.type() == PedModelInfo::kType);
+    const auto& t = dynamic_cast<PedModelInfo&>(info);
+    BOOST_CHECK_EQUAL(t.name, model);
+    BOOST_CHECK_EQUAL(t.textureslot, txd);
+    BOOST_CHECK_EQUAL(t.pedtype_, type);
+    BOOST_CHECK_EQUAL(t.statindex_, statindex);
+    BOOST_CHECK_EQUAL(t.animgroup_, animgroup);
+    BOOST_CHECK_EQUAL(t.carsmask_, carmask);
+}
 }
 
 struct WithLoaderIDE {
@@ -53,23 +70,25 @@ struct WithLoaderIDE {
 
 BOOST_FIXTURE_TEST_SUITE(ObjectDataTests, WithLoaderIDE)
 
-BOOST_AUTO_TEST_CASE(parses_basic_instance) {
+BOOST_AUTO_TEST_CASE(objects_contains_modelID) {
     loader.load(test_data_stream, {});
-
     BOOST_ASSERT(loader.objects.find(1100) != loader.objects.end());
-    auto info = loader.objects[1100].get();
-
-    ASSERT_INSTANCE_IS<1>(*info, "NAME", "TXD", {220}, 0);
 }
 
-BOOST_AUTO_TEST_CASE(parses_vehicle) {
+BOOST_AUTO_TEST_CASE(instance_data_is_correct) {
     loader.load(test_data_stream, {});
+    ASSERT_INSTANCE_IS<1>(*loader.objects[1100], "NAME", "TXD", {220}, 0);
+}
 
-    BOOST_ASSERT(loader.objects.find(90) != loader.objects.end());
-    auto obj = loader.objects[90].get();
-
-    ASSERT_VEHICLE_IS(*obj, "vehicle", "texture", VehicleModelInfo::CAR, "HANDLING", "NAME",
+BOOST_AUTO_TEST_CASE(vehicle_data_is_correct) {
+    loader.load(test_data_stream, {});
+    ASSERT_VEHICLE_IS(*loader.objects[90], "vehicle", "texture", VehicleModelInfo::CAR, "HANDLING", "NAME",
             VehicleModelInfo::RICHFAMILY, 10, 164, 0.8f);
+}
+
+BOOST_AUTO_TEST_CASE(pedestrian_data_is_correct) {
+    loader.load(test_data_stream, {});
+    ASSERT_PED_IS(*loader.objects[1], "mod", "txd", PedModelInfo::COP, -1, "man", 0x7f);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_ObjectData.cpp
+++ b/tests/test_ObjectData.cpp
@@ -7,11 +7,23 @@ struct WithLoaderIDE {
     LoaderIDE loader;
 };
 
+namespace {
+constexpr auto kTestDataObjects = R"(
+objs
+1100, NAME, TXD, 1, 220, 0"
+end
+
+cars
+90, vehicle, texture, car, HANDLING, NAME, richfamily, 10, 7, 0, 164, 0.8
+end
+)";
+}
+
 BOOST_FIXTURE_TEST_SUITE(ObjectDataTests, WithLoaderIDE)
 
-#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(parses_basic_instance) {
-    loader.load(Global::get().getGamePath() + "/data/maps/generic.ide", {});
+    std::istringstream str {kTestDataObjects};
+    loader.load(str, {});
 
     BOOST_ASSERT(loader.objects.find(1100) != loader.objects.end());
 
@@ -21,15 +33,16 @@ BOOST_AUTO_TEST_CASE(parses_basic_instance) {
 
     BOOST_ASSERT(def->type() == ModelDataType::SimpleInfo);
 
-    BOOST_CHECK_EQUAL(def->name, "rd_Corner1");
-    BOOST_CHECK_EQUAL(def->textureslot, "generic");
+    BOOST_CHECK_EQUAL(def->name, "NAME");
+    BOOST_CHECK_EQUAL(def->textureslot, "TXD");
     BOOST_CHECK_EQUAL(def->getNumAtomics(), 1);
     BOOST_CHECK_EQUAL(def->getLodDistance(0), 220);
     BOOST_CHECK_EQUAL(def->flags, 0);
 }
 
 BOOST_AUTO_TEST_CASE(parses_vehicle) {
-    loader.load(Global::get().getGamePath() + "/data/default.ide", {});
+    std::istringstream str {kTestDataObjects};
+    loader.load(str, {});
 
     BOOST_ASSERT(loader.objects.find(90) != loader.objects.end());
 
@@ -39,16 +52,15 @@ BOOST_AUTO_TEST_CASE(parses_vehicle) {
 
     BOOST_ASSERT(def->type() == ModelDataType::VehicleInfo);
 
-    BOOST_CHECK_EQUAL(def->name, "landstal");
-    BOOST_CHECK_EQUAL(def->textureslot, "landstal");
+    BOOST_CHECK_EQUAL(def->name, "vehicle");
+    BOOST_CHECK_EQUAL(def->textureslot, "texture");
     BOOST_CHECK_EQUAL(def->vehicletype_, VehicleModelInfo::CAR);
-    BOOST_CHECK_EQUAL(def->handling_, "LANDSTAL");
-    BOOST_CHECK_EQUAL(def->vehiclename_, "LANDSTK");
+    BOOST_CHECK_EQUAL(def->handling_, "HANDLING");
+    BOOST_CHECK_EQUAL(def->vehiclename_, "NAME");
     BOOST_CHECK_EQUAL(def->vehicleclass_, VehicleModelInfo::RICHFAMILY);
     BOOST_CHECK_EQUAL(def->frequency_, 10);
     BOOST_CHECK_EQUAL(def->wheelmodel_, 164);
     BOOST_CHECK_CLOSE(def->wheelscale_, 0.8f, 0.01f);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_ObjectData.cpp
+++ b/tests/test_ObjectData.cpp
@@ -3,17 +3,19 @@
 #include <loaders/LoaderIDE.hpp>
 #include "test_Globals.hpp"
 
-BOOST_AUTO_TEST_SUITE(ObjectDataTests)
+struct WithLoaderIDE {
+    LoaderIDE loader;
+};
+
+BOOST_FIXTURE_TEST_SUITE(ObjectDataTests, WithLoaderIDE)
 
 #if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(parses_basic_instance) {
-    LoaderIDE l;
+    loader.load(Global::get().getGamePath() + "/data/maps/generic.ide", {});
 
-    l.load(Global::get().getGamePath() + "/data/maps/generic.ide", {});
+    BOOST_ASSERT(loader.objects.find(1100) != loader.objects.end());
 
-    BOOST_ASSERT(l.objects.find(1100) != l.objects.end());
-
-    auto obj = l.objects[1100].get();
+    auto obj = loader.objects[1100].get();
 
     auto def = dynamic_cast<SimpleModelInfo *>(obj);
 
@@ -27,13 +29,11 @@ BOOST_AUTO_TEST_CASE(parses_basic_instance) {
 }
 
 BOOST_AUTO_TEST_CASE(parses_vehicle) {
-    LoaderIDE l;
+    loader.load(Global::get().getGamePath() + "/data/default.ide", {});
 
-    l.load(Global::get().getGamePath() + "/data/default.ide", {});
+    BOOST_ASSERT(loader.objects.find(90) != loader.objects.end());
 
-    BOOST_ASSERT(l.objects.find(90) != l.objects.end());
-
-    auto obj = l.objects[90].get();
+    auto obj = loader.objects[90].get();
 
     auto def = dynamic_cast<VehicleModelInfo*>(obj);
 

--- a/tests/test_ObjectData.cpp
+++ b/tests/test_ObjectData.cpp
@@ -6,52 +6,48 @@
 BOOST_AUTO_TEST_SUITE(ObjectDataTests)
 
 #if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_object_data) {
-    {
-        LoaderIDE l;
+BOOST_AUTO_TEST_CASE(parses_basic_instance) {
+    LoaderIDE l;
 
-        l.load(Global::get().getGamePath() + "/data/maps/generic.ide", {});
+    l.load(Global::get().getGamePath() + "/data/maps/generic.ide", {});
 
-        BOOST_ASSERT(l.objects.find(1100) != l.objects.end());
+    BOOST_ASSERT(l.objects.find(1100) != l.objects.end());
 
-        auto obj = l.objects[1100].get();
+    auto obj = l.objects[1100].get();
 
-        auto def = dynamic_cast<SimpleModelInfo*>(obj);
+    auto def = dynamic_cast<SimpleModelInfo *>(obj);
 
-        BOOST_ASSERT(def->type() == ModelDataType::SimpleInfo);
+    BOOST_ASSERT(def->type() == ModelDataType::SimpleInfo);
 
-        BOOST_CHECK_EQUAL(def->name, "rd_Corner1");
-        BOOST_CHECK_EQUAL(def->textureslot, "generic");
-        BOOST_CHECK_EQUAL(def->getNumAtomics(), 1);
-        BOOST_CHECK_EQUAL(def->getLodDistance(0), 220);
-        BOOST_CHECK_EQUAL(def->flags, 0);
-    }
-    {
-        LoaderIDE l;
-
-        l.load(Global::get().getGamePath() + "/data/default.ide", {});
-
-        BOOST_ASSERT(l.objects.find(90) != l.objects.end());
-
-        auto obj = l.objects[90].get();
-
-        auto def = dynamic_cast<VehicleModelInfo*>(obj);
-
-        BOOST_ASSERT(def->type() == ModelDataType::VehicleInfo);
-
-        BOOST_CHECK_EQUAL(def->name, "landstal");
-        BOOST_CHECK_EQUAL(def->textureslot, "landstal");
-        BOOST_CHECK_EQUAL(def->vehicletype_, VehicleModelInfo::CAR);
-        BOOST_CHECK_EQUAL(def->handling_, "LANDSTAL");
-        BOOST_CHECK_EQUAL(def->vehiclename_, "LANDSTK");
-        BOOST_CHECK_EQUAL(def->vehicleclass_, VehicleModelInfo::RICHFAMILY);
-        BOOST_CHECK_EQUAL(def->frequency_, 10);
-        BOOST_CHECK_EQUAL(def->wheelmodel_, 164);
-        BOOST_CHECK_CLOSE(def->wheelscale_, 0.8f, 0.01f);
-    }
+    BOOST_CHECK_EQUAL(def->name, "rd_Corner1");
+    BOOST_CHECK_EQUAL(def->textureslot, "generic");
+    BOOST_CHECK_EQUAL(def->getNumAtomics(), 1);
+    BOOST_CHECK_EQUAL(def->getLodDistance(0), 220);
+    BOOST_CHECK_EQUAL(def->flags, 0);
 }
 
-BOOST_AUTO_TEST_CASE(test_gamedata_data) {
+BOOST_AUTO_TEST_CASE(parses_vehicle) {
+    LoaderIDE l;
+
+    l.load(Global::get().getGamePath() + "/data/default.ide", {});
+
+    BOOST_ASSERT(l.objects.find(90) != l.objects.end());
+
+    auto obj = l.objects[90].get();
+
+    auto def = dynamic_cast<VehicleModelInfo*>(obj);
+
+    BOOST_ASSERT(def->type() == ModelDataType::VehicleInfo);
+
+    BOOST_CHECK_EQUAL(def->name, "landstal");
+    BOOST_CHECK_EQUAL(def->textureslot, "landstal");
+    BOOST_CHECK_EQUAL(def->vehicletype_, VehicleModelInfo::CAR);
+    BOOST_CHECK_EQUAL(def->handling_, "LANDSTAL");
+    BOOST_CHECK_EQUAL(def->vehiclename_, "LANDSTK");
+    BOOST_CHECK_EQUAL(def->vehicleclass_, VehicleModelInfo::RICHFAMILY);
+    BOOST_CHECK_EQUAL(def->frequency_, 10);
+    BOOST_CHECK_EQUAL(def->wheelmodel_, 164);
+    BOOST_CHECK_CLOSE(def->wheelscale_, 0.8f, 0.01f);
 }
 #endif
 

--- a/tests/test_ObjectData.cpp
+++ b/tests/test_ObjectData.cpp
@@ -17,6 +17,36 @@ cars
 90, vehicle, texture, car, HANDLING, NAME, richfamily, 10, 7, 0, 164, 0.8
 end
 )";
+
+template<size_t N>
+void ASSERT_INSTANCE_IS(BaseModelInfo& info, const char* model, const char* txd,
+        const std::array<float, N>& lods, size_t flags) {
+    BOOST_ASSERT(info.type() == SimpleModelInfo::kType);
+    const auto& t = dynamic_cast<SimpleModelInfo&>(info);
+    BOOST_CHECK_EQUAL(t.name, model);
+    BOOST_CHECK_EQUAL(t.textureslot, txd);
+    BOOST_CHECK_EQUAL(t.getNumAtomics(), lods.size());
+    for (auto i = 0u; i < lods.size(); ++i) {
+        BOOST_CHECK_EQUAL(t.getLodDistance(i), lods[i]);
+    }
+    BOOST_CHECK_EQUAL(t.flags, flags);
+}
+
+void ASSERT_VEHICLE_IS(BaseModelInfo& info, const char* model, const char* txd,
+        VehicleModelInfo::VehicleType type, const char* handling, const char* name,
+        VehicleModelInfo::VehicleClass clas_, int frequency, ModelID wheel, float wheelScale) {
+    BOOST_ASSERT(info.type() == VehicleModelInfo::kType);
+    const auto& t = dynamic_cast<VehicleModelInfo&>(info);
+    BOOST_CHECK_EQUAL(t.name, model);
+    BOOST_CHECK_EQUAL(t.textureslot, txd);
+    BOOST_CHECK_EQUAL(t.vehicletype_, type);
+    BOOST_CHECK_EQUAL(t.handling_, handling);
+    BOOST_CHECK_EQUAL(t.vehiclename_, name);
+    BOOST_CHECK_EQUAL(t.vehicleclass_, clas_);
+    BOOST_CHECK_EQUAL(t.frequency_, frequency);
+    BOOST_CHECK_EQUAL(t.wheelmodel_, wheel);
+    BOOST_CHECK_EQUAL(t.wheelscale_, wheelScale);
+}
 }
 
 BOOST_FIXTURE_TEST_SUITE(ObjectDataTests, WithLoaderIDE)
@@ -26,18 +56,9 @@ BOOST_AUTO_TEST_CASE(parses_basic_instance) {
     loader.load(str, {});
 
     BOOST_ASSERT(loader.objects.find(1100) != loader.objects.end());
+    auto info = loader.objects[1100].get();
 
-    auto obj = loader.objects[1100].get();
-
-    auto def = dynamic_cast<SimpleModelInfo *>(obj);
-
-    BOOST_ASSERT(def->type() == ModelDataType::SimpleInfo);
-
-    BOOST_CHECK_EQUAL(def->name, "NAME");
-    BOOST_CHECK_EQUAL(def->textureslot, "TXD");
-    BOOST_CHECK_EQUAL(def->getNumAtomics(), 1);
-    BOOST_CHECK_EQUAL(def->getLodDistance(0), 220);
-    BOOST_CHECK_EQUAL(def->flags, 0);
+    ASSERT_INSTANCE_IS<1>(*info, "NAME", "TXD", {220}, 0);
 }
 
 BOOST_AUTO_TEST_CASE(parses_vehicle) {
@@ -45,22 +66,10 @@ BOOST_AUTO_TEST_CASE(parses_vehicle) {
     loader.load(str, {});
 
     BOOST_ASSERT(loader.objects.find(90) != loader.objects.end());
-
     auto obj = loader.objects[90].get();
 
-    auto def = dynamic_cast<VehicleModelInfo*>(obj);
-
-    BOOST_ASSERT(def->type() == ModelDataType::VehicleInfo);
-
-    BOOST_CHECK_EQUAL(def->name, "vehicle");
-    BOOST_CHECK_EQUAL(def->textureslot, "texture");
-    BOOST_CHECK_EQUAL(def->vehicletype_, VehicleModelInfo::CAR);
-    BOOST_CHECK_EQUAL(def->handling_, "HANDLING");
-    BOOST_CHECK_EQUAL(def->vehiclename_, "NAME");
-    BOOST_CHECK_EQUAL(def->vehicleclass_, VehicleModelInfo::RICHFAMILY);
-    BOOST_CHECK_EQUAL(def->frequency_, 10);
-    BOOST_CHECK_EQUAL(def->wheelmodel_, 164);
-    BOOST_CHECK_CLOSE(def->wheelscale_, 0.8f, 0.01f);
+    ASSERT_VEHICLE_IS(*obj, "vehicle", "texture", VehicleModelInfo::CAR, "HANDLING", "NAME",
+            VehicleModelInfo::RICHFAMILY, 10, 164, 0.8f);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Part of a series to deal with #126 

This PR does the following:

- Renames ObjectDataTests to LoaderIDETests
- Makes the tests against LoaderIDE more descriptive
- Removes the dependency on game data for LoaderIDE tests
- Fixes a bug where carmask was loaded as base 10 instead of base 16

Data Free Tests: +4

Remaining issues:

- [x] use BOOST_TEST for assertions
- [x] Restore lexical cast usage
