### PR TITLE
Fix conanfile.py on case-insensitive filesystems

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -37,7 +37,7 @@ class OpenrwConan(ConanFile):
             'boost/1.68.0@conan/stable',
         ),
         'viewer': (
-            'qt/5.12.0@bincrafters/stable',
+            'Qt/5.12.0@bincrafters/stable',
         ),
         'tools': (
             'freetype/2.9.0@bincrafters/stable',


### PR DESCRIPTION
When running `cd build && conan install ..` you get the following error:
`ERROR: Failed requirement 'qt/5.12.0@bincrafters/stable' from 'conanfile.py (openrw/master@None/None)'
ERROR: Requested 'qt/5.12.0@bincrafters/stable' but found case incompatible 'Qt'
Case insensitive filesystem can't manage this`
This pull request fixes the case of Qt so it will work.