### PR TITLE
tests: GameWorld needs a loaded GameData

### DIFF
--- a/tests/test_GameData.cpp
+++ b/tests/test_GameData.cpp
@@ -7,10 +7,9 @@ BOOST_AUTO_TEST_SUITE(GameDataTests)
 #if RW_TEST_WITH_DATA
 BOOST_AUTO_TEST_CASE(test_object_data) {
     GameData gd(&Global::get().log, Global::getGamePath());
-    GameWorld gw(&Global::get().log, &gd);
-
     gd.load();
 
+    GameWorld gw(&Global::get().log, &gd);
     {
         auto def = gd.findModelInfo<SimpleModelInfo>(1100);
 


### PR DESCRIPTION
By fetching the paths of the sfx file in the `SoundManager` constructor, `GameWorld` needs a loaded GameData object.

This fixes the first `GameDataTests`

GameWorld -> SoundManager -> FileIndex