### PR TITLE
Cleanup Game Renderer

### DIFF
--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -500,32 +500,14 @@ void GameRenderer::renderEffects(GameWorld* world) {
 }
 
 void GameRenderer::drawTexture(TextureData* texture, glm::vec4 extents) {
-    // Move into NDC
-    extents.x /= renderer->getViewport().x;
-    extents.y /= renderer->getViewport().y;
-    extents.z /= renderer->getViewport().x;
-    extents.w /= renderer->getViewport().y;
-    extents.x += extents.z / 2.f;
-    extents.y += extents.w / 2.f;
-    extents.x -= .5f;
-    extents.y -= .5f;
-    extents *= glm::vec4(2.f, -2.f, 1.f, 1.f);
-
-    renderer->useProgram(ssRectProg.get());
-    renderer->setUniform(ssRectProg.get(), "colour", glm::vec4{0.f, 0.f, 0.f, 1.f});
-    renderer->setUniform(ssRectProg.get(), "size", glm::vec2{extents.z, extents.w});
-    renderer->setUniform(ssRectProg.get(), "offset", glm::vec2{extents.x, extents.y});
-
-    Renderer::DrawParameters wdp;
-    wdp.depthMode = DepthMode::OFF;
-    wdp.blendMode = BlendMode::BLEND_ALPHA;
-    wdp.count = ssRectGeom.getCount();
-    wdp.textures = {texture->getName()};
-
-    renderer->drawArrays(glm::mat4(1.0f), &ssRectDraw, wdp);
+    drawRect({0.f, 0.f, 0.f, 1.f}, texture, extents);
 }
 
 void GameRenderer::drawColour(const glm::vec4& colour, glm::vec4 extents) {
+    drawRect(colour, nullptr, extents);
+}
+
+void GameRenderer::drawRect(const glm::vec4& colour, TextureData* texture, glm::vec4& extents) {
     // Move into NDC
     extents.x /= renderer->getViewport().x;
     extents.y /= renderer->getViewport().y;
@@ -546,7 +528,7 @@ void GameRenderer::drawColour(const glm::vec4& colour, glm::vec4 extents) {
     wdp.depthMode = DepthMode::OFF;
     wdp.blendMode = BlendMode::BLEND_ALPHA;
     wdp.count = ssRectGeom.getCount();
-    wdp.textures = {0};
+    wdp.textures = {texture ? texture->getName() : 0};
 
     renderer->drawArrays(glm::mat4(1.0f), &ssRectDraw, wdp);
 }

--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -437,6 +437,7 @@ void GameRenderer::renderPostProcess() {
     wdp.start = 0;
     wdp.count = ssRectGeom.getCount();
     wdp.textures = {fbTextures[0]};
+    wdp.depthMode = DepthMode::OFF;
 
     renderer->drawArrays(glm::mat4(1.0f), &ssRectDraw, wdp);
 }

--- a/rwengine/src/render/GameRenderer.hpp
+++ b/rwengine/src/render/GameRenderer.hpp
@@ -119,6 +119,9 @@ public:
     void drawTexture(TextureData* texture, glm::vec4 extents);
     void drawColour(const glm::vec4& colour, glm::vec4 extents);
 
+    /** Render full screen splash / fade */
+    void renderSplash(GameWorld* world, GLuint tex, glm::u16vec3 fc);
+
     /** Increases cinematic value */
     void renderLetterbox();
 

--- a/rwengine/src/render/GameRenderer.hpp
+++ b/rwengine/src/render/GameRenderer.hpp
@@ -170,6 +170,8 @@ private:
     ClumpPtr getSpecialModel(SpecialModel usage) const {
         return specialmodels_[usage];
     }
+
+    void drawRect(const glm::vec4& colour, TextureData* texture, glm::vec4& extents);
 };
 
 #endif

--- a/rwengine/src/render/GameRenderer.hpp
+++ b/rwengine/src/render/GameRenderer.hpp
@@ -44,7 +44,7 @@ class GameRenderer {
     GameWorld* _renderWorld = nullptr;
 
     /** Internal non-descript VAOs */
-    GLuint vao, debugVAO;
+    GLuint vao;
 
     /** Camera values passed to renderWorld() */
     ViewCamera _camera;
@@ -65,10 +65,6 @@ class GameRenderer {
     GeometryBuffer particleGeom;
     DrawBuffer particleDraw;
 
-    std::vector<VertexP2> sspaceRect = {
-            {-1.f, -1.f}, {1.f, -1.f}, {-1.f, 1.f}, {1.f, 1.f},
-    };
-
     GeometryBuffer ssRectGeom;
     DrawBuffer ssRectDraw;
 
@@ -84,8 +80,7 @@ public:
     GLuint ssRectProgram;
     GLint ssRectTexture, ssRectColour, ssRectSize, ssRectOffset;
 
-    GLuint skydomeVBO, skydomeIBO, debugVBO;
-    GLuint debugTex;
+    GLuint skydomeIBO;
 
     DrawBuffer skyDbuff;
     GeometryBuffer skyGbuff;
@@ -119,18 +114,10 @@ public:
     void renderEffects(GameWorld* world);
 
     /**
-     * @brief Draws the current on screen text.
-     */
-    void drawOnScreenText();
-
-    /**
      * @brief Draws a texture on the screen
      */
     void drawTexture(TextureData* texture, glm::vec4 extents);
     void drawColour(const glm::vec4& colour, glm::vec4 extents);
-
-    /** method for rendering AI debug information */
-    void renderPaths();
 
     /** Increases cinematic value */
     void renderLetterbox();

--- a/rwengine/src/render/GameRenderer.hpp
+++ b/rwengine/src/render/GameRenderer.hpp
@@ -77,8 +77,7 @@ public:
     std::unique_ptr<Renderer::ShaderProgram> skyProg;
     std::unique_ptr<Renderer::ShaderProgram> particleProg;
 
-    GLuint ssRectProgram;
-    GLint ssRectTexture, ssRectColour, ssRectSize, ssRectOffset;
+    std::unique_ptr<Renderer::ShaderProgram> ssRectProg;
 
     GLuint skydomeIBO;
 

--- a/rwengine/src/render/OpenGLRenderer.cpp
+++ b/rwengine/src/render/OpenGLRenderer.cpp
@@ -282,6 +282,7 @@ void OpenGLRenderer::setDrawState(const glm::mat4& model, DrawBuffer* draw,
 
     setBlend(p.blendMode);
     setDepthWrite(p.depthWrite);
+    setDepthMode(p.depthMode);
 
     ObjectUniformData objectData{model,
                              glm::vec4(p.colour.r / 255.f, p.colour.g / 255.f,
@@ -369,6 +370,7 @@ void OpenGLRenderer::invalidate() {
     currentTextures.clear();
     currentUBO = 0;
     setBlend(BlendMode::BLEND_NONE);
+    setDepthMode(DepthMode::OFF);
 }
 
 bool OpenGLRenderer::createUBO(Buffer &out, GLsizei size, GLsizei entrySize)

--- a/rwengine/src/render/OpenGLRenderer.hpp
+++ b/rwengine/src/render/OpenGLRenderer.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <array>
 
 #include <glm/glm.hpp>
 
@@ -69,7 +70,7 @@ enum class DepthMode {
 
 class Renderer {
 public:
-    typedef std::vector<GLuint> Textures;
+    typedef std::array<GLuint,2> Textures;
 
     /**
      * @brief The DrawParameters struct stores drawing state

--- a/rwengine/src/render/OpenGLRenderer.hpp
+++ b/rwengine/src/render/OpenGLRenderer.hpp
@@ -62,6 +62,11 @@ enum class BlendMode {
     BLEND_ADDITIVE
 };
 
+enum class DepthMode {
+    OFF,
+    LESS,
+};
+
 class Renderer {
 public:
     typedef std::vector<GLuint> Textures;
@@ -84,7 +89,9 @@ public:
         Textures textures{};
         /// Blending mode
         BlendMode blendMode = BlendMode::BLEND_NONE;
-        // Depth writing state
+        /// Depth
+        DepthMode depthMode = DepthMode::LESS;
+        /// Depth writing state
         bool depthWrite = true;
         /// Material
         glm::u8vec4 colour{};
@@ -342,6 +349,7 @@ private:
     DrawBuffer* currentDbuff = nullptr;
     OpenGLShaderProgram* currentProgram = nullptr;
     BlendMode blendMode = BlendMode::BLEND_NONE;
+    DepthMode depthMode = DepthMode::OFF;
     bool depthWriteEnabled = false;
     GLuint currentUBO = 0;
     GLuint currentUnit = 0;
@@ -371,6 +379,17 @@ private:
         }
 
         blendMode = mode;
+    }
+
+    void setDepthMode(DepthMode mode) {
+        if (mode != depthMode) {
+            if (depthMode == DepthMode::OFF) glEnable(GL_DEPTH_TEST);
+            switch(mode) {
+                case DepthMode::OFF: glDisable(GL_DEPTH_TEST); break;
+                case DepthMode::LESS: glDepthFunc(GL_LESS); break;
+            }
+            depthMode = mode;
+        }
     }
 
     void setDepthWrite(bool enable) {

--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -353,7 +353,7 @@ void TextRenderer::renderText(const TextRenderer::TextInfo& ti,
     dp.count = gb.getCount();
     auto ftexture = renderer->getData()->findSlotTexture("fonts", fontMetaData.textureName);
     dp.textures = {ftexture->getName()};
-    dp.depthWrite = false;
+    dp.depthMode = DepthMode::OFF;
 
     renderer->getRenderer()->drawArrays(glm::mat4(1.0f), &db, dp);
 


### PR DESCRIPTION
This is just an initial pass to take care of the OpenGL usage that was interfering with removing OpenGL from elsewhere, and make the code easier to look at.

- Remove unused code
- Remove bare glDraw calls
- Remove unused opengl objects
- Refactored some code into more readable methods

Follow up work:
- Remove raw OpenGL from MapRenderer
