### PR TITLE
setForcedUpdateAllAabbs to false; Reduces stepSimulation time by 35%.

### DIFF
--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -92,6 +92,7 @@ GameWorld::GameWorld(Logger* log, GameData* dat)
         _overlappingPairCallback.get());
     gContactProcessedCallback = ContactProcessedCallback;
     dynamicsWorld->setInternalTickCallback(PhysicsTickCallback, this);
+    dynamicsWorld->setForceUpdateAllAabbs(false);
 }
 
 GameWorld::~GameWorld() {


### PR DESCRIPTION
This causes a drop from 6.5ms to 4.2ms on my machine.

Thanks to @FP4 for pointing this out in #622.

To Check:
- [ ] Static objects update their AABB when moved by the game.