### PR TITLE
Melee Weapon implementation

### DIFF
--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -688,9 +688,31 @@ bool Activities::UseItem::update(CharacterObject *character,
             character->playCycle(shootcycle);
         }
     } else if (weapon->fireType == WeaponData::MELEE) {
-        RW_CHECK(weapon->fireType != WeaponData::MELEE,
-                 "Melee attacks not implemented");
-        return true;
+        /// @todo second attack animation for on-ground targets
+        const auto attackAnimation = shootcycle;
+
+        if (character->getCurrentCycle() != attackAnimation) {
+            character->playCycle(attackAnimation);
+        }
+
+        auto fireTime = weapon->animFirePoint / 100.f;
+        auto loopStart = weapon->animLoopStart / 100.f;
+        auto currentTime = animator->getAnimationTime(AnimIndexAction);
+
+        if (currentTime >= fireTime && !fired) {
+            /// @todo weapon hit here
+            fired = true;
+        }
+
+        if (animator->isCompleted(AnimIndexAction)) {
+            if (character->getCurrentState().primaryActive) {
+                animator->setAnimationTime(AnimIndexAction, loopStart);
+                fired = false;
+            }
+            else {
+                return true;
+            }
+        }
     } else {
         RW_ERROR("Unrecognized fireType: " << weapon->fireType);
         return true;

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -700,7 +700,7 @@ bool Activities::UseItem::update(CharacterObject *character,
         auto currentTime = animator->getAnimationTime(AnimIndexAction);
 
         if (currentTime >= fireTime && !fired) {
-            /// @todo weapon hit here
+            Weapon::meleeHit(weapon, character);
             fired = true;
         }
 

--- a/rwengine/src/data/WeaponData.hpp
+++ b/rwengine/src/data/WeaponData.hpp
@@ -34,49 +34,4 @@ struct WeaponData {
     std::uint32_t inventorySlot;
 };
 
-/**
- * @brief simple object for performing weapon checks against the world
- *
- * @todo RADIUS hitscans
- */
-struct WeaponScan {
-    enum ScanType {
-        /** Instant-hit ray weapons */
-        HITSCAN,
-        /** Area of effect attack */
-        RADIUS,
-    };
-
-    const ScanType type;
-
-    float damage;
-
-    glm::vec3 center{};
-    float radius;
-
-    glm::vec3 end{};
-
-    WeaponData* weapon;
-
-    // Constructor for a RADIUS hitscan
-    WeaponScan(float damage, const glm::vec3& center, float radius,
-               WeaponData* weapon = nullptr)
-        : type(RADIUS)
-        , damage(damage)
-        , center(center)
-        , radius(radius)
-        , weapon(weapon) {
-    }
-
-    // Constructor for a ray hitscan
-    WeaponScan(float damage, const glm::vec3& start, const glm::vec3& end,
-               WeaponData* weapon = nullptr)
-        : type(HITSCAN)
-        , damage(damage)
-        , center(start)
-        , end(end)
-        , weapon(weapon) {
-    }
-};
-
 #endif

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -568,7 +568,7 @@ void GameWorld::destroyEffect(VisualFX& effect) {
 }
 
 void GameWorld::doWeaponScan(const WeaponScan& scan) {
-    if (scan.type == WeaponScan::RADIUS) {
+    if (scan.type == ScanType::Radius) {
         HitTest test {*dynamicsWorld};
         const auto result = test.sphereTest(scan.center, scan.radius);
 
@@ -584,7 +584,7 @@ void GameWorld::doWeaponScan(const WeaponScan& scan) {
             target.object->takeDamage(di);
         }
 
-    } else if (scan.type == WeaponScan::HITSCAN) {
+    } else if (scan.type == ScanType::HitScan) {
         btVector3 from(scan.center.x, scan.center.y, scan.center.z),
             to(scan.end.x, scan.end.y, scan.end.z);
         glm::vec3 hitEnd = scan.end;

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -25,7 +25,8 @@
 
 #include "data/CutsceneData.hpp"
 #include "data/InstanceData.hpp"
-#include "data/WeaponData.hpp"
+
+#include "items/Weapon.hpp"
 
 #include "loaders/LoaderCutsceneDAT.hpp"
 #include "loaders/LoaderIFP.hpp"

--- a/rwengine/src/items/Weapon.cpp
+++ b/rwengine/src/items/Weapon.cpp
@@ -22,7 +22,7 @@ void Weapon::fireHitscan(WeaponData* weapon, CharacterObject* owner) {
     auto fireOrigin = glm::vec3(handMatrix[3]);
     float dmg = static_cast<float>(weapon->damage);
 
-    owner->engine->doWeaponScan({dmg, fireOrigin, rayend, weapon});
+    owner->engine->doWeaponScan({dmg, fireOrigin, rayend, weapon, owner});
 }
 
 void Weapon::fireProjectile(WeaponData* weapon, CharacterObject* owner,
@@ -48,4 +48,15 @@ void Weapon::fireProjectile(WeaponData* weapon, CharacterObject* owner,
     auto& pool = owner->engine->getTypeObjectPool(ptr);
     pool.insert(std::move(projectile));
     owner->engine->allObjects.push_back(ptr);
+}
+
+void Weapon::meleeHit(WeaponData* weapon, CharacterObject* character) {
+    const auto center = character->getPosition() + character->getRotation()
+                                                   * weapon->fireOffset;
+    auto e = character->engine;
+    e->doWeaponScan({
+                        static_cast<float>(weapon->damage),
+                        center, weapon->meleeRadius, weapon,
+                        character
+                    });
 }

--- a/rwengine/src/items/Weapon.cpp
+++ b/rwengine/src/items/Weapon.cpp
@@ -9,6 +9,10 @@
 #include "objects/CharacterObject.hpp"
 #include "objects/ProjectileObject.hpp"
 
+bool WeaponScan::doesDamage(GameObject* target) const {
+    return target != source;
+}
+
 void Weapon::fireHitscan(WeaponData* weapon, CharacterObject* owner) {
     auto handFrame = owner->getClump()->findFrame("srhand");
     glm::mat4 handMatrix = handFrame->getWorldTransform();

--- a/rwengine/src/items/Weapon.hpp
+++ b/rwengine/src/items/Weapon.hpp
@@ -1,22 +1,22 @@
 #ifndef _RWENGINE_WEAPON_HPP_
 #define _RWENGINE_WEAPON_HPP_
-#include <glm/glm.hpp>
+#include <glm/vec3.hpp>
 
 class CharacterObject;
 class GameObject;
 struct WeaponData;
 
+enum class ScanType {
+    /** Instant-hit ray weapons */
+    HitScan,
+    /** Area of effect attack */
+    Radius,
+};
+
 /**
  * @brief simple object for performing weapon checks against the world
  */
 struct WeaponScan {
-    enum ScanType {
-        /** Instant-hit ray weapons */
-        HITSCAN,
-        /** Area of effect attack */
-        RADIUS,
-    };
-
     const ScanType type;
 
     float damage;
@@ -29,10 +29,10 @@ struct WeaponScan {
     WeaponData* weapon;
     GameObject* source;
 
-    // Constructor for a RADIUS hitscan
+    // Constructor for Radius
     WeaponScan(float damage, const glm::vec3& center, float radius,
                WeaponData* weapon = nullptr, GameObject* source = nullptr)
-            : type(RADIUS)
+            : type(ScanType::Radius)
             , damage(damage)
             , center(center)
             , radius(radius)
@@ -40,10 +40,10 @@ struct WeaponScan {
             , source(source) {
     }
 
-    // Constructor for a ray hitscan
+    // Constructor for HitScan
     WeaponScan(float damage, const glm::vec3& start, const glm::vec3& end,
                WeaponData* weapon = nullptr, GameObject* source = nullptr)
-            : type(HITSCAN)
+            : type(ScanType::HitScan)
             , damage(damage)
             , center(start)
             , end(end)

--- a/rwengine/src/items/Weapon.hpp
+++ b/rwengine/src/items/Weapon.hpp
@@ -58,6 +58,7 @@ namespace Weapon {
 void fireProjectile(WeaponData* weapon, CharacterObject* character, float force);
 void fireHitscan(WeaponData *weapon, CharacterObject* character);
 void meleeHit(WeaponData *weapon, CharacterObject* character);
+bool targetOnGround(WeaponData *weapon, CharacterObject* character);
 }
 
 #endif

--- a/rwengine/src/items/Weapon.hpp
+++ b/rwengine/src/items/Weapon.hpp
@@ -57,6 +57,7 @@ struct WeaponScan {
 namespace Weapon {
 void fireProjectile(WeaponData* weapon, CharacterObject* character, float force);
 void fireHitscan(WeaponData *weapon, CharacterObject* character);
+void meleeHit(WeaponData *weapon, CharacterObject* character);
 }
 
 #endif

--- a/rwengine/src/items/Weapon.hpp
+++ b/rwengine/src/items/Weapon.hpp
@@ -1,8 +1,58 @@
 #ifndef _RWENGINE_WEAPON_HPP_
 #define _RWENGINE_WEAPON_HPP_
+#include <glm/glm.hpp>
 
 class CharacterObject;
+class GameObject;
 struct WeaponData;
+
+/**
+ * @brief simple object for performing weapon checks against the world
+ */
+struct WeaponScan {
+    enum ScanType {
+        /** Instant-hit ray weapons */
+        HITSCAN,
+        /** Area of effect attack */
+        RADIUS,
+    };
+
+    const ScanType type;
+
+    float damage;
+
+    glm::vec3 center{};
+    float radius;
+
+    glm::vec3 end{};
+
+    WeaponData* weapon;
+    GameObject* source;
+
+    // Constructor for a RADIUS hitscan
+    WeaponScan(float damage, const glm::vec3& center, float radius,
+               WeaponData* weapon = nullptr, GameObject* source = nullptr)
+            : type(RADIUS)
+            , damage(damage)
+            , center(center)
+            , radius(radius)
+            , weapon(weapon)
+            , source(source) {
+    }
+
+    // Constructor for a ray hitscan
+    WeaponScan(float damage, const glm::vec3& start, const glm::vec3& end,
+               WeaponData* weapon = nullptr, GameObject* source = nullptr)
+            : type(HITSCAN)
+            , damage(damage)
+            , center(start)
+            , end(end)
+            , weapon(weapon)
+            , source(source) {
+    }
+
+    bool doesDamage(GameObject* target) const;
+};
 
 namespace Weapon {
 void fireProjectile(WeaponData* weapon, CharacterObject* character, float force);

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -26,6 +26,7 @@
 #include "loaders/LoaderIFP.hpp"
 #include "objects/VehicleObject.hpp"
 
+
 #ifndef BT_BULLET_VERSION
 #error Unable to find BT_BULLET_VERSION
 #endif
@@ -466,6 +467,12 @@ void CharacterObject::Die() {
 void CharacterObject::SetDead() {
     currentState.isDying = false;
     currentState.isDead = true;
+}
+
+bool CharacterObject::isKnockedDown() const {
+    /// @todo husho says: State in [knocked down, getting up, dying, dead]
+    auto a = animator->getAnimation(AnimIndexMovement);
+    return a == animations->animation(AnimCycle::KnockOutShotFront0);
 }
 
 bool CharacterObject::enterVehicle(VehicleObject* vehicle, size_t seat) {

--- a/rwengine/src/objects/CharacterObject.hpp
+++ b/rwengine/src/objects/CharacterObject.hpp
@@ -141,6 +141,8 @@ public:
     void Die();
     void SetDead();
 
+    bool isKnockedDown() const;
+
     bool takeDamage(const DamageInfo& damage) override;
 
     bool enterVehicle(VehicleObject* vehicle, size_t seat);

--- a/rwengine/src/objects/GameObject.hpp
+++ b/rwengine/src/objects/GameObject.hpp
@@ -164,7 +164,7 @@ public:
     }
 
     struct DamageInfo {
-        enum DamageType { Explosion, Burning, Bullet, Physics };
+        enum DamageType { Explosion, Burning, Bullet, Physics, Melee };
 
         /**
          * World position of damage

--- a/rwengine/src/objects/GameObject.hpp
+++ b/rwengine/src/objects/GameObject.hpp
@@ -164,7 +164,9 @@ public:
     }
 
     struct DamageInfo {
-        enum DamageType { Explosion, Burning, Bullet, Physics, Melee };
+        enum class DamageType {
+            Explosion, Burning, Bullet, Physics, Melee
+        };
 
         /**
          * World position of damage
@@ -190,6 +192,11 @@ public:
          * Physics impulse.
          */
         float impulse;
+
+        DamageInfo(DamageType type, const glm::vec3 &location,
+                   const glm::vec3 &source, float damage, float impulse = 0.f)
+            : damageLocation(location), damageSource(source), hitpoints(damage),
+              type(type), impulse(impulse) {}
     };
 
     virtual bool takeDamage(const DamageInfo& damage) {

--- a/rwengine/src/objects/ProjectileObject.cpp
+++ b/rwengine/src/objects/ProjectileObject.cpp
@@ -78,8 +78,9 @@ void ProjectileObject::explode() {
             float d = glm::distance(getPosition(), o->getPosition());
             if (d > damageSize) continue;
 
-            o->takeDamage({getPosition(), getPosition(),
-                           damage / glm::max(d, 1.f), DamageInfo::Explosion,
+            o->takeDamage({DamageInfo::DamageType::Explosion,
+                           getPosition(), getPosition(),
+                           damage / glm::max(d, 1.f),
                            0.f});
         }
 

--- a/rwgame/states/DebugState.cpp
+++ b/rwgame/states/DebugState.cpp
@@ -207,9 +207,13 @@ Menu DebugState::createAIMenu() {
             if (pedestrianPtr->getLifetime() == GameObject::PlayerLifetime) {
                 continue;
             }
-            pedestrianPtr->takeDamage({pedestrianPtr->getPosition(),
-                                       pedestrianPtr->getPosition(), 100.f,
-                                       GameObject::DamageInfo::Explosion, 0.f});
+            pedestrianPtr->takeDamage(
+                {
+                    GameObject::DamageInfo::DamageType::Explosion,
+                    pedestrianPtr->getPosition(),
+                    pedestrianPtr->getPosition(), 100.f,
+                    0.f
+                });
         }
     });
 

--- a/tests/test_Character.cpp
+++ b/tests/test_Character.cpp
@@ -129,9 +129,11 @@ BOOST_AUTO_TEST_CASE(test_death) {
         BOOST_CHECK_EQUAL(character->getCurrentState().health, 100.f);
         BOOST_CHECK(character->isAlive());
 
-        GameObject::DamageInfo dmg;
-        dmg.type = GameObject::DamageInfo::Bullet;
-        dmg.hitpoints = character->getCurrentState().health + 1.f;
+        GameObject::DamageInfo dmg {
+            GameObject::DamageInfo::DamageType::Bullet,
+            {}, {},
+            character->getCurrentState().health + 1.f
+        };
 
         // Do some damage
         BOOST_CHECK(character->takeDamage(dmg));

--- a/tests/test_Weapon.cpp
+++ b/tests/test_Weapon.cpp
@@ -5,16 +5,20 @@
 #include <objects/ProjectileObject.hpp>
 #include "test_Globals.hpp"
 
+auto& operator<<(std::ostream& s, const ScanType& type) {
+    return s << static_cast<int>(type);
+}
+
 BOOST_AUTO_TEST_SUITE(WeaponTests)
 
 BOOST_AUTO_TEST_CASE(radius_ctor_creates_radius_scan) {
     WeaponScan scan{10.f, {1.f, 1.f, 1.f}, 5.f};
-    BOOST_CHECK_EQUAL(scan.type, WeaponScan::RADIUS);
+    BOOST_CHECK_EQUAL(scan.type, ScanType::Radius);
 }
 
 BOOST_AUTO_TEST_CASE(hitscan_ctor_creates_radius_scan) {
     WeaponScan scan{10.f, {1.f, 1.f, 1.f}, {0.f, 0.f, 0.f}};
-    BOOST_CHECK_EQUAL(scan.type, WeaponScan::HITSCAN);
+    BOOST_CHECK_EQUAL(scan.type, ScanType::HitScan);
 }
 
 struct WeaponScanFixture {

--- a/tests/test_Weapon.cpp
+++ b/tests/test_Weapon.cpp
@@ -1,13 +1,37 @@
 #include <boost/test/unit_test.hpp>
 #include <data/WeaponData.hpp>
+#include <items/Weapon.hpp>
 #include <objects/CharacterObject.hpp>
 #include <objects/ProjectileObject.hpp>
 #include "test_Globals.hpp"
 
 BOOST_AUTO_TEST_SUITE(WeaponTests)
 
+BOOST_AUTO_TEST_CASE(radius_ctor_creates_radius_scan) {
+    WeaponScan scan{10.f, {1.f, 1.f, 1.f}, 5.f};
+    BOOST_CHECK_EQUAL(scan.type, WeaponScan::RADIUS);
+}
+
+BOOST_AUTO_TEST_CASE(hitscan_ctor_creates_radius_scan) {
+    WeaponScan scan{10.f, {1.f, 1.f, 1.f}, {0.f, 0.f, 0.f}};
+    BOOST_CHECK_EQUAL(scan.type, WeaponScan::HITSCAN);
+}
+
+struct WeaponScanFixture {
+    GameObject* source = reinterpret_cast<GameObject*>(0x0000BEEF);
+    WeaponScan scan{10.f, {1.f, 1.f, 1.f}, {0.f, 0.f, 0.f}, nullptr, source};
+};
+
+BOOST_FIXTURE_TEST_CASE(weapon_scan_doesnt_injur_source, WeaponScanFixture) {
+    BOOST_CHECK(!scan.doesDamage(reinterpret_cast<GameObject*>(0x0000BEEF)));
+}
+
+BOOST_FIXTURE_TEST_CASE(weapon_scan_does_injur_others, WeaponScanFixture) {
+    BOOST_CHECK(scan.doesDamage(reinterpret_cast<GameObject*>(0xDEADBEEF)));
+}
+
 #if RW_TEST_WITH_DATA
-BOOST_AUTO_TEST_CASE(TestWeaponScan) {
+BOOST_AUTO_TEST_CASE(TestDoWeaponScan) {
     {
         // Test RADIUS scan
         auto character = Global::get().e->createPedestrian(1, {0.f, 0.f, 0.f});


### PR DESCRIPTION
Provide a basic implementation of melee attacks. This enables attacking while unarmed and with the bat. The alternate ground attack animation is selected if there is anyone on the ground. Currently only dead NPCs fall the ground however so this isn't all that useful yet.