### PR TITLE
Remove TESTS_NODATA cmake configuration option

### DIFF
--- a/cmake/ctest/build.ctest
+++ b/cmake/ctest/build.ctest
@@ -162,7 +162,6 @@ set(_CONFIGURE_OPTIONS
     "-DBUILD_TOOLS=${BUILD_TOOLS}"
     "-DBUILD_VIEWER=${BUILD_VIEWER}"
     "-DBUILD_TESTS=TRUE"
-    "-DTESTS_NODATA=${TESTS_NODATA}"
     "-DTEST_COVERAGE=${RUN_COVERAGE}"
     "-DSEPARATE_TEST_SUITES=${SEPARATE_TEST_SUITES}"
     "-DCHECK_IWYU=${CHECK_IWYU}"
@@ -190,7 +189,13 @@ ctest_build(
 
 if(RUN_TESTS)
     message(STATUS "Running tests...")
+    if(TESTS_NODATA)
+        set(TEST_INCLUDE_REGEX "no_data")
+    else()
+        set(TEST_INCLUDE_REGEX "")
+    endif()
     ctest_test(
+        INCLUDE "${TEST_INCLUDE_REGEX}"
         RETURN_VALUE _TEST_RESULT
         )
 else()

--- a/cmake/ctest/script_ci.ctest
+++ b/cmake/ctest/script_ci.ctest
@@ -55,19 +55,11 @@ set(RUN_COVERAGE FALSE)
 set(RUN_MEMCHECK FALSE)
 openrw_should_submit_ci(SUBMIT)
 
-# Build with no data and test
-set(BUILDER_NAME "${BUILDER_NAME_BASE}-nodata")
+# Configure, build and test with no data
+set(BUILDER_NAME "${BUILDER_NAME_BASE}")
 set(APPEND_RESULTS FALSE)
 set(TESTS_NODATA TRUE)
 set(RUN_TESTS TRUE)
-
-include("${CTEST_SCRIPT_DIRECTORY}/build.ctest")
-
-# Build with data and do not test
-set(BUILDER_NAME "${BUILDER_NAME_BASE}-data")
-set(APPEND_RESULTS FALSE)
-set(TESTS_NODATA FALSE)
-set(RUN_TESTS FALSE)
 
 include("${CTEST_SCRIPT_DIRECTORY}/build.ctest")
 

--- a/cmake_options.cmake
+++ b/cmake_options.cmake
@@ -7,8 +7,6 @@ option(BUILD_VIEWER "Build GUI data viewer")
 option(ENABLE_SCRIPT_DEBUG "Enable verbose script execution")
 option(ENABLE_PROFILING "Enable detailed profiling metrics")
 
-option(TESTS_NODATA "Build tests for no-data testing")
-
 set(FAILED_CHECK_ACTION "IGNORE" CACHE STRING "What action to perform on a failed RW_CHECK (in debug mode)")
 set_property(CACHE FAILED_CHECK_ACTION PROPERTY STRINGS "IGNORE" "ABORT" "BREAKPOINT")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,13 +10,11 @@ class OpenrwConan(ConanFile):
     description = "OpenRW 'Open ReWrite' is an un-official open source recreation of the classic Grand Theft Auto III game executable"
     settings = 'os', 'compiler', 'build_type', 'arch'
     options = {
-        'test_data': [True, False],
         'viewer': [True, False],
         'tools': [True, False],
     }
 
     default_options = (
-        'test_data=False',
         'viewer=True',
         'tools=True',
         'bullet:shared=False',
@@ -66,7 +64,6 @@ class OpenrwConan(ConanFile):
             'BUILD_TESTS': True,
             'BUILD_VIEWER': self.options.viewer,
             'BUILD_TOOLS': self.options.tools,
-            'TESTS_NODATA': not self.options.test_data,
             'USE_CONAN': True,
             'BOOST_STATIC': not self.options['boost'].shared,
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,8 @@ set(TESTS
     )
 
 set(TEST_SOURCES
+    boost_fixes.hpp
+
     main.cpp
     test_Globals.cpp
     test_Globals.hpp
@@ -56,11 +58,6 @@ add_executable(rwtests
     ${TEST_SOURCES}
     )
 
-target_compile_definitions(rwtests
-    PRIVATE
-        "RW_TEST_WITH_DATA=$<NOT:$<BOOL:${TESTS_NODATA}>>"
-    )
-
 target_include_directories(rwtests
     PRIVATE
         "${PROJECT_SOURCE_DIR}/tests"
@@ -70,6 +67,7 @@ target_include_directories(rwtests
 target_link_libraries(rwtests
     PRIVATE
         Boost::unit_test_framework
+        Boost::program_options
         rwengine
         SDL2::SDL2
         Boost::filesystem
@@ -89,10 +87,18 @@ if(SEPARATE_TEST_SUITES)
             )
     endforeach()
 else()
-    add_test(NAME UnitTests
+    add_test(NAME all_tests
         COMMAND "$<TARGET_FILE:rwtests>"
         )
-    set_tests_properties(UnitTests
+    set_tests_properties(all_tests
+        PROPERTIES
+            TIMEOUT 300
+        )
+
+    add_test(NAME all_tests_no_data
+        COMMAND "$<TARGET_FILE:rwtests>" "--" "--nodata"
+        )
+    set_tests_properties(all_tests
         PROPERTIES
             TIMEOUT 300
         )

--- a/tests/boost_fixes.hpp
+++ b/tests/boost_fixes.hpp
@@ -1,0 +1,64 @@
+#ifndef _RWTESTS_BOOST_FIXES_HPP_
+#define _RWTESTS_BOOST_FIXES_HPP_
+
+#include <fonts/GameTexts.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <glm/gtx/string_cast.hpp>
+
+// Boost moved the print_log_value struct in version 1.59
+// TODO: use another testing library
+#if BOOST_VERSION >= 105900
+#define BOOST_NS_MAGIC namespace tt_detail {
+#define BOOST_NS_MAGIC_CLOSING }
+#else
+#define BOOST_NS_MAGIC
+#define BOOST_NS_MAGIC_CLOSING
+#endif
+
+namespace boost {
+namespace test_tools {
+BOOST_NS_MAGIC
+template <>
+struct print_log_value<glm::vec3> {
+    void operator()(std::ostream& s, glm::vec3 const& v) {
+        s << glm::to_string(v);
+    }
+};
+BOOST_NS_MAGIC_CLOSING
+}
+}
+
+#if BOOST_VERSION < 106400
+namespace boost {
+namespace test_tools {
+BOOST_NS_MAGIC
+template <>
+struct print_log_value<std::nullptr_t> {
+    void operator()(std::ostream& s, std::nullptr_t) {
+        s << "nullptr";
+    }
+};
+BOOST_NS_MAGIC_CLOSING
+}
+}
+#endif
+
+namespace boost {
+namespace test_tools {
+BOOST_NS_MAGIC
+template <>
+struct print_log_value<GameString> {
+    void operator()(std::ostream& s, GameString const& v) {
+        for (GameString::size_type i = 0u; i < v.size(); ++i) {
+            s << static_cast<char>(v[i]);
+        }
+    }
+};
+BOOST_NS_MAGIC_CLOSING
+}
+}
+
+#undef BOOST_NS_MAGIC
+#undef BOOST_NS_MAGIC_CLOSING
+#endif

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,2 +1,52 @@
 #define BOOST_TEST_MODULE openrw
 #include <boost/test/unit_test.hpp>
+#include <boost/program_options.hpp>
+
+#include "test_Globals.hpp"
+
+#include <iostream>
+
+static bool global_texture_ran = false;
+
+class RWTestGlobalFixture {
+public:
+    RWTestGlobalFixture() {
+        int argc = utf::framework::master_test_suite().argc;
+        char** argv= utf::framework::master_test_suite().argv;
+        parse_args(argc, argv);
+
+        global_texture_ran = true;
+    }
+private:
+    void parse_args(int argc, char** argv) {
+        namespace po = boost::program_options;
+        po::options_description test_options("Test options");
+        test_options.add_options()(
+            "nodata", "Disable tests that need game data")(
+            "help", "Show this help message");
+
+        po::variables_map vm;
+        try {
+            po::store(po::parse_command_line(argc, argv, test_options), vm);
+            po::notify(vm);
+        } catch (po::error& ex) {
+            std::cout << "Error parsing arguments: " << ex.what() << std::endl;
+            std::cerr << test_options;
+            _exit(EXIT_FAILURE);
+        }
+        if (vm.count("help")) {
+            std::cout << test_options;
+            _exit(EXIT_SUCCESS);
+        }
+
+        if (vm.count("nodata")) {
+            global_args.with_data = false;
+        }
+    }
+};
+
+BOOST_TEST_GLOBAL_FIXTURE(RWTestGlobalFixture);
+
+BOOST_AUTO_TEST_CASE(test_global_fixture) {
+    BOOST_TEST_REQUIRE(global_texture_ran);
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,8 +1,2 @@
 #define BOOST_TEST_MODULE openrw
 #include <boost/test/unit_test.hpp>
-#include "test_Globals.hpp"
-
-std::ostream& operator<<(std::ostream& stream, const glm::vec3& v) {
-    stream << v.x << " " << v.y << " " << v.z;
-    return stream;
-}

--- a/tests/test_Animation.cpp
+++ b/tests/test_Animation.cpp
@@ -7,8 +7,8 @@
 
 BOOST_AUTO_TEST_SUITE(AnimationTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_matrix) {
+BOOST_AUTO_TEST_CASE(test_matrix,
+                     * utf::precondition(with_data{})) {
     {
         auto animation = std::make_shared<Animation>();
 
@@ -46,6 +46,5 @@ BOOST_AUTO_TEST_CASE(test_matrix) {
                     glm::vec3(0.f, 1.f, 0.f));
     }
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_Archive.cpp
+++ b/tests/test_Archive.cpp
@@ -4,8 +4,8 @@
 
 BOOST_AUTO_TEST_SUITE(ArchiveTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_open_archive) {
+BOOST_AUTO_TEST_CASE(test_open_archive,
+                     * utf::precondition(with_data{})) {
     LoaderIMG archive;
 
     BOOST_REQUIRE(archive.load(Global::getGamePath() + "/models/gta3"));
@@ -28,6 +28,5 @@ BOOST_AUTO_TEST_CASE(test_open_archive) {
     BOOST_CHECK_EQUAL(f2.offset, f.offset);
     BOOST_CHECK_EQUAL(f2.size, f.size);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_Buoyancy.cpp
+++ b/tests/test_Buoyancy.cpp
@@ -4,8 +4,8 @@
 
 BOOST_AUTO_TEST_SUITE(BuoyancyTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_vehicle_buoyancy) {
+BOOST_AUTO_TEST_CASE(test_vehicle_buoyancy,
+                     * utf::precondition(with_data{})) {
     glm::vec2 tpos(-WATER_WORLD_SIZE / 2.f + 10.f);
     {
         VehicleObject* vehicle = Global::get().e->createVehicle(
@@ -57,6 +57,5 @@ BOOST_AUTO_TEST_CASE(test_vehicle_buoyancy) {
         Global::get().e->destroyObject(vehicle);
     }
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_Character.cpp
+++ b/tests/test_Character.cpp
@@ -1,14 +1,16 @@
+#include "test_Globals.hpp"
+
 #include <ai/DefaultAIController.hpp>
-#include <boost/test/unit_test.hpp>
 #include <engine/Animator.hpp>
 #include <objects/CharacterObject.hpp>
 #include <objects/VehicleObject.hpp>
-#include "test_Globals.hpp"
+
+#include <btBulletDynamicsCommon.h>
 
 BOOST_AUTO_TEST_SUITE(CharacterTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_create) {
+BOOST_AUTO_TEST_CASE(test_create,
+                     * utf::precondition(with_data{})) {
     {
         auto character =
             Global::get().e->createPedestrian(1, {100.f, 100.f, 50.f});
@@ -31,7 +33,8 @@ BOOST_AUTO_TEST_CASE(test_create) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_activities) {
+BOOST_AUTO_TEST_CASE(test_activities,
+                     * utf::precondition(with_data{})) {
     {
         auto character =
             Global::get().e->createPedestrian(1, {0.f, 0.f, 225.6f});
@@ -120,7 +123,8 @@ BOOST_AUTO_TEST_CASE(test_activities) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_death) {
+BOOST_AUTO_TEST_CASE(test_death,
+                     * utf::precondition(with_data{})) {
     {
         auto character =
             Global::get().e->createPedestrian(1, {100.f, 100.f, 50.f});
@@ -148,7 +152,8 @@ BOOST_AUTO_TEST_CASE(test_death) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_cycle_animating) {
+BOOST_AUTO_TEST_CASE(test_cycle_animating,
+                     * utf::precondition(with_data{})) {
     {
         auto character =
             Global::get().e->createPedestrian(1, {100.f, 100.f, 50.f});
@@ -162,6 +167,5 @@ BOOST_AUTO_TEST_CASE(test_cycle_animating) {
                           static_cast<uint32_t>(AnimCycle::ArrestGun));
     }
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_Chase.cpp
+++ b/tests/test_Chase.cpp
@@ -4,14 +4,13 @@
 
 BOOST_AUTO_TEST_SUITE(ChaseTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_load_keyframes) {
+BOOST_AUTO_TEST_CASE(test_load_keyframes,
+                     * utf::precondition(with_data{})) {
     std::vector<ChaseKeyframe> keyframes;
     BOOST_REQUIRE(ChaseKeyframe::load(
         Global::getGamePath() + "/data/paths/CHASE0.DAT", keyframes));
     BOOST_REQUIRE(keyframes.size() == 5400);
     BOOST_CHECK_CLOSE(keyframes[0].position.x, 273.5422, 0.1);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_Cutscene.cpp
+++ b/tests/test_Cutscene.cpp
@@ -6,8 +6,8 @@
 
 BOOST_AUTO_TEST_SUITE(CutsceneTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_load) {
+BOOST_AUTO_TEST_CASE(test_load,
+                     * utf::precondition(with_data{})) {
     {
         auto d = Global::get().e->data->index.openFile("intro.dat");
 
@@ -29,6 +29,5 @@ BOOST_AUTO_TEST_CASE(test_load) {
         BOOST_CHECK(tracks.duration == 64.8f);
     }
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_Data.cpp
+++ b/tests/test_Data.cpp
@@ -10,8 +10,8 @@
 
 BOOST_AUTO_TEST_SUITE(DataTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_weapon_dat) {
+BOOST_AUTO_TEST_CASE(test_weapon_dat,
+                     * utf::precondition(with_data{})) {
     GenericDATLoader l;
     WeaponDataPtrs weaponData;
 
@@ -42,7 +42,8 @@ BOOST_AUTO_TEST_CASE(test_weapon_dat) {
     BOOST_CHECK(data->flags == 0);
 }
 
-BOOST_AUTO_TEST_CASE(test_dynamic_dat_loader) {
+BOOST_AUTO_TEST_CASE(test_dynamic_dat_loader,
+                     * utf::precondition(with_data{})) {
     GenericDATLoader l;
     DynamicObjectDataPtrs loaded;
 
@@ -68,7 +69,8 @@ BOOST_AUTO_TEST_CASE(test_dynamic_dat_loader) {
     BOOST_CHECK_EQUAL(lamp->cameraAvoid, false);
 }
 
-BOOST_AUTO_TEST_CASE(test_handling_data_loader) {
+BOOST_AUTO_TEST_CASE(test_handling_data_loader,
+                     * utf::precondition(with_data{})) {
     GenericDATLoader l;
     VehicleInfoPtrs loaded;
 
@@ -86,7 +88,8 @@ BOOST_AUTO_TEST_CASE(test_handling_data_loader) {
     BOOST_CHECK_EQUAL(handling.engineType, VehicleHandlingInfo::Petrol);
 }
 
-BOOST_AUTO_TEST_CASE(test_model_files_loaded) {
+BOOST_AUTO_TEST_CASE(test_model_files_loaded,
+                     * utf::precondition(with_data{})) {
     auto& d = Global::get().d;
 
     // The weapon models should be associated by the MODELFILE entries
@@ -96,7 +99,8 @@ BOOST_AUTO_TEST_CASE(test_model_files_loaded) {
     BOOST_CHECK_NE(ak47->getAtomic(0), nullptr);
 }
 
-BOOST_AUTO_TEST_CASE(test_model_archive_loaded) {
+BOOST_AUTO_TEST_CASE(test_model_archive_loaded,
+                     * utf::precondition(with_data{})) {
     auto& d = Global::get().d;
     auto& e = Global::get().e;
 
@@ -121,6 +125,5 @@ BOOST_AUTO_TEST_CASE(test_model_archive_loaded) {
         e->destroyObject(inst);
     }
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_FileIndex.cpp
+++ b/tests/test_FileIndex.cpp
@@ -21,8 +21,8 @@ BOOST_AUTO_TEST_CASE(test_normalizeName) {
     }
 }
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_indexTree) {
+BOOST_AUTO_TEST_CASE(test_indexTree,
+                     * utf::precondition(with_data{})) {
     FileIndex index;
     index.indexTree(Global::getGamePath());
 
@@ -46,7 +46,8 @@ BOOST_AUTO_TEST_CASE(test_indexTree) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_openFile) {
+BOOST_AUTO_TEST_CASE(test_openFile,
+                     * utf::precondition(with_data{})) {
     FileIndex index;
     index.indexTree(Global::getGamePath() + "/data");
 
@@ -54,7 +55,8 @@ BOOST_AUTO_TEST_CASE(test_openFile) {
     BOOST_CHECK(handle.data != nullptr);
 }
 
-BOOST_AUTO_TEST_CASE(test_indexArchive) {
+BOOST_AUTO_TEST_CASE(test_indexArchive,
+                     * utf::precondition(with_data{})) {
     FileIndex index;
     index.indexTree(Global::getGamePath());
 
@@ -70,6 +72,5 @@ BOOST_AUTO_TEST_CASE(test_indexArchive) {
         BOOST_CHECK(handle.data != nullptr);
     }
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_GameData.cpp
+++ b/tests/test_GameData.cpp
@@ -4,8 +4,8 @@
 
 BOOST_AUTO_TEST_SUITE(GameDataTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_object_data) {
+BOOST_AUTO_TEST_CASE(test_object_data,
+                     * utf::precondition(with_data{})) {
     GameData gd(&Global::get().log, Global::getGamePath());
     gd.load();
 
@@ -25,7 +25,8 @@ BOOST_AUTO_TEST_CASE(test_object_data) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_ped_stats) {
+BOOST_AUTO_TEST_CASE(test_ped_stats,
+                     * utf::precondition(with_data{})) {
     GameData gd(&Global::get().log, Global::getGamePath());
     gd.load();
 
@@ -45,7 +46,8 @@ BOOST_AUTO_TEST_CASE(test_ped_stats) {
     BOOST_CHECK_EQUAL(stat2.flags_, 2);
 }
 
-BOOST_AUTO_TEST_CASE(test_ped_stat_info) {
+BOOST_AUTO_TEST_CASE(test_ped_stat_info,
+                     * utf::precondition(with_data{})) {
     GameData gd(&Global::get().log, Global::getGamePath());
     gd.load();
 
@@ -59,7 +61,8 @@ BOOST_AUTO_TEST_CASE(test_ped_stat_info) {
     BOOST_CHECK_EQUAL(cop->statindex_, stat_cop.id_);
 }
 
-BOOST_AUTO_TEST_CASE(test_ped_relations) {
+BOOST_AUTO_TEST_CASE(test_ped_relations,
+                     * utf::precondition(with_data{})) {
     GameData gd(&Global::get().log, Global::getGamePath());
     gd.load();
 
@@ -79,7 +82,8 @@ BOOST_AUTO_TEST_CASE(test_ped_relations) {
                           PedRelationship::THREAT_EXPLOSION);
 }
 
-BOOST_AUTO_TEST_CASE(test_ped_groups) {
+BOOST_AUTO_TEST_CASE(test_ped_groups,
+                     * utf::precondition(with_data{})) {
     GameData gd(&Global::get().log, Global::getGamePath());
     gd.load();
 
@@ -94,6 +98,5 @@ BOOST_AUTO_TEST_CASE(test_ped_groups) {
     BOOST_REQUIRE_GE(red.size(), 8);
     BOOST_CHECK_EQUAL(red[0], 34);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_GameWorld.cpp
+++ b/tests/test_GameWorld.cpp
@@ -6,8 +6,8 @@
 
 BOOST_AUTO_TEST_SUITE(GameWorldTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_gameobject_id) {
+BOOST_AUTO_TEST_CASE(test_gameobject_id,
+                     * utf::precondition(with_data{})) {
     GameWorld gw(&Global::get().log, Global::get().d);
 
     auto object1 = gw.createInstance(1337, glm::vec3(100.f, 0.f, 0.f));
@@ -16,7 +16,8 @@ BOOST_AUTO_TEST_CASE(test_gameobject_id) {
     BOOST_CHECK_NE(object1->getGameObjectID(), object2->getGameObjectID());
 }
 
-BOOST_AUTO_TEST_CASE(test_offsetgametime) {
+BOOST_AUTO_TEST_CASE(test_offsetgametime,
+                     * utf::precondition(with_data{})) {
     GameWorld gw(&Global::get().log, Global::get().d);
     gw.state = new GameState();
 
@@ -67,6 +68,5 @@ BOOST_AUTO_TEST_CASE(test_offsetgametime) {
     BOOST_CHECK_EQUAL(9, gw.getHour());
     BOOST_CHECK_EQUAL(25, gw.getMinute());
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_Garage.cpp
+++ b/tests/test_Garage.cpp
@@ -1,11 +1,11 @@
 #include <boost/test/unit_test.hpp>
 #include <engine/Garage.hpp>
 #include "test_Globals.hpp"
-#if RW_TEST_WITH_DATA
 
 BOOST_AUTO_TEST_SUITE(GarageTests)
 
-BOOST_AUTO_TEST_CASE(test_garage_interaction) {
+BOOST_AUTO_TEST_CASE(test_garage_interaction,
+                     * utf::precondition(with_data{})) {
     {
         auto garage = Global::get().e->createGarage(
             {0.f, 0.f, 0.f}, {3.f, 3.f, 3.f}, Garage::Type::Respray);
@@ -15,4 +15,3 @@ BOOST_AUTO_TEST_CASE(test_garage_interaction) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
-#endif

--- a/tests/test_Globals.cpp
+++ b/tests/test_Globals.cpp
@@ -2,6 +2,38 @@
 
 #include <GameConfig.hpp>
 
+std::ostream& operator<<(std::ostream& stream, const glm::vec3& v) {
+    stream << v.x << " " << v.y << " " << v.z;
+    return stream;
+}
+
+Global::Global() {
+    if (SDL_Init(SDL_INIT_VIDEO) < 0)
+        throw std::runtime_error("Failed to initialize SDL2!");
+
+    window.create("Tests", 800, 600, false);
+    window.hideCursor();
+
+#if RW_TEST_WITH_DATA
+    d = new GameData(&log, getGamePath());
+
+    d->load();
+
+    e = new GameWorld(&log, d);
+    s = new GameState;
+    e->state = s;
+
+    e->dynamicsWorld->setGravity(btVector3(0.f, 0.f, 0.f));
+#endif
+}
+
+Global::~Global() {
+    window.close();
+#if RW_TEST_WITH_DATA
+    delete e;
+#endif
+}
+
 #if RW_TEST_WITH_DATA
 std::string Global::getGamePath() {
     GameConfig config;

--- a/tests/test_Globals.cpp
+++ b/tests/test_Globals.cpp
@@ -2,42 +2,60 @@
 
 #include <GameConfig.hpp>
 
+#include <btBulletDynamicsCommon.h>
+#include <SDL.h>
+
+static std::unique_ptr<Global> global_singleton;
+GlobalArgs global_args;
+
 std::ostream& operator<<(std::ostream& stream, const glm::vec3& v) {
     stream << v.x << " " << v.y << " " << v.z;
     return stream;
 }
 
-Global::Global() {
+Global::Global(const GlobalArgs& args) {
     if (SDL_Init(SDL_INIT_VIDEO) < 0)
         throw std::runtime_error("Failed to initialize SDL2!");
 
     window.create("Tests", 800, 600, false);
     window.hideCursor();
 
-#if RW_TEST_WITH_DATA
-    d = new GameData(&log, getGamePath());
+    if (args.with_data) {
+        d = new GameData(&log, getGamePath());
 
-    d->load();
+        d->load();
 
-    e = new GameWorld(&log, d);
-    s = new GameState;
-    e->state = s;
+        e = new GameWorld(&log, d);
+        s = new GameState;
+        e->state = s;
 
-    e->dynamicsWorld->setGravity(btVector3(0.f, 0.f, 0.f));
-#endif
+        e->dynamicsWorld->setGravity(btVector3(0.f, 0.f, 0.f));
+    }
 }
 
 Global::~Global() {
     window.close();
-#if RW_TEST_WITH_DATA
     delete e;
-#endif
 }
 
-#if RW_TEST_WITH_DATA
+Global& Global::get() {
+   if (!global_singleton) {
+       global_singleton = std::make_unique<Global>(global_args);
+   }
+   return *global_singleton;
+}
+
 std::string Global::getGamePath() {
     GameConfig config;
     config.loadFile(GameConfig::getDefaultConfigPath() / "openrw.ini");
     return config.getGameDataPath().string(); //FIXME: use path
 }
-#endif
+
+tt::assertion_result with_data::operator()(utf::test_unit_id id) const {
+    tt::assertion_result ans(global_args.with_data);
+    if (!global_args.with_data) {
+        auto& master = utf::framework::master_test_suite();
+        ans.message() << "no data is available";
+    }
+    return ans;
+}

--- a/tests/test_Globals.hpp
+++ b/tests/test_Globals.hpp
@@ -1,95 +1,43 @@
 #ifndef _TESTGLOBALS_HPP_
 #define _TESTGLOBALS_HPP_
 
-#include <btBulletDynamicsCommon.h>
-#include <SDL.h>
-#include <GameWindow.hpp>
 #include <boost/test/unit_test.hpp>
+
+#include "boost_fixes.hpp"
+
+namespace utf = boost::unit_test;
+namespace tt = boost::test_tools;
+
 #include <core/Logger.hpp>
+#include <GameWindow.hpp>
 #include <engine/GameData.hpp>
 #include <engine/GameState.hpp>
 #include <engine/GameWorld.hpp>
-#include <glm/gtx/string_cast.hpp>
 
 std::ostream& operator<<(std::ostream& stream, glm::vec3 const& v);
 
-// Boost moved the print_log_value struct in version 1.59
-// TODO: use another testing library
-#if BOOST_VERSION >= 105900
-#define BOOST_NS_MAGIC namespace tt_detail {
-#define BOOST_NS_MAGIC_CLOSING }
-#else
-#define BOOST_NS_MAGIC
-#define BOOST_NS_MAGIC_CLOSING
-#endif
-
-namespace boost {
-namespace test_tools {
-BOOST_NS_MAGIC
-template <>
-struct print_log_value<glm::vec3> {
-    void operator()(std::ostream& s, glm::vec3 const& v) {
-        s << glm::to_string(v);
-    }
+struct GlobalArgs {
+    bool with_data = true;
 };
-BOOST_NS_MAGIC_CLOSING
-}
-}
-
-#if BOOST_VERSION < 106400
-namespace boost {
-namespace test_tools {
-BOOST_NS_MAGIC
-template <>
-struct print_log_value<std::nullptr_t> {
-    void operator()(std::ostream& s, std::nullptr_t) {
-        s << "nullptr";
-    }
-};
-BOOST_NS_MAGIC_CLOSING
-}
-}
-#endif
-
-namespace boost {
-namespace test_tools {
-BOOST_NS_MAGIC
-template <>
-struct print_log_value<GameString> {
-    void operator()(std::ostream& s, GameString const& v) {
-        for (GameString::size_type i = 0u; i < v.size(); ++i) {
-            s << static_cast<char>(v[i]);
-        }
-    }
-};
-BOOST_NS_MAGIC_CLOSING
-}
-}
-
-#undef BOOST_NS_MAGIC
-#undef BOOST_NS_MAGIC_CLOSING
+extern GlobalArgs global_args;
 
 class Global {
 public:
-    GameWindow window;
-#if RW_TEST_WITH_DATA
-    GameData* d;
-    GameWorld* e;
-    GameState* s;
-    Logger log;
-#endif
-
-    Global();
+    Global(const GlobalArgs& args);
     ~Global();
 
-#if RW_TEST_WITH_DATA
     static std::string getGamePath();
-#endif
 
-    static Global& get() {
-        static Global g;
-        return g;
-    }
+    GameWindow window;
+    GameData* d = nullptr;
+    GameWorld* e = nullptr;
+    GameState* s = nullptr;
+    Logger log;
+    static Global& get();
+};
+
+struct with_data {
+    tt::assertion_result operator()(utf::test_unit_id id) const;
 };
 
 #endif

--- a/tests/test_Globals.hpp
+++ b/tests/test_Globals.hpp
@@ -79,32 +79,8 @@ public:
     Logger log;
 #endif
 
-    Global() {
-        if (SDL_Init(SDL_INIT_VIDEO) < 0)
-            throw std::runtime_error("Failed to initialize SDL2!");
-
-        window.create("Tests", 800, 600, false);
-        window.hideCursor();
-
-#if RW_TEST_WITH_DATA
-        d = new GameData(&log, getGamePath());
-
-        d->load();
-
-        e = new GameWorld(&log, d);
-        s = new GameState;
-        e->state = s;
-
-        e->dynamicsWorld->setGravity(btVector3(0.f, 0.f, 0.f));
-#endif
-    }
-
-    ~Global() {
-        window.close();
-#if RW_TEST_WITH_DATA
-        delete e;
-#endif
-    }
+    Global();
+    ~Global();
 
 #if RW_TEST_WITH_DATA
     static std::string getGamePath();

--- a/tests/test_Items.cpp
+++ b/tests/test_Items.cpp
@@ -4,8 +4,8 @@
 
 BOOST_AUTO_TEST_SUITE(ItemsTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_character_inventory) {
+BOOST_AUTO_TEST_CASE(test_character_inventory,
+                     * utf::precondition(with_data{})) {
     {
         auto character = Global::get().e->createPedestrian(1, {0.f, 0.f, 0.f});
         BOOST_REQUIRE(character != nullptr);
@@ -25,6 +25,5 @@ BOOST_AUTO_TEST_CASE(test_character_inventory) {
         Global::get().e->destroyObject(character);
     }
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_Lifetime.cpp
+++ b/tests/test_Lifetime.cpp
@@ -6,8 +6,8 @@
 
 BOOST_AUTO_TEST_SUITE(LifetimeTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_cleanup) {
+BOOST_AUTO_TEST_CASE(test_cleanup,
+                     * utf::precondition(with_data{})) {
     GameObject* f =
         Global::get().e->createInstance(1337, glm::vec3(0.f, 0.f, 1000.f));
     auto id = f->getGameObjectID();
@@ -29,6 +29,5 @@ BOOST_AUTO_TEST_CASE(test_cleanup) {
         BOOST_CHECK(search != objects.end());
     }
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_LoaderDFF.cpp
+++ b/tests/test_LoaderDFF.cpp
@@ -5,8 +5,8 @@
 
 BOOST_AUTO_TEST_SUITE(LoaderDFFTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_load_dff) {
+BOOST_AUTO_TEST_CASE(test_load_dff,
+                     * utf::precondition(with_data{})) {
     {
         auto d = Global::get().e->data->index.openFile("landstal.dff");
 
@@ -25,8 +25,6 @@ BOOST_AUTO_TEST_CASE(test_load_dff) {
         BOOST_REQUIRE(atomic->getFrame());
     }
 }
-
-#endif
 
 BOOST_AUTO_TEST_CASE(test_clump_clone) {
     {

--- a/tests/test_Payphone.cpp
+++ b/tests/test_Payphone.cpp
@@ -6,11 +6,11 @@
 #include <objects/GameObject.hpp>
 #include <objects/InstanceObject.hpp>
 #include "test_Globals.hpp"
-#if RW_TEST_WITH_DATA
 
 BOOST_AUTO_TEST_SUITE(PayphoneTests)
 
-BOOST_AUTO_TEST_CASE(test_payphone_interaction) {
+BOOST_AUTO_TEST_CASE(test_payphone_interaction,
+                     * utf::precondition(with_data{})) {
     {
         const auto playerID = 7777;
         auto character = Global::get().e->createPlayer(
@@ -68,5 +68,3 @@ BOOST_AUTO_TEST_CASE(test_payphone_interaction) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-
-#endif

--- a/tests/test_Pickup.cpp
+++ b/tests/test_Pickup.cpp
@@ -1,9 +1,10 @@
-#include <boost/test/unit_test.hpp>
+#include "test_Globals.hpp"
+
 #include <data/WeaponData.hpp>
 #include <objects/CharacterObject.hpp>
 #include <objects/PickupObject.hpp>
-#include "test_Globals.hpp"
-#if RW_TEST_WITH_DATA
+
+#include <btBulletDynamicsCommon.h>
 
 class TestPickup : public PickupObject {
 public:
@@ -22,7 +23,8 @@ public:
 
 BOOST_AUTO_TEST_SUITE(PickupTests)
 
-BOOST_AUTO_TEST_CASE(test_pickup_interaction) {
+BOOST_AUTO_TEST_CASE(test_pickup_interaction,
+                     * utf::precondition(with_data{})) {
     {
         auto objectID = 9999;
         auto character =
@@ -60,7 +62,8 @@ BOOST_AUTO_TEST_CASE(test_pickup_interaction) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_item_pickup) {
+BOOST_AUTO_TEST_CASE(test_item_pickup,
+                     * utf::precondition(with_data{})) {
     {
         auto objectID = 9999;
         auto character =
@@ -96,5 +99,3 @@ BOOST_AUTO_TEST_CASE(test_item_pickup) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-
-#endif

--- a/tests/test_RWBStream.cpp
+++ b/tests/test_RWBStream.cpp
@@ -5,8 +5,8 @@
 
 BOOST_AUTO_TEST_SUITE(RWBStreamTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(iterate_stream_test) {
+BOOST_AUTO_TEST_CASE(iterate_stream_test,
+                     * utf::precondition(with_data{})) {
     {
         auto d = Global::get().e->data->index.openFile("landstal.dff");
 
@@ -28,6 +28,5 @@ BOOST_AUTO_TEST_CASE(iterate_stream_test) {
         BOOST_CHECK_EQUAL(*reinterpret_cast<std::uint32_t*>(innerCursor), 0x10);
     }
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_Text.cpp
+++ b/tests/test_Text.cpp
@@ -9,8 +9,8 @@
 
 BOOST_AUTO_TEST_SUITE(TextTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(load_test) {
+BOOST_AUTO_TEST_CASE(load_test,
+                     * utf::precondition(with_data{})) {
     {
         auto d = Global::get().e->data->index.openFileRaw("text/english.gxt");
 
@@ -23,7 +23,6 @@ BOOST_AUTO_TEST_CASE(load_test) {
         BOOST_CHECK_EQUAL(texts.text("1008"), T("BUSTED"));
     }
 }
-#endif
 
 BOOST_AUTO_TEST_CASE(special_chars) {
     {

--- a/tests/test_TrafficDirector.cpp
+++ b/tests/test_TrafficDirector.cpp
@@ -17,8 +17,8 @@ std::ostream& operator<<(std::ostream& os, const AIGraphNode* yt) {
 
 BOOST_AUTO_TEST_SUITE(TrafficDirectorTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_available_nodes) {
+BOOST_AUTO_TEST_CASE(test_available_nodes,
+                     * utf::precondition(with_data{})) {
     AIGraph graph;
 
     PathData path{PathData::PATH_PED,
@@ -56,7 +56,8 @@ BOOST_AUTO_TEST_CASE(test_available_nodes) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_node_not_blocking) {
+BOOST_AUTO_TEST_CASE(test_node_not_blocking,
+                     * utf::precondition(with_data{})) {
     AIGraph graph;
 
     PathData path{PathData::PATH_PED,
@@ -83,7 +84,8 @@ BOOST_AUTO_TEST_CASE(test_node_not_blocking) {
     Global::get().e->destroyObject(box);
 }
 
-BOOST_AUTO_TEST_CASE(test_node_blocking) {
+BOOST_AUTO_TEST_CASE(test_node_blocking,
+                     * utf::precondition(with_data{})) {
     AIGraph graph;
 
     PathData path{PathData::PATH_PED,
@@ -110,7 +112,8 @@ BOOST_AUTO_TEST_CASE(test_node_blocking) {
     Global::get().e->destroyObject(ped);
 }
 
-BOOST_AUTO_TEST_CASE(test_node_density) {
+BOOST_AUTO_TEST_CASE(test_node_density,
+                     * utf::precondition(with_data{})) {
     AIGraph graph;
 
     PathData path{PathData::PATH_PED,
@@ -144,7 +147,8 @@ BOOST_AUTO_TEST_CASE(test_node_density) {
     Global::get().e->destroyObject(ped);
 }
 
-BOOST_AUTO_TEST_CASE(test_create_traffic) {
+BOOST_AUTO_TEST_CASE(test_create_traffic,
+                     * utf::precondition(with_data{})) {
     AIGraph graph;
 
     PathData path{PathData::PATH_PED,
@@ -164,6 +168,5 @@ BOOST_AUTO_TEST_CASE(test_create_traffic) {
 
     // Global::get().e->destroyObject(created[0]);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_Vehicle.cpp
+++ b/tests/test_Vehicle.cpp
@@ -5,8 +5,8 @@
 
 BOOST_AUTO_TEST_SUITE(VehicleTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(test_create_vehicle) {
+BOOST_AUTO_TEST_CASE(test_create_vehicle,
+                     * utf::precondition(with_data{})) {
     VehicleObject* vehicle =
         Global::get().e->createVehicle(90u, glm::vec3(), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
@@ -26,7 +26,8 @@ BOOST_AUTO_TEST_CASE(test_create_vehicle) {
     Global::get().e->destroyObject(vehicle);
 }
 
-BOOST_AUTO_TEST_CASE(vehicle_parts) {
+BOOST_AUTO_TEST_CASE(vehicle_parts,
+                     * utf::precondition(with_data{})) {
     VehicleObject* vehicle =
         Global::get().e->createVehicle(90u, glm::vec3(), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
@@ -49,7 +50,8 @@ BOOST_AUTO_TEST_CASE(vehicle_parts) {
     Global::get().e->destroyObject(vehicle);
 }
 
-BOOST_AUTO_TEST_CASE(vehicle_part_vis) {
+BOOST_AUTO_TEST_CASE(vehicle_part_vis,
+                     * utf::precondition(with_data{})) {
     VehicleObject* vehicle =
         Global::get().e->createVehicle(90u, glm::vec3(), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
@@ -71,7 +73,8 @@ BOOST_AUTO_TEST_CASE(vehicle_part_vis) {
     Global::get().e->destroyObject(vehicle);
 }
 
-BOOST_AUTO_TEST_CASE(test_door_position) {
+BOOST_AUTO_TEST_CASE(test_door_position,
+                     * utf::precondition(with_data{})) {
     VehicleObject* vehicle = Global::get().e->createVehicle(
         90u, glm::vec3(10.f, 0.f, 0.f), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
@@ -85,7 +88,8 @@ BOOST_AUTO_TEST_CASE(test_door_position) {
     Global::get().e->destroyObject(vehicle);
 }
 
-BOOST_AUTO_TEST_CASE(test_hinges) {
+BOOST_AUTO_TEST_CASE(test_hinges,
+                     * utf::precondition(with_data{})) {
     VehicleObject* vehicle = Global::get().e->createVehicle(
         90u, glm::vec3(10.f, 0.f, 0.f), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
@@ -111,7 +115,8 @@ BOOST_AUTO_TEST_CASE(test_hinges) {
     Global::get().e->destroyObject(vehicle);
 }
 
-BOOST_AUTO_TEST_CASE(test_open_part) {
+BOOST_AUTO_TEST_CASE(test_open_part,
+                     * utf::precondition(with_data{})) {
     VehicleObject* vehicle = Global::get().e->createVehicle(
         90u, glm::vec3(10.f, 0.f, 0.f), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
@@ -130,6 +135,5 @@ BOOST_AUTO_TEST_CASE(test_open_part) {
 
     Global::get().e->destroyObject(vehicle);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_Weapon.cpp
+++ b/tests/test_Weapon.cpp
@@ -1,13 +1,15 @@
-#include <boost/test/unit_test.hpp>
+#include "test_Globals.hpp"
+
 #include <data/WeaponData.hpp>
 #include <objects/CharacterObject.hpp>
 #include <objects/ProjectileObject.hpp>
-#include "test_Globals.hpp"
+
+#include <btBulletDynamicsCommon.h>
 
 BOOST_AUTO_TEST_SUITE(WeaponTests)
 
-#if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(TestWeaponScan) {
+BOOST_AUTO_TEST_CASE(TestWeaponScan,
+                     * utf::precondition(with_data{})) {
     {
         // Test RADIUS scan
         auto character = Global::get().e->createPedestrian(1, {0.f, 0.f, 0.f});
@@ -25,7 +27,8 @@ BOOST_AUTO_TEST_CASE(TestWeaponScan) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(TestProjectile) {
+BOOST_AUTO_TEST_CASE(TestProjectile,
+                     * utf::precondition(with_data{})) {
     {
         auto character = Global::get().e->createPedestrian(1, {25.f, 0.f, 0.f});
         BOOST_REQUIRE(character != nullptr);
@@ -113,6 +116,5 @@ BOOST_AUTO_TEST_CASE(TestProjectile) {
         Global::get().e->destroyQueuedObjects();
     }
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This pr removed the `TESTS_NODATA` cmake configuration option.
- ci does not have to build the tests twice anymore (with TESTS_NODATA enabled and disabled)
- the user can conditionally run the tests with data and without data

How to use?

```
# Run all tests with data
./rwtests

# Run only the tests that do not require data
./rwtests -- --nodata

# Show all extra options
./rwtests -- --help
```
This requires boost 1.68.0 because of a bug: boostorg/test#153