### PR TITLE
Fix opcode 03e5

### DIFF
--- a/rwengine/src/script/modules/GTA3ModuleImpl.inl
+++ b/rwengine/src/script/modules/GTA3ModuleImpl.inl
@@ -11481,6 +11481,7 @@ void opcode_03e4(const ScriptArguments& args, const ScriptBoolean arg1) {
     @arg gxtEntry GXT entry
 */
 void opcode_03e5(const ScriptArguments& args, const ScriptString gxtEntry) {
+    args.getState()->text.clear<ScreenTextType::Big>();
     args.getState()->text.addText<ScreenTextType::Big>(
         ScreenTextEntry::makeHelp(gxtEntry, script::gxt(args, gxtEntry)));
 }


### PR DESCRIPTION
https://github.com/Lighnat0r/GTA-III-SCM-Converted/blob/master/02_wanted.sc
As you can see there's no another cleaning functionality, so 03e5 should clean after itself.
Before:
![before](https://user-images.githubusercontent.com/7227492/44140678-11444014-a07b-11e8-94d1-e17a55734e91.png)
After:
![after](https://user-images.githubusercontent.com/7227492/44140685-17563944-a07b-11e8-8bb9-76dcb70dbb0c.png)



How to test? Just start mission "wanted".

fixes #584