### PR TITLE
Various conan/cmake updates 'n fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
     endif()
 
     # Do not link to SDL2main library
-    set(SDL2_BUILDING_LIBRARY True)
+    set(SDL2_BUILDING_LIBRARY TRUE)
 
     find_package(OpenAL REQUIRED)
     find_package(Bullet REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(USE_CONAN)
         message(STATUS "Using conan 'cmake' generator")
         include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
     endif()
-    conan_basic_setup(TARGETS)
+    conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
 
     rwdep_wrap_conan_targets()
 else()

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ this it will not be possible to play.
 
 Windows | Linux | macOS | coverage
 ---| --- | ---  | ---
-[![Build status](https://ci.appveyor.com/api/projects/status/k33qf9ssrja6ckx8/branch/master?svg=true)](https://ci.appveyor.com/project/rwengine/openrw/branch/master) | [![Build Status](https://travis-ci.org/rwengine/openrw.svg?branch=master)](https://travis-ci.org/rwengine/openrw) | [![Build Status](https://travis-ci.org/rwengine/openrw.svg?branch=master)](https://travis-ci.org/rwengine/openrw) | [![codecov](https://codecov.io/gh/rwengine/openrw/branch/master/graph/badge.svg)](https://codecov.io/gh/rwengine/openrw)
+[![Build status](https://ci.appveyor.com/api/projects/status/k33qf9ssrja6ckx8/branch/master?svg=true)](https://ci.appveyor.com/project/rwengine/openrw/branch/master) | [![Build Status](https://travis-ci.com/rwengine/openrw.svg?branch=master)](https://travis-ci.com/rwengine/openrw) | [![Build Status](https://travis-ci.com/rwengine/openrw.svg?branch=master)](https://travis-ci.com/rwengine/openrw) | [![codecov](https://codecov.io/gh/rwengine/openrw/branch/master/graph/badge.svg)](https://codecov.io/gh/rwengine/openrw)
 
 
 ## Links

--- a/cmake/modules/WrapTargets.cmake
+++ b/cmake/modules/WrapTargets.cmake
@@ -1,37 +1,25 @@
 function(rwdep_wrap_find_packages)
     if(BULLET_FOUND AND NOT TARGET bullet::bullet)
-        add_library(bullet INTERFACE)
-        target_link_libraries(bullet
-            INTERFACE
-                ${BULLET_LIBRARIES}
-            )
-        target_include_directories(bullet SYSTEM
-            INTERFACE
-                "${BULLET_INCLUDE_DIR}"
-            )
-        add_library(bullet::bullet ALIAS bullet)
+        add_library(bullet::bullet INTERFACE IMPORTED)
+        set_property(TARGET bullet::bullet
+            PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${BULLET_INCLUDE_DIR})
+        set_property(TARGET bullet::bullet
+            PROPERTY INTERFACE_LINK_LIBRARIES ${BULLET_LIBRARIES})
     endif()
 
     if(OPENAL_FOUND AND NOT TARGET OpenAL::OpenAL)
-        add_library(OpenAL INTERFACE)
-        target_link_libraries(OpenAL
-            INTERFACE
-                "${OPENAL_LIBRARY}"
-            )
-        target_include_directories(OpenAL SYSTEM
-            INTERFACE
-                "${OPENAL_INCLUDE_DIR}"
-            )
-        add_library(OpenAL::OpenAL ALIAS OpenAL)
+        add_library(OpenAL::OpenAL INTERFACE IMPORTED)
+        set_property(TARGET OpenAL::OpenAL
+            PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${OPENAL_INCLUDE_DIR})
+        set_property(TARGET OpenAL::OpenAL
+            PROPERTY INTERFACE_LINK_LIBRARIES ${OPENAL_LIBRARY})
     endif()
 endfunction()
 
 function(rwdep_wrap_conan_target TARGET CONAN_NAME)
-    string(RANDOM RND)
-    set(TGT "CONAN_${CONAN_NAME}_${RND}")
-    add_library("${TGT}" INTERFACE)
-    target_link_libraries("${TGT}" INTERFACE "CONAN_PKG::${CONAN_NAME}")
-    add_library("${TARGET}" ALIAS "${TGT}")
+    add_library("${TARGET}" INTERFACE IMPORTED)
+    set_property(TARGET "${TARGET}"
+        PROPERTY INTERFACE_LINK_LIBRARIES "CONAN_PKG::${CONAN_NAME}")
 endfunction()
 
 function(rwdep_wrap_conan_targets)

--- a/cmake/modules/WrapTargets.cmake
+++ b/cmake/modules/WrapTargets.cmake
@@ -24,7 +24,7 @@ endfunction()
 
 function(rwdep_wrap_conan_targets)
     rwdep_wrap_conan_target(OpenAL::OpenAL openal)
-    rwdep_wrap_conan_target(bullet::bullet bullet)
+    rwdep_wrap_conan_target(bullet::bullet bullet3)
     rwdep_wrap_conan_target(glm::glm glm)
     rwdep_wrap_conan_target(ffmpeg::ffmpeg ffmpeg)
     rwdep_wrap_conan_target(SDL2::SDL2 sdl2)

--- a/cmake_configure.cmake
+++ b/cmake_configure.cmake
@@ -5,11 +5,6 @@ add_library(rw_checks INTERFACE)
 add_library(openrw::checks ALIAS rw_checks)
 target_link_libraries(rw_interface INTERFACE rw_checks)
 
-# target_compile_features(rw_interface INTERFACE cxx_std_14) is not supported by CMake 3.2
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     target_compile_options(rw_interface
         INTERFACE
@@ -189,25 +184,36 @@ endforeach()
 
 function(openrw_target_apply_options)
     set(IWYU_MAPPING "${PROJECT_SOURCE_DIR}/openrw_iwyu.imp")
-    cmake_parse_arguments("ORW" "INSTALL;INSTALL_PDB;COVERAGE" "TARGET" "COVERAGE_EXCEPT" ${ARGN})
-    if(CHECK_IWYU)
-        iwyu_check(TARGET "${ORW_TARGET}"
-            EXTRA_OPTS
-                "--mapping_file=${IWYU_MAPPING}"
-        )
-    endif()
+    cmake_parse_arguments("ORW" "CORE;INSTALL;INSTALL_PDB;COVERAGE" "TARGET" "COVERAGE_EXCEPT" ${ARGN})
 
     if(TEST_COVERAGE AND ORW_COVERAGE)
         coverage_add_target("${ORW_TARGET}" EXCEPT ${ORW_COVERAGE_EXCEPT})
     endif()
 
-    if(CHECK_CLANGTIDY)
-        clang_tidy_check_target(
-            TARGET "${ORW_TARGET}"
-            FORMAT_STYLE "file"
-            FIX "${CHECK_CLANGTIDY_FIX}"
-            CHECK_ALL
-        )
+    if(ORW_CORE)
+        if(CHECK_IWYU)
+            iwyu_check(TARGET "${ORW_TARGET}"
+                EXTRA_OPTS
+                    "--mapping_file=${IWYU_MAPPING}"
+            )
+        endif()
+
+        set_target_properties("${ORW_TARGET}"
+            PROPERTIES
+                CXX_EXTENSIONS OFF
+                CXX_STANDARD 17
+                C_EXTENSIONS OFF
+                C_STANDARD 11
+            )
+
+        if(CHECK_CLANGTIDY)
+            clang_tidy_check_target(
+                TARGET "${ORW_TARGET}"
+                FORMAT_STYLE "file"
+                FIX "${CHECK_CLANGTIDY_FIX}"
+                CHECK_ALL
+            )
+        endif()
     endif()
 
     if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")

--- a/cmake_configure.cmake
+++ b/cmake_configure.cmake
@@ -4,7 +4,6 @@ add_library(openrw::interface ALIAS rw_interface)
 add_library(rw_checks INTERFACE)
 add_library(openrw::checks ALIAS rw_checks)
 target_link_libraries(rw_interface INTERFACE rw_checks)
-
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     target_compile_options(rw_interface
         INTERFACE
@@ -16,6 +15,20 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang
             "$<IF:$<COMPILE_LANGUAGE:CXX>,-Wold-style-cast,>"
         )
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    if(MSVC_NO_DEBUG_RUNTIME)
+        foreach(LANG C CXX)
+            foreach(CONFIGURATION_TYPE ${CMAKE_CONFIGURATION_TYPES} "")
+                string(TOUPPER "${CONFIGURATION_TYPE}" CONFIGURATION_TYPE)
+                set(FLAGS_VAR "CMAKE_${LANG}_FLAGS")
+                if(CONFIGURATION_TYPE)
+                    set(FLAGS_VAR "${FLAGS_VAR}_${CONFIGURATION_TYPE}")
+                endif()
+                string(REPLACE "/MDd" "/MD" "${FLAGS_VAR}" "${${FLAGS_VAR}}")
+                string(REPLACE "/MTd" "/MT" "${FLAGS_VAR}" "${${FLAGS_VAR}}")
+                set("${FLAGS_VAR}" "${${FLAGS_VAR}}" CACHE STRING "${LANG} flags for ${CONFIGURATION_TYPE} configuration type")
+            endforeach()
+        endforeach()
+    endif()
     target_compile_definitions(rw_checks
         INTERFACE
             "_SCL_SECURE_NO_WARNINGS"

--- a/cmake_configure.cmake
+++ b/cmake_configure.cmake
@@ -29,6 +29,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(rw_interface
         INTERFACE
             "/MP"
+            "/Zc:__cplusplus"
         )
 else()
     message(FATAL_ERROR "Unknown compiler ID: '${CMAKE_CXX_COMPILER_ID}'")

--- a/cmake_options.cmake
+++ b/cmake_options.cmake
@@ -19,6 +19,9 @@ set(CMAKE_CONFIGURATION_TYPES "Release;Debug;RelWithDebInfo;MinSizeRel" CACHE IN
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: ${CMAKE_CONFIGURATION_TYPES}")
 endif()
+if(MSVC)
+    option(MSVC_NO_DEBUG_RUNTIME "Don't use the debug runtime")
+endif()
 
 option(CHECK_IWYU "Enable IncludeWhatYouUse (Analyze #includes in C and C++ source files)")
 option(CHECK_CLANGTIDY "Enable clang-tidy (A clang-based C++ linter tool)")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,4 @@
 from conans import ConanFile, CMake
-from conans.errors import ConanException
 
 
 class OpenrwConan(ConanFile):
@@ -13,19 +12,22 @@ class OpenrwConan(ConanFile):
         'test_data': [True, False],
         'viewer': [True, False],
         'tools': [True, False],
+        'profiling': [True, False],
     }
 
-    default_options = (
-        'test_data=False',
-        'viewer=True',
-        'tools=True',
-        'bullet3:shared=False',
-        'sdl2:sdl2main=False',
-    )
+    default_options = {
+        'test_data': False,
+        'viewer': True,
+        'tools': True,
+        'profiling': True,
+        'bullet3:shared': False,
+        'sdl2:sdl2main': False,
+    }
 
     generators = 'cmake',
-    exports_sources = 'CMakeLists.txt', 'cmake_configure.cmake', 'cmake_options.cmake', 'COPYING', \
-                      'cmake/modules/*', 'benchmarks', 'rwlib/*', 'rwengine/*', 'rwgame/*', 'rwviewer/*', 'tests/*'
+    exports_sources = 'CMakeLists.txt', 'cmake_configure.cmake', 'cmake_options.cmake', 'CMakeCPack.cmake', 'COPYING', \
+                      'cmake/modules/*', 'benchmarks', 'rwcore/*', 'rwengine/*', 'rwgame/*', 'rwviewer/*', \
+                      'rwtools/*', 'tests/*', 'external/*'
 
     _rw_dependencies = {
         'game': (
@@ -67,6 +69,7 @@ class OpenrwConan(ConanFile):
             'BUILD_VIEWER': self.options.viewer,
             'BUILD_TOOLS': self.options.tools,
             'TESTS_NODATA': not self.options.test_data,
+            'ENABLE_PROFILING': self.options.profiling,
             'USE_CONAN': True,
             'BOOST_STATIC': not self.options['boost'].shared,
         }

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,7 +19,7 @@ class OpenrwConan(ConanFile):
         'test_data=False',
         'viewer=True',
         'tools=True',
-        'bullet:shared=False',
+        'bullet3:shared=False',
         'sdl2:sdl2main=False',
     )
 
@@ -29,15 +29,15 @@ class OpenrwConan(ConanFile):
 
     _rw_dependencies = {
         'game': (
-            'openal/1.18.2@bincrafters/stable',
-            'bullet/2.87@bincrafters/stable',
+            'openal/1.19.0@bincrafters/stable',
+            'bullet3/2.87@bincrafters/stable',
             'glm/0.9.9.1@g-truc/stable',
-            'ffmpeg/4.0@bincrafters/stable',
-            'sdl2/2.0.8@bincrafters/stable',
-            'boost/1.67.0@conan/stable',
+            'ffmpeg/4.0.2@bincrafters/stable',
+            'sdl2/2.0.9@bincrafters/stable',
+            'boost/1.68.0@conan/stable',
         ),
         'viewer': (
-            'Qt/5.11.1@bincrafters/stable',
+            'qt/5.12.0@bincrafters/stable',
         ),
         'tools': (
             'freetype/2.9.0@bincrafters/stable',
@@ -46,7 +46,7 @@ class OpenrwConan(ConanFile):
 
     def configure(self):
         if self.options.viewer:
-            self.options['Qt'].opengl = 'desktop'
+            self.options['qt'].opengl = 'desktop'
 
     def requirements(self):
         for dep in self._rw_dependencies['game']:

--- a/external/microprofile/CMakeLists.txt
+++ b/external/microprofile/CMakeLists.txt
@@ -25,4 +25,10 @@ openrw_target_apply_options(
     TARGET microprofile
 )
 
+set_target_properties(microprofile
+    PROPERTIES
+        CXX_EXTENSIONS OFF
+        CXX_STANDARD 11
+    )
+
 add_library(microprofile::microprofile ALIAS microprofile)

--- a/rwcore/CMakeLists.txt
+++ b/rwcore/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 add_library(rwcore
     # GL stuff is only here temporarily, hoping to move it back to rwengine
     gl/gl_core_3_3.c
@@ -67,6 +66,7 @@ target_link_libraries(rwcore
     )
 
 openrw_target_apply_options(TARGET rwcore
+    CORE
     COVERAGE
     COVERAGE_EXCEPT gl/gl_core_3_3.c gl/gl_core_3_3.h
     )

--- a/rwengine/CMakeLists.txt
+++ b/rwengine/CMakeLists.txt
@@ -169,6 +169,7 @@ target_include_directories(rwengine
     )
 
 openrw_target_apply_options(TARGET rwengine
+    CORE
     COVERAGE
     )
 

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -5,12 +5,12 @@
 #include <utility>
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <BulletDynamics/Character/btKinematicCharacterController.h>
 #include <btBulletDynamicsCommon.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <glm/gtc/constants.hpp>

--- a/rwengine/src/dynamics/CollisionInstance.cpp
+++ b/rwengine/src/dynamics/CollisionInstance.cpp
@@ -5,11 +5,11 @@
 #include <limits>
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <btBulletDynamicsCommon.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <glm/glm.hpp>

--- a/rwengine/src/dynamics/RaycastCallbacks.hpp
+++ b/rwengine/src/dynamics/RaycastCallbacks.hpp
@@ -2,11 +2,11 @@
 #define _RWENGINE_RAYCASTCALLBACKS_HPP_
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <btBulletDynamicsCommon.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 /**

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -1,12 +1,12 @@
 #include "engine/GameWorld.hpp"
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <BulletCollision/CollisionDispatch/btGhostObject.h>
 #include <btBulletDynamicsCommon.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <glm/gtx/norm.hpp>

--- a/rwengine/src/engine/GameWorld.hpp
+++ b/rwengine/src/engine/GameWorld.hpp
@@ -10,11 +10,11 @@
 #include <vector>
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <LinearMath/btScalar.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <glm/glm.hpp>

--- a/rwengine/src/engine/Garage.cpp
+++ b/rwengine/src/engine/Garage.cpp
@@ -1,11 +1,11 @@
 #include "Garage.hpp"
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <btBulletDynamicsCommon.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <glm/gtx/quaternion.hpp>

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -6,13 +6,13 @@
 #include <memory>
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <BulletCollision/CollisionDispatch/btGhostObject.h>
 #include <BulletDynamics/Character/btKinematicCharacterController.h>
 #include <btBulletDynamicsCommon.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <rw/debug.hpp>

--- a/rwengine/src/objects/InstanceObject.cpp
+++ b/rwengine/src/objects/InstanceObject.cpp
@@ -4,12 +4,12 @@
 #include <string>
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <btBulletDynamicsCommon.h>
 #include <glm/gtc/quaternion.hpp>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <rw/types.hpp>

--- a/rwengine/src/objects/PickupObject.cpp
+++ b/rwengine/src/objects/PickupObject.cpp
@@ -3,12 +3,12 @@
 #include <cmath>
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <BulletCollision/CollisionDispatch/btGhostObject.h>
 #include <btBulletDynamicsCommon.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <glm/gtc/quaternion.hpp>

--- a/rwengine/src/objects/ProjectileObject.cpp
+++ b/rwengine/src/objects/ProjectileObject.cpp
@@ -1,12 +1,12 @@
 #include "objects/ProjectileObject.hpp"
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <BulletCollision/CollisionDispatch/btGhostObject.h>
 #include <btBulletDynamicsCommon.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <glm/gtc/quaternion.hpp>

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -6,12 +6,12 @@
 #include <limits>
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <BulletDynamics/Vehicle/btRaycastVehicle.h>
 #include <btBulletDynamicsCommon.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <glm/gtx/quaternion.hpp>

--- a/rwengine/src/objects/VehicleObject.hpp
+++ b/rwengine/src/objects/VehicleObject.hpp
@@ -8,12 +8,12 @@
 #include <unordered_map>
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <btBulletDynamicsCommon.h>
 #include <LinearMath/btScalar.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <glm/glm.hpp>

--- a/rwengine/src/render/DebugDraw.cpp
+++ b/rwengine/src/render/DebugDraw.cpp
@@ -5,11 +5,11 @@
 #include <glm/glm.hpp>
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <LinearMath/btVector3.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <data/Clump.hpp>

--- a/rwengine/src/render/DebugDraw.hpp
+++ b/rwengine/src/render/DebugDraw.hpp
@@ -5,12 +5,12 @@
 #include <vector>
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <LinearMath/btIDebugDraw.h>
 #include <LinearMath/btScalar.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <data/Clump.hpp>

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -2,13 +2,7 @@
 
 #include <cstdint>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 5033)
-#endif
 #include <BulletDynamics/Vehicle/btRaycastVehicle.h>
-#ifdef _MSC_VER
-#pragma warning(default : 5033)
-#endif
 #include <glm/gtc/type_ptr.hpp>
 
 #include <data/Clump.hpp>

--- a/rwgame/CMakeLists.txt
+++ b/rwgame/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(librwgame STATIC
 
 openrw_target_apply_options(
     TARGET librwgame
+    CORE
     COVERAGE
     )
 
@@ -78,6 +79,7 @@ target_link_libraries(rwgame
 
 openrw_target_apply_options(
     TARGET rwgame
+    CORE
     COVERAGE
     INSTALL INSTALL_PDB
     )

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -8,12 +8,12 @@
 #include "StateManager.hpp"
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 // FIXME: should be in rwengine, deeply hidden
 #include <BulletDynamics/Dynamics/btDiscreteDynamicsWorld.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <engine/GameData.hpp>

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -22,11 +22,11 @@
 #include <glm/gtx/norm.hpp>
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <BulletCollision/CollisionDispatch/btGhostObject.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 

--- a/rwtools/rwfont/CMakeLists.txt
+++ b/rwtools/rwfont/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(rwfontmap
 
 openrw_target_apply_options(
     TARGET rwfontmap
+    CORE
     COVERAGE
     INSTALL INSTALL_PDB
     )

--- a/rwviewer/CMakeLists.txt
+++ b/rwviewer/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(rwviewer
 
 openrw_target_apply_options(
     TARGET rwviewer
+    CORE
     COVERAGE
     INSTALL INSTALL_PDB
     )

--- a/scripts/conan/create_vs_solution.py
+++ b/scripts/conan/create_vs_solution.py
@@ -11,7 +11,6 @@ from conans.client import conan_api
 
 openrw_path = Path(__file__).resolve().parents[2]
 cmake_generator_lookup = {
-    2015: 'Visual Studio 14 2015',
     2017: 'Visual Studio 15 2017',
 }
 architectures = ['x64', 'x86']

--- a/scripts/conan/create_vs_solution.py
+++ b/scripts/conan/create_vs_solution.py
@@ -32,14 +32,13 @@ def create_solution(path, vs_version, arch):
     conan, _, _ = conan_api.ConanAPIV1.factory()
     conan.remote_add('bincrafters', 'https://api.bintray.com/conan/bincrafters/public-conan', force=True)
     conan_arch = conan_arch_map[arch]
-    conan.install(path=openrw_path, generators=('cmake_multi',), build=['missing', ],
-                  settings=('build_type=Debug', 'arch={}'.format(conan_arch), ), install_folder=path)
-    conan.install(path=openrw_path, generators=('cmake_multi',), build=['missing', ],
-                  settings=('build_type=Release', 'arch={}'.format(conan_arch), ), install_folder=path)
+    conan.install(path=openrw_path, generators=('cmake',), build=['missing', ],
+                  settings=('build_type=Release', 'arch={}'.format(conan_arch), 'compiler.runtime=MD', ),
+                  install_folder=path)
     cmake_generator = to_cmake_generator(vs_version=vs_version, arch=arch)
     subprocess.run([
-        'cmake', '-DUSE_CONAN=TRUE', '-DBOOST_STATIC=TRUE',
-        '-DBUILD_TESTS=TRUE', '-DBUILD_VIEWER=TRUE', '-DBUILD_TOOLS=TRUE',
+        'cmake', '-DUSE_CONAN=ON', '-DBOOST_STATIC=ON', '-DMSVC_NO_DEBUG_RUNTIME=ON',
+        '-DBUILD_TESTS=ON', '-DBUILD_VIEWER=ON', '-DBUILD_TOOLS=ON',
         '-G{}'.format(cmake_generator), str(openrw_path),
     ], cwd=path, check=True)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ target_link_libraries(rwtests
 
 openrw_target_apply_options(
     TARGET rwtests
+    CORE
     COVERAGE
     INSTALL INSTALL_PDB
     )

--- a/tests/test_Globals.hpp
+++ b/tests/test_Globals.hpp
@@ -2,11 +2,11 @@
 #define _TESTGLOBALS_HPP_
 
 #ifdef _MSC_VER
-#pragma warning(disable : 4305 5033)
+#pragma warning(disable : 4305)
 #endif
 #include <btBulletDynamicsCommon.h>
 #ifdef _MSC_VER
-#pragma warning(default : 4305 5033)
+#pragma warning(default : 4305)
 #endif
 
 #include <SDL.h>


### PR DESCRIPTION
- The `register` warnings in bullet are caused because the `__cplusplus` variable is not defined correctly: https://blogs.msdn.microsoft.com/vcblog/2018/04/09/msvc-now-correctly-reports-__cplusplus
  Fix this by adding the `/Zc:__cplusplus` compile flag
- update travis-ci.org to travis-ci.com
- tweaked cmake find scripts of SDL2 and ffmpeg a bit (they report version now + have conforming indents)
- tweaked the cmake wrapped targets a bit
- ~Merge `RW_FREEBSD`, `RW_NETBSD` and `RW_OPENBSD`: `RW_BSD`~
- set C and C++ standard explicitly as cmake properties. Do something similiar (but lower standard for microprofiler)
- I haven't tested, but I don't think the C++2017 support in Visual Studio 2015 is stellar. So do not generate projects for that Visual Studio version.
- updated conan versions of boost (1.68.0), bullet (2.87, they renamed it), openal (1.19.0), ffmpeg (4.0.2) and qt (5.12.0)
- Debugging on windows (in `Debug` build modus, not `RelWithDebInfo` modus) is currently slow because openrw, along with all dependencies, is built with the standard library containing debug symbols. So add an option `MSVC_NO_DEBUG_RUNTIME` to not use to debug runtime in any configuration type.
  I think this fixes #595.
  It would be nice if @husho can test this (by running the `create_vs_solution.py` script, building openrw and testing it)

Merry christmas! :santa: 