### PR TITLE
[Discussion] Remove setPosition() offset in CharacterObject

### DIFF
--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -427,7 +427,7 @@ void CharacterObject::setPosition(const glm::vec3& pos) {
         if (pos.z <= -99.f) {
             realPos = engine->getGroundAtPosition(pos);
         }
-        btVector3 bpos(realPos.x, realPos.y, realPos.z + 1.0f);
+        btVector3 bpos(realPos.x, realPos.y, realPos.z);
         physCharacter->warp(bpos);
     }
     position = realPos;


### PR DESCRIPTION
Currently `setPosition()` in `CharacterObject` warps the character one unit higher than the actual hight.

I think this behavior was intended for testing, but isn't necessary anymore.

Removing the offset helps in a variety of situations, mostly where `GoTo()` was used:

- Pedestrians don't "jump" anymore when reaching an `AIGraphNode`
- During missions with various characters
- AI followers
- ...

I tested the change in debug mode and various missions and I found no issues.

Maybe some testers can confirm that everything works as intended.
