### PR TITLE
Ignore jump input while in airborne state

### DIFF
--- a/rwengine/src/ai/PlayerController.cpp
+++ b/rwengine/src/ai/PlayerController.cpp
@@ -327,7 +327,8 @@ glm::vec3 PlayerController::getTargetPosition() {
 }
 
 void PlayerController::jump() {
-    if (!character->isInWater()) {
+    if (!character->isInWater() &&
+		 character->isOnGround()) {
         setNextActivity(std::make_unique<Activities::Jump>());
     }
 }


### PR DESCRIPTION
Fixes #568. Jump action only checks for "not in water" condition, adding "on ground" check fixes the issue.