### PR TITLE
Remove existing vehicles & peds when creating script objects

### DIFF
--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -1006,31 +1006,9 @@ bool GameWorld::isRaining() const {
 void GameWorld::clearObjectsWithinArea(const glm::vec3 center,
                                        const float radius,
                                        const bool clearParticles) {
-    bool skipFlag = false;
-
     // Vehicles
     for (auto& obj : vehiclePool.objects) {
-        skipFlag = false;
-
-        // Skip if it's the player or owned by player or owned by mission
-        if (obj.second->getLifetime() == GameObject::PlayerLifetime ||
-            obj.second->getLifetime() == GameObject::MissionLifetime) {
-            continue;
-        }
-
-        // Check if we have any important objects in a vehicle, if we do - don't
-        // erase it
-        for (auto& seat :
-             static_cast<VehicleObject*>(obj.second.get())->seatOccupants) {
-            auto character = static_cast<CharacterObject*>(seat.second);
-
-            if (character->getLifetime() == GameObject::PlayerLifetime ||
-                character->getLifetime() == GameObject::MissionLifetime) {
-                skipFlag = true;
-            }
-        }
-
-        if (skipFlag) {
+        if (!obj.second->canBeRemoved()) {
             continue;
         }
 
@@ -1041,9 +1019,7 @@ void GameWorld::clearObjectsWithinArea(const glm::vec3 center,
 
     // Peds
     for (auto& obj : pedestrianPool.objects) {
-        // Skip if it's the player or owned by player or owned by mission
-        if (obj.second->getLifetime() == GameObject::PlayerLifetime ||
-            obj.second->getLifetime() == GameObject::MissionLifetime) {
+        if (!obj.second->canBeRemoved()) {
             continue;
         }
 

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -1042,6 +1042,28 @@ void GameWorld::clearObjectsWithinArea(const glm::vec3 center,
     // explosions, remove all projectiles
 }
 
+std::vector<GameObject *>
+GameWorld::findOverlappingObjects(const glm::vec3 &center,
+                                  float radius) const {
+    std::vector<GameObject*> overlapping;
+
+    auto checkObjects = [&](const auto& objects) {
+        for (auto& p : objects) {
+            const auto& object = p.second.get();
+            auto objectBounds = object->getModel()->getBoundingRadius();
+            if (glm::distance(center, object->getPosition()) <
+                radius + objectBounds) {
+                overlapping.push_back(object);
+            }
+        }
+    };
+
+    checkObjects(vehiclePool.objects);
+    checkObjects(pedestrianPool.objects);
+
+    return overlapping;
+}
+
 ai::PlayerController* GameWorld::getPlayer() {
     auto object = pedestrianPool.find(state->playerObject);
     if (object) {

--- a/rwengine/src/engine/GameWorld.hpp
+++ b/rwengine/src/engine/GameWorld.hpp
@@ -397,6 +397,9 @@ public:
     void clearObjectsWithinArea(const glm::vec3 center, const float radius,
                                 const bool clearParticles);
 
+    std::vector<GameObject*> findOverlappingObjects(const glm::vec3& center,
+                                                    float radius) const;
+
     ai::PlayerController* getPlayer();
 
     template <

--- a/rwengine/src/objects/GameObject.hpp
+++ b/rwengine/src/objects/GameObject.hpp
@@ -238,8 +238,20 @@ public:
     void setLifetime(ObjectLifetime ol) {
         lifetime = ol;
     }
+
     ObjectLifetime getLifetime() const {
         return lifetime;
+    }
+
+    /// Returns true if the object is not referenced by a script or player
+    virtual bool canBeRemoved() const {
+        switch (lifetime) {
+            case MissionLifetime:
+            case PlayerLifetime:
+                return false;
+            default:
+                return true;
+        }
     }
 
     virtual void updateTransform(const glm::vec3& pos, const glm::quat& rot) {

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -643,6 +643,21 @@ float VehicleObject::getVelocity() const {
     return 0.f;
 }
 
+bool VehicleObject::canBeRemoved() const {
+    if (!GameObject::canBeRemoved()) {
+        return false;
+    }
+
+    for (auto& seat : seatOccupants) {
+        auto character = static_cast<CharacterObject*>(seat.second);
+
+        if (!character->canBeRemoved())
+            return false;
+    }
+
+    return true;
+}
+
 bool VehicleObject::isWrecked() const {
     return health < 250.f;
 }

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -644,18 +644,9 @@ float VehicleObject::getVelocity() const {
 }
 
 bool VehicleObject::canBeRemoved() const {
-    if (!GameObject::canBeRemoved()) {
-        return false;
-    }
-
-    for (auto& seat : seatOccupants) {
-        auto character = static_cast<CharacterObject*>(seat.second);
-
-        if (!character->canBeRemoved())
-            return false;
-    }
-
-    return true;
+    return GameObject::canBeRemoved() &&
+           all_of(seatOccupants.begin(), seatOccupants.end(),
+                  [](const auto& p) { return p.second->canBeRemoved(); });
 }
 
 bool VehicleObject::isWrecked() const {

--- a/rwengine/src/objects/VehicleObject.hpp
+++ b/rwengine/src/objects/VehicleObject.hpp
@@ -123,6 +123,8 @@ public:
         return Vehicle;
     }
 
+    bool canBeRemoved() const override;
+
     bool isWrecked() const;
 
     void setHealth(float);

--- a/rwengine/src/script/ScriptFunctions.hpp
+++ b/rwengine/src/script/ScriptFunctions.hpp
@@ -217,6 +217,23 @@ inline BlipData createObjectBlipSprite(const ScriptArguments& args,
 
 ScriptModel getModel(const ScriptArguments& args, ScriptModel model);
 
+inline void clearSpaceForObject(const ScriptArguments& args,
+                                GameObject* object) {
+    RW_ASSERT(object->getModel());
+
+    auto radius = object->getModel()->getBoundingRadius();
+
+    const auto& overlapping = args.getWorld()->findOverlappingObjects(
+        object->getPosition(), radius);
+
+    for (const auto& found : overlapping) {
+        if (found->canBeRemoved())
+            args.getWorld()->destroyObjectQueued(found);
+
+        // @todo check collision meshes for real intersection
+    }
+}
+
 inline void addObjectToMissionCleanup(const ScriptArguments& args,
                                       GameObject* object) {
     if (args.getThread()->isMission) {

--- a/rwengine/src/script/modules/GTA3ModuleImpl.inl
+++ b/rwengine/src/script/modules/GTA3ModuleImpl.inl
@@ -1797,11 +1797,11 @@ void opcode_009a(const ScriptArguments& args, const ScriptPedType pedType, const
     character->applyOffset();
     character->setLifetime(GameObject::MissionLifetime);
 
+    script::clearSpaceForObject(args, character);
+
     if (args.getThread()->isMission) {
         script::addObjectToMissionCleanup(args, character);
     }
-
-    /// @todo track object mission status
 }
 
 /**
@@ -1946,6 +1946,8 @@ void opcode_00a5(const ScriptArguments& args, const ScriptModelID model, ScriptV
     vehicle = args.getWorld()->createVehicle(model, coord);
     vehicle->applyOffset();
     vehicle->setLifetime(GameObject::MissionLifetime);
+
+    script::clearSpaceForObject(args, vehicle);
 
     if (args.getThread()->isMission) {
         script::addObjectToMissionCleanup(args, vehicle);
@@ -5035,7 +5037,6 @@ void opcode_01c4(const ScriptArguments& args, const ScriptObject object) {
     @arg character Character/ped
 */
 void opcode_01c5(const ScriptArguments& args, const ScriptCharacter character) {
-    RW_UNUSED(args);
     script::removeObjectFromMissionCleanup(args, character);
 }
 
@@ -5046,7 +5047,6 @@ void opcode_01c5(const ScriptArguments& args, const ScriptCharacter character) {
     @arg vehicle Car/vehicle
 */
 void opcode_01c6(const ScriptArguments& args, const ScriptVehicle vehicle) {
-    RW_UNUSED(args);
     script::removeObjectFromMissionCleanup(args, vehicle);
 }
 
@@ -5057,7 +5057,6 @@ void opcode_01c6(const ScriptArguments& args, const ScriptVehicle vehicle) {
     @arg object Object
 */
 void opcode_01c7(const ScriptArguments& args, const ScriptObject object) {
-    RW_UNUSED(args);
     script::removeObjectFromMissionCleanup(args, object);
 }
 

--- a/rwengine/src/script/modules/GTA3ModuleImpl.inl
+++ b/rwengine/src/script/modules/GTA3ModuleImpl.inl
@@ -916,6 +916,7 @@ void opcode_0053(const ScriptArguments& args, const ScriptInt index, ScriptVec3 
     character->applyOffset();
     player = static_cast<ai::PlayerController*>(character->controller);
     args.getState()->playerObject = character->getGameObjectID();
+    script::clearSpaceForObject(args, character);
 }
 
 /**
@@ -940,9 +941,9 @@ void opcode_0054(const ScriptArguments& args, const ScriptPlayer player, ScriptF
     @arg coord Coordinates
 */
 void opcode_0055(const ScriptArguments& args, const ScriptPlayer player, ScriptVec3 coord) {
-    RW_UNUSED(args);
     player->getCharacter()->setPosition(coord);
     player->getCharacter()->applyOffset();
+    script::clearSpaceForObject(args, player->getCharacter());
 }
 
 /**
@@ -1889,7 +1890,7 @@ void opcode_00a0(const ScriptArguments& args, const ScriptCharacter character, S
 */
 void opcode_00a1(const ScriptArguments& args, const ScriptCharacter character, ScriptVec3 coord) {
     script::setObjectPosition(character, coord);
-    RW_UNUSED(args);
+    script::clearSpaceForObject(args, character);
 }
 
 /**
@@ -2024,8 +2025,8 @@ void opcode_00aa(const ScriptArguments& args, const ScriptVehicle vehicle, Scrip
     @arg coord Coordinates
 */
 void opcode_00ab(const ScriptArguments& args, const ScriptVehicle vehicle, ScriptVec3 coord) {
-    RW_UNUSED(args);
     script::setObjectPosition(vehicle, coord);
+    script::clearSpaceForObject(args, vehicle);
 }
 
 /**
@@ -4919,8 +4920,8 @@ void opcode_01bb(const ScriptArguments& args, const ScriptObject object, ScriptF
     @arg coord Coordinates
 */
 void opcode_01bc(const ScriptArguments& args, const ScriptObject object, ScriptVec3 coord) {
-    RW_UNUSED(args);
     script::setObjectPosition(object, coord);
+    script::clearSpaceForObject(args, object);
 }
 
 /**
@@ -9609,9 +9610,9 @@ void opcode_0361(const ScriptArguments& args, const ScriptGarage garage) {
 */
 void opcode_0362(const ScriptArguments& args, const ScriptCharacter character,
                  ScriptVec3 coord) {
-    RW_UNUSED(args);
     character->setCurrentVehicle(nullptr, 0);
     character->setPosition(coord);
+    script::clearSpaceForObject(args, character);
 }
 
 /**
@@ -9963,6 +9964,7 @@ void opcode_0376(const ScriptArguments& args, ScriptVec3 coord,
         pedGroup.at(args.getWorld()->getRandomNumber(0u, pedGroup.size() - 1));
     character = world->createPedestrian(model, coord);
     character->applyOffset();
+    script::clearSpaceForObject(args, character);
 }
 
 /**


### PR DESCRIPTION
Unreferenced objects should be erased if a script is creating an object that would intersect with it.

This fixes the current issue with the intro where 8-ball and the Kuruma are duplicated.