### PR TITLE
Remove data dependency from LoaderIPL tests

### DIFF
--- a/rwengine/src/loaders/LoaderIPL.cpp
+++ b/rwengine/src/loaders/LoaderIPL.cpp
@@ -13,17 +13,20 @@
 
 #include "data/InstanceData.hpp"
 #include "data/ZoneData.hpp"
+#include "LoaderIPL.hpp"
+
 
 #include <rw/casts.hpp>
 
 enum SectionTypes { INST, PICK, CULL, ZONE, NONE };
 
-/// Load the IPL data into memory
 bool LoaderIPL::load(const std::string& filename) {
     std::ifstream str(filename);
-
     if (!str.is_open()) return false;
+    return load(str);
+}
 
+bool LoaderIPL::load(std::istream &str) {
     SectionTypes section = NONE;
     while (!str.eof()) {
         std::string line;
@@ -134,3 +137,4 @@ bool LoaderIPL::load(const std::string& filename) {
 
     return true;
 }
+

--- a/rwengine/src/loaders/LoaderIPL.hpp
+++ b/rwengine/src/loaders/LoaderIPL.hpp
@@ -15,8 +15,11 @@ struct InstanceData;
 */
 class LoaderIPL {
 public:
-    /// Load the IPL data into memory
+    /// Load the IPL data from filename
     bool load(const std::string& filename);
+
+    /// Parse IPL data from the stream
+    bool load(std::istream& stream);
 
     /// The list of instances from the IPL file
     std::vector<std::shared_ptr<InstanceData>> m_instances;

--- a/tests/test_LoaderIPL.cpp
+++ b/tests/test_LoaderIPL.cpp
@@ -9,16 +9,23 @@ struct WithLoaderIPL {
 BOOST_FIXTURE_TEST_SUITE(LoaderIPLTests, WithLoaderIPL)
 
 #if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_load_zones) {
+BOOST_AUTO_TEST_CASE(zone_count_is_correct) {
     const auto& gdpath = Global::get().getGamePath();
     BOOST_REQUIRE(loader.load(gdpath + "/data/gta3.zon"));
 
-    BOOST_REQUIRE(loader.zones.size() > 2);
-
-    auto& zone1 = loader.zones[0];
-    BOOST_CHECK_EQUAL(zone1.name, "ROADBR1");
+    BOOST_TEST(loader.zones.size() == 42);
 }
 
+BOOST_AUTO_TEST_CASE(zone_data_is_correct) {
+    const auto& gdpath = Global::get().getGamePath();
+    BOOST_REQUIRE(loader.load(gdpath + "/data/gta3.zon"));
+
+    auto& zone1 = loader.zones[1];
+    BOOST_TEST(zone1.name == "PORT_W");
+    BOOST_TEST(zone1.type == 0);
+    BOOST_TEST(zone1.min.x == 751.68f);
+    BOOST_TEST(zone1.island == 1);
+}
 #endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_LoaderIPL.cpp
+++ b/tests/test_LoaderIPL.cpp
@@ -4,21 +4,21 @@
 
 struct WithLoaderIPL {
     LoaderIPL loader;
+
+    std::ifstream test_data_stream {Global::get().getGamePath() + "/data/gta3.zon"};
 };
 
 BOOST_FIXTURE_TEST_SUITE(LoaderIPLTests, WithLoaderIPL)
 
 #if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(zone_count_is_correct) {
-    const auto& gdpath = Global::get().getGamePath();
-    BOOST_REQUIRE(loader.load(gdpath + "/data/gta3.zon"));
+    BOOST_REQUIRE(loader.load(test_data_stream));
 
     BOOST_TEST(loader.zones.size() == 42);
 }
 
 BOOST_AUTO_TEST_CASE(zone_data_is_correct) {
-    const auto& gdpath = Global::get().getGamePath();
-    BOOST_REQUIRE(loader.load(gdpath + "/data/gta3.zon"));
+    BOOST_REQUIRE(loader.load(test_data_stream));
 
     auto& zone1 = loader.zones[1];
     BOOST_TEST(zone1.name == "PORT_W");

--- a/tests/test_LoaderIPL.cpp
+++ b/tests/test_LoaderIPL.cpp
@@ -11,11 +11,41 @@ ZONE_B, 0,  200.0, 10.0, -100.0, 100.0, 1000.0, 100.0, 2
 end
 
 inst
-101, ModelA, 10.0, 12.0, 5.0, 1, 1, 1, 0, 0, -0.70, 0.70
-112, ModelB, 10.0, 12.0, 5.0, 1, 1, 1, 0, 0, -0.70, 0.70
+101, ModelA, 10.0, 12.0, 5.0, 1, 1, 1, 0, 0, 1, 0
+112, ModelB, 10.0, 12.0, 5.0, 1, 1, 1, 0, 0, 1, 0
 112, ModelB, 11.0, 12.0, 5.0, 1, 1, 1, 0, 0, 0, 1
 end
 )";
+}
+
+bool operator==(const ZoneData& lhs, const ZoneData& rhs) {
+    return
+            lhs.name == rhs.name &&
+            lhs.type == rhs.type &&
+            lhs.min == rhs.min &&
+            lhs.max == rhs.max &&
+            lhs.island == rhs.island;
+}
+
+std::ostream& operator<<(std::ostream& str, const ZoneData& z) {
+    str << "ZoneData { " << z.name << ", "
+        << z.type << ", " << z.min << ", " << z.max << ", " << z.island << " }";
+    return str;
+}
+
+bool operator==(const InstanceData& lhs, const InstanceData& rhs) {
+    return
+            lhs.id == rhs.id &&
+            lhs.model == rhs.model &&
+            lhs.pos == rhs.pos &&
+            lhs.scale == rhs.scale &&
+            lhs.rot == rhs.rot;
+}
+
+std::ostream& operator<<(std::ostream& str, const InstanceData& i) {
+    str << "InstanceData { " << i.id << ", "
+        << i.model << ", " << i.pos << ", " << i.scale << ", " << glm::to_string(i.rot) << " }";
+    return str;
 }
 
 struct WithLoaderIPL {
@@ -34,11 +64,8 @@ BOOST_AUTO_TEST_CASE(zone_count_is_correct) {
 BOOST_AUTO_TEST_CASE(zone_data_is_correct) {
     BOOST_REQUIRE(loader.load(test_data_stream));
 
-    auto& zone1 = loader.zones[1];
-    BOOST_TEST(zone1.name == "ZONE_B");
-    BOOST_TEST(zone1.type == 0);
-    BOOST_TEST(zone1.min.x == 200.0f);
-    BOOST_TEST(zone1.island == 2);
+    const auto expectedZone = ZoneData("ZONE_B", 0, {200.0f, 10.0f, -100.0}, {100.0f, 1000.0f, 100.0f}, 2, 0, 0);
+    BOOST_TEST(loader.zones[1] == expectedZone);
 }
 
 BOOST_AUTO_TEST_CASE(instance_count_is_correct) {
@@ -49,13 +76,8 @@ BOOST_AUTO_TEST_CASE(instance_count_is_correct) {
 BOOST_AUTO_TEST_CASE(instance_data_is_correct) {
     BOOST_REQUIRE(loader.load(test_data_stream));
 
-    auto& instance = loader.m_instances[1];
-    BOOST_TEST(instance->id == 112);
-    BOOST_TEST(instance->model == "ModelB");
-    BOOST_TEST(instance->pos.x == 10.0f);
-    BOOST_TEST(instance->pos.y == 12.0f);
-    BOOST_TEST(instance->pos.z == 5.0f);
-    BOOST_TEST(instance->rot.x == 0.0f);
+    const auto expectedInstance = InstanceData(112, "ModelB", {10.0f, 12.0f, 5.0f}, {1.f, 1.f, 1.f}, {0.0f, 0.f, 0.f, 1.0f});
+    BOOST_TEST(*loader.m_instances[1] == expectedInstance);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_LoaderIPL.cpp
+++ b/tests/test_LoaderIPL.cpp
@@ -2,30 +2,37 @@
 #include <loaders/LoaderIPL.hpp>
 #include "test_Globals.hpp"
 
+namespace {
+constexpr auto kIPLTestData = R"(
+zone
+ZONE_A, 1, -100.0, -200.00, -100.0, 100.0, 1000.0, 100.0, 1
+ZONE_B, 0,  200.0, 10.0, -100.0, 100.0, 1000.0, 100.0, 2
+end
+)";
+}
+
 struct WithLoaderIPL {
     LoaderIPL loader;
 
-    std::ifstream test_data_stream {Global::get().getGamePath() + "/data/gta3.zon"};
+    std::istringstream test_data_stream {kIPLTestData};
 };
 
 BOOST_FIXTURE_TEST_SUITE(LoaderIPLTests, WithLoaderIPL)
 
-#if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(zone_count_is_correct) {
     BOOST_REQUIRE(loader.load(test_data_stream));
 
-    BOOST_TEST(loader.zones.size() == 42);
+    BOOST_TEST(loader.zones.size() == 2);
 }
 
 BOOST_AUTO_TEST_CASE(zone_data_is_correct) {
     BOOST_REQUIRE(loader.load(test_data_stream));
 
     auto& zone1 = loader.zones[1];
-    BOOST_TEST(zone1.name == "PORT_W");
+    BOOST_TEST(zone1.name == "ZONE_B");
     BOOST_TEST(zone1.type == 0);
-    BOOST_TEST(zone1.min.x == 751.68f);
-    BOOST_TEST(zone1.island == 1);
+    BOOST_TEST(zone1.min.x == 200.0f);
+    BOOST_TEST(zone1.island == 2);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_LoaderIPL.cpp
+++ b/tests/test_LoaderIPL.cpp
@@ -2,11 +2,14 @@
 #include <loaders/LoaderIPL.hpp>
 #include "test_Globals.hpp"
 
-BOOST_AUTO_TEST_SUITE(LoaderIPLTests)
+struct WithLoaderIPL {
+    LoaderIPL loader;
+};
+
+BOOST_FIXTURE_TEST_SUITE(LoaderIPLTests, WithLoaderIPL)
 
 #if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_load_zones) {
-    LoaderIPL loader;
     const auto& gdpath = Global::get().getGamePath();
     BOOST_REQUIRE(loader.load(gdpath + "/data/gta3.zon"));
 

--- a/tests/test_LoaderIPL.cpp
+++ b/tests/test_LoaderIPL.cpp
@@ -1,5 +1,6 @@
 #include <boost/test/unit_test.hpp>
 #include <loaders/LoaderIPL.hpp>
+#include <data/InstanceData.hpp>
 #include "test_Globals.hpp"
 
 namespace {
@@ -7,6 +8,12 @@ constexpr auto kIPLTestData = R"(
 zone
 ZONE_A, 1, -100.0, -200.00, -100.0, 100.0, 1000.0, 100.0, 1
 ZONE_B, 0,  200.0, 10.0, -100.0, 100.0, 1000.0, 100.0, 2
+end
+
+inst
+101, ModelA, 10.0, 12.0, 5.0, 1, 1, 1, 0, 0, -0.70, 0.70
+112, ModelB, 10.0, 12.0, 5.0, 1, 1, 1, 0, 0, -0.70, 0.70
+112, ModelB, 11.0, 12.0, 5.0, 1, 1, 1, 0, 0, 0, 1
 end
 )";
 }
@@ -21,7 +28,6 @@ BOOST_FIXTURE_TEST_SUITE(LoaderIPLTests, WithLoaderIPL)
 
 BOOST_AUTO_TEST_CASE(zone_count_is_correct) {
     BOOST_REQUIRE(loader.load(test_data_stream));
-
     BOOST_TEST(loader.zones.size() == 2);
 }
 
@@ -33,6 +39,23 @@ BOOST_AUTO_TEST_CASE(zone_data_is_correct) {
     BOOST_TEST(zone1.type == 0);
     BOOST_TEST(zone1.min.x == 200.0f);
     BOOST_TEST(zone1.island == 2);
+}
+
+BOOST_AUTO_TEST_CASE(instance_count_is_correct) {
+    BOOST_REQUIRE(loader.load(test_data_stream));
+    BOOST_TEST(loader.m_instances.size() == 3);
+}
+
+BOOST_AUTO_TEST_CASE(instance_data_is_correct) {
+    BOOST_REQUIRE(loader.load(test_data_stream));
+
+    auto& instance = loader.m_instances[1];
+    BOOST_TEST(instance->id == 112);
+    BOOST_TEST(instance->model == "ModelB");
+    BOOST_TEST(instance->pos.x == 10.0f);
+    BOOST_TEST(instance->pos.y == 12.0f);
+    BOOST_TEST(instance->pos.z == 5.0f);
+    BOOST_TEST(instance->rot.x == 0.0f);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This one is straightforward.

- Remove dependency on game data for LoaderIPL test suite.
- Add additional tests for instance data loading.

Changes to do:

- [x] Provide operator == and << for tested types