### PR TITLE
rwengine: delete OpenAL buffers and sources before OpenAL shutdown

### DIFF
--- a/rwengine/src/audio/SoundBuffer.cpp
+++ b/rwengine/src/audio/SoundBuffer.cpp
@@ -15,6 +15,11 @@ SoundBuffer::SoundBuffer() {
     alCheck(alSourcei(source, AL_LOOPING, AL_FALSE));
 }
 
+SoundBuffer::~SoundBuffer() {
+    alCheck(alDeleteSources(1, &source));
+    alCheck(alDeleteBuffers(1, &buffer));
+}
+
 bool SoundBuffer::bufferData(SoundSource& soundSource) {
     alCheck(alBufferData(
         buffer,

--- a/rwengine/src/audio/SoundBuffer.hpp
+++ b/rwengine/src/audio/SoundBuffer.hpp
@@ -14,6 +14,7 @@ class SoundBuffer {
 
 public:
     SoundBuffer();
+    ~SoundBuffer();
     bool bufferData(SoundSource& soundSource);
 
     bool isPlaying() const;

--- a/rwengine/src/audio/SoundManager.cpp
+++ b/rwengine/src/audio/SoundManager.cpp
@@ -38,13 +38,7 @@ SoundManager::SoundManager(GameWorld* engine) : _engine(engine) {
 }
 
 SoundManager::~SoundManager() {
-    // De-initialize OpenAL
-    if (alContext) {
-        alcMakeContextCurrent(nullptr);
-        alcDestroyContext(alContext);
-    }
-
-    if (alDevice) alcCloseDevice(alDevice);
+    deinitializeOpenAL();
 }
 
 bool SoundManager::initializeOpenAL() {
@@ -71,7 +65,7 @@ bool SoundManager::initializeOpenAL() {
     return true;
 }
 
-bool SoundManager::initializeAVCodec() {
+void SoundManager::initializeAVCodec() {
 #if defined(RW_DEBUG) && defined(RW_VERBOSE_DEBUG_MESSAGES)
     av_log_set_level(AV_LOG_WARNING);
 #else
@@ -83,8 +77,24 @@ bool SoundManager::initializeAVCodec() {
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
     av_register_all();
 #endif
+}
 
-    return true;
+void SoundManager::deinitializeOpenAL() {
+    // Buffers have to been removed before openAL is deinitialized
+    sounds.clear();
+    buffers.clear();
+
+    // De-initialize OpenAL
+    if (alContext) {
+         alcMakeContextCurrent(nullptr);
+         alcDestroyContext(alContext);
+     }
+     alContext = nullptr;
+
+     if (alDevice) {
+         alcCloseDevice(alDevice);
+     }
+     alDevice = nullptr;
 }
 
 bool SoundManager::loadSound(const std::string& name,

--- a/rwengine/src/audio/SoundManager.hpp
+++ b/rwengine/src/audio/SoundManager.hpp
@@ -86,7 +86,9 @@ public:
 
 private:
     bool initializeOpenAL();
-    bool initializeAVCodec();
+    void initializeAVCodec();
+
+    void deinitializeOpenAL();
 
     ALCcontext* alContext = nullptr;
     ALCdevice* alDevice = nullptr;


### PR DESCRIPTION
OpenAL printing
```
AL lib: (WW) FreeContext: (0x614000052440) Deleting 22 Sources
AL lib: (WW) FreeDevice: (0x62d0001f4400) Deleting 22 Buffers
```
at program shutdown is actually a warning that not all sources and
buffers were deleted.