### PR TITLE
Fix segfault when failed to create shader object

### DIFF
--- a/rwengine/src/render/OpenGLRenderer.cpp
+++ b/rwengine/src/render/OpenGLRenderer.cpp
@@ -17,6 +17,12 @@ constexpr GLuint kUBOIndexDraw = 2;
 
 GLuint compileShader(GLenum type, const char* source) {
     GLuint shader = glCreateShader(type);
+
+    if (shader == 0) {
+        RW_ERROR("[OGL] Failed to create shader object");
+        throw std::runtime_error("Compiling shader failed");
+    }
+
     glShaderSource(shader, 1, &source, nullptr);
     glCompileShader(shader);
 


### PR DESCRIPTION
When for some reason a shader object creation returns 0 then there likely will be an error when trying to allocate **sourceBuff** object (because glGetShaderiv with GL_SHADER_SOURCE_LENGTH will fail).
That cause a std::bad_alloc exception and a termination of the program. So I added a check for a shader object creation and now there will be an error message box containing clear message of what was happened. 