### PR TITLE
Fix conan script error due to conan API change

### DIFF
--- a/scripts/conan/create_vs_solution.py
+++ b/scripts/conan/create_vs_solution.py
@@ -31,7 +31,7 @@ def to_cmake_generator(vs_version, arch):
     
 def create_solution(path, vs_version, arch):
     conan, _, _ = conan_api.ConanAPIV1.factory()
-    conan.remote_add(remote='bincrafters', url='https://api.bintray.com/conan/bincrafters/public-conan', force=True)
+    conan.remote_add('bincrafters', 'https://api.bintray.com/conan/bincrafters/public-conan', force=True)
     conan_arch = conan_arch_map[arch]
     conan.install(path=openrw_path, generators=('cmake_multi',), build=['missing', ],
                   settings=('build_type=Debug', 'arch={}'.format(conan_arch), ), install_folder=path)


### PR DESCRIPTION
Python complains because of unexpected keyword argument ``remote``. It is actually ``remote_name`` in the current version of Conan API:

- https://github.com/conan-io/conan/blob/develop/conans/client/conan_api.py

The script now uses positional arguments, except when keyword argument is necessary.