### PR TITLE
Pause all other sounds during a cutscene

### DIFF
--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -883,7 +883,8 @@ void GameWorld::clearTickData() {
 
 void GameWorld::setPaused(bool pause) {
     paused = pause;
-    if (!pause && !isCutsceneDone()) {
+    bool resumingCutscene = !pause && !isCutsceneDone();
+    if (resumingCutscene) {
         sound.playMusic(cutsceneAudio);
     } else {
         sound.pause(pause);

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -782,6 +782,7 @@ void GameWorld::startCutscene() {
     state->skipCutscene = false;
 
     if (cutsceneAudio.length() > 0) {
+        sound.pauseAllSounds();
         sound.playMusic(cutsceneAudio);
     }
 }
@@ -794,6 +795,7 @@ void GameWorld::clearCutscene() {
     if (cutsceneAudio.length() > 0) {
         sound.stopMusic(cutsceneAudio);
         cutsceneAudio = "";
+        sound.resumeAllSounds();
     }
 
     delete state->currentCutscene;
@@ -881,7 +883,11 @@ void GameWorld::clearTickData() {
 
 void GameWorld::setPaused(bool pause) {
     paused = pause;
-    sound.pause(pause);
+    if (!pause && !isCutsceneDone()) {
+        sound.playMusic(cutsceneAudio);
+    } else {
+        sound.pause(pause);
+    }
 }
 
 bool GameWorld::isPaused() const {


### PR DESCRIPTION
Fixes #583 
I tested only the cutscene on the first mission (Luigi's Girls), but it should work for any other.