### PR TITLE
Cleanup Atomic & Clump usage

### DIFF
--- a/rwcore/data/Clump.cpp
+++ b/rwcore/data/Clump.cpp
@@ -118,6 +118,7 @@ ClumpPtr Clump::clone() const {
     auto newroot = rootframe_->cloneHierarchy();
     auto clump = std::make_shared<Clump>();
     clump->setFrame(newroot);
+    clump->boundingRadius = boundingRadius;
 
     // This isn't the most optimal implementation, but this code is likely
     // to be replaced soon.

--- a/rwcore/data/Clump.cpp
+++ b/rwcore/data/Clump.cpp
@@ -82,10 +82,10 @@ ModelFramePtr ModelFrame::cloneHierarchy() const {
     return self;
 }
 
-AtomicPtr Atomic::clone() const {
+AtomicPtr Atomic::clone(const ModelFramePtr& newFrame) const {
     auto newatomic = std::make_shared<Atomic>();
     newatomic->setGeometry(getGeometry());
-    newatomic->setFrame(getFrame());
+    newatomic->setFrame(newFrame ? newFrame : getFrame());
     newatomic->setFlags(getFlags());
     return newatomic;
 }

--- a/rwcore/data/Clump.hpp
+++ b/rwcore/data/Clump.hpp
@@ -234,7 +234,7 @@ public:
         }
     }
 
-    AtomicPtr clone() const;
+    AtomicPtr clone(const ModelFramePtr& newFrame = {}) const;
 };
 
 /**

--- a/rwengine/src/dynamics/CollisionInstance.cpp
+++ b/rwengine/src/dynamics/CollisionInstance.cpp
@@ -21,30 +21,21 @@
 #include "objects/GameObject.hpp"
 #include "objects/VehicleInfo.hpp"
 
-class GameObjectMotionState : public btMotionState {
-public:
-    GameObjectMotionState(GameObject* object) : m_object(object) {
-    }
+void GameObjectMotionState::getWorldTransform(btTransform& tform) const {
+    auto& position = m_object->getPosition();
+    auto& rotation = m_object->getRotation();
+    tform.setOrigin(btVector3(position.x, position.y, position.z));
+    tform.setRotation(
+        btQuaternion(rotation.x, rotation.y, rotation.z, rotation.w));
+}
 
-    void getWorldTransform(btTransform& tform) const override {
-        auto& position = m_object->getPosition();
-        auto& rotation = m_object->getRotation();
-        tform.setOrigin(btVector3(position.x, position.y, position.z));
-        tform.setRotation(
-            btQuaternion(rotation.x, rotation.y, rotation.z, rotation.w));
-    }
-
-    void setWorldTransform(const btTransform& tform) override {
-        auto& o = tform.getOrigin();
-        auto r = tform.getRotation();
-        glm::vec3 position(o.x(), o.y(), o.z());
-        glm::quat rotation(r.w(), r.x(), r.y(), r.z());
-        m_object->updateTransform(position, rotation);
-    }
-
-private:
-    GameObject* m_object;
-};
+void GameObjectMotionState::setWorldTransform(const btTransform& tform) {
+    auto& o = tform.getOrigin();
+    auto r = tform.getRotation();
+    glm::vec3 position(o.x(), o.y(), o.z());
+    glm::quat rotation(r.w(), r.x(), r.y(), r.z());
+    m_object->updateTransform(position, rotation);
+}
 
 CollisionInstance::~CollisionInstance() {
     if (m_body) {

--- a/rwengine/src/dynamics/CollisionInstance.hpp
+++ b/rwengine/src/dynamics/CollisionInstance.hpp
@@ -4,16 +4,29 @@
 #include <memory>
 #include <vector>
 
+#include <btBulletDynamicsCommon.h>
+
 class btCollisionShape;
 class btCompoundShape;
-class btMotionState;
-class btRigidBody;
 class btTriangleIndexVertexArray;
 struct CollisionModel;
 
 class GameObject;
 struct DynamicObjectData;
 struct VehicleHandlingInfo;
+
+class GameObjectMotionState : public btMotionState {
+public:
+    explicit GameObjectMotionState(GameObject* object) : m_object(object) {
+    }
+
+    void getWorldTransform(btTransform& tform) const override;
+
+    void setWorldTransform(const btTransform& tform) override;
+
+private:
+    GameObject* m_object;
+};
 
 /**
  * @brief CollisionInstance stores bullet body information

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -227,7 +227,7 @@ CutsceneObject* GameWorld::createCutsceneObject(const uint16_t id,
     if (id == 0) {
         auto playerobj = pedestrianPool.find(state->playerObject);
         if (playerobj) {
-            model = playerobj->getModel();
+            model = playerobj->getClump();
         }
     }
 
@@ -1050,7 +1050,7 @@ GameWorld::findOverlappingObjects(const glm::vec3 &center,
     auto checkObjects = [&](const auto& objects) {
         for (auto& p : objects) {
             const auto& object = p.second.get();
-            auto objectBounds = object->getModel()->getBoundingRadius();
+            auto objectBounds = object->getClump()->getBoundingRadius();
             if (glm::distance(center, object->getPosition()) <
                 radius + objectBounds) {
                 overlapping.push_back(object);

--- a/rwengine/src/engine/Garage.cpp
+++ b/rwengine/src/engine/Garage.cpp
@@ -38,7 +38,7 @@ Garage::Garage(GameWorld* engine_, size_t id_, const glm::vec3& coord0,
     for (const auto& p : engine->instancePool.objects) {
         const auto inst = static_cast<InstanceObject*>(p.second.get());
 
-        if (!inst->getModel()) {
+        if (!inst->getClump()) {
             continue;
         }
 

--- a/rwengine/src/engine/Payphone.cpp
+++ b/rwengine/src/engine/Payphone.cpp
@@ -16,7 +16,7 @@ Payphone::Payphone(GameWorld* engine_, size_t id_, const glm::vec2& coord)
     // Find payphone object, original game does this differently
     for (const auto& p : engine->instancePool.objects) {
         auto o = p.second.get();
-        if (!o->getModel()) {
+        if (!o->getClump()) {
             continue;
         }
         if (o->getModelInfo<BaseModelInfo>()->name != "phonebooth1") {

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -43,9 +43,8 @@ CharacterObject::CharacterObject(GameWorld* engine, const glm::vec3& pos,
                                  ai::CharacterController* controller)
     : GameObject(engine, pos, rot, modelinfo), controller(controller) {
     auto info = getModelInfo<PedModelInfo>();
-    setClump(info->getModel()->clone());
     if (info->getModel()) {
-        setModel(info->getModel());
+        setModel(info->getModel()->clone());
         animator = std::make_unique<Animator>(getClump());
 
         createActor();
@@ -70,7 +69,7 @@ void CharacterObject::createActor(const glm::vec2& size) {
     }
 
     // Don't create anything without a valid model.
-    if (getModel()) {
+    if (getClump()) {
         btTransform tf;
         tf.setIdentity();
         tf.setOrigin(btVector3(position.x, position.y, position.z));

--- a/rwengine/src/objects/CharacterObject.hpp
+++ b/rwengine/src/objects/CharacterObject.hpp
@@ -53,7 +53,7 @@ class GameWorld;
  * @brief The CharacterObject struct
  * Implements Character object behaviours.
  */
-class CharacterObject final : public GameObject, public ClumpObject {
+class CharacterObject final : public GameObject {
 private:
     CharacterState currentState{};
 

--- a/rwengine/src/objects/CutsceneObject.cpp
+++ b/rwengine/src/objects/CutsceneObject.cpp
@@ -10,12 +10,11 @@ CutsceneObject::CutsceneObject(GameWorld *engine, const glm::vec3 &pos,
                                BaseModelInfo *modelinfo)
     : GameObject(engine, pos, rot, modelinfo) {
     if (model) {
-        setModel(model);
+        setModel(model->clone());
     }
     else {
-        setModel(getModelInfo<ClumpModelInfo>()->getModel());
+        setModel(getModelInfo<ClumpModelInfo>()->getModel()->clone());
     }
-    setClump(getModel()->clone());
     animator = std::make_unique<Animator>(getClump());
 }
 

--- a/rwengine/src/objects/CutsceneObject.hpp
+++ b/rwengine/src/objects/CutsceneObject.hpp
@@ -12,7 +12,7 @@ class ModelFrame;
 /**
  * @brief Object type used for cutscene animations.
  */
-class CutsceneObject final : public GameObject, public ClumpObject {
+class CutsceneObject final : public GameObject {
     GameObject* _parent = nullptr;
     ModelFrame* _bone = nullptr;
 

--- a/rwengine/src/objects/GameObject.cpp
+++ b/rwengine/src/objects/GameObject.cpp
@@ -18,7 +18,7 @@ GameObject::~GameObject() {
 }
 
 void GameObject::setPosition(const glm::vec3& pos) {
-    _lastPosition = position = pos;
+    position = pos;
 }
 
 void GameObject::setRotation(const glm::quat& orientation) {
@@ -36,16 +36,7 @@ void GameObject::setHeading(float heading) {
     setRotation(quat);
 }
 
-glm::mat4 GameObject::getTimeAdjustedTransform(float alpha) const {
-    glm::mat4 t{1.0f};
-    t = glm::translate(t, glm::mix(_lastPosition, getPosition(), alpha));
-    t = t * glm::mat4_cast(glm::slerp(_lastRotation, getRotation(), alpha));
-    return t;
-}
-
 void GameObject::updateTransform(const glm::vec3& pos, const glm::quat& rot) {
-    _lastPosition = position;
-    _lastRotation = rotation;
     position = pos;
     rotation = rot;
 

--- a/rwengine/src/objects/GameObject.cpp
+++ b/rwengine/src/objects/GameObject.cpp
@@ -1,5 +1,7 @@
 #include "objects/GameObject.hpp"
 
+#include <data/Clump.hpp>
+
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtc/matrix_transform.hpp>
@@ -39,4 +41,22 @@ glm::mat4 GameObject::getTimeAdjustedTransform(float alpha) const {
     t = glm::translate(t, glm::mix(_lastPosition, getPosition(), alpha));
     t = t * glm::mat4_cast(glm::slerp(_lastRotation, getRotation(), alpha));
     return t;
+}
+
+void GameObject::updateTransform(const glm::vec3& pos, const glm::quat& rot) {
+    _lastPosition = position;
+    _lastRotation = rotation;
+    position = pos;
+    rotation = rot;
+
+    const auto& clump = getClump();
+    const auto& atomic = getAtomic();
+    if (clump) {
+        clump->getFrame()->setRotation(glm::mat3_cast(rot));
+        clump->getFrame()->setTranslation(pos);
+    }
+    if (atomic) {
+        atomic->getFrame()->setRotation(glm::mat3_cast(rot));
+        atomic->getFrame()->setTranslation(pos);
+    }
 }

--- a/rwengine/src/objects/GameObject.cpp
+++ b/rwengine/src/objects/GameObject.cpp
@@ -6,6 +6,9 @@
 
 #include "engine/Animator.hpp"
 
+const AtomicPtr GameObject::NullAtomic;
+const ClumpPtr GameObject::NullClump;
+
 GameObject::~GameObject() {
     if (modelinfo_) {
         modelinfo_->removeReference();

--- a/rwengine/src/objects/GameObject.hpp
+++ b/rwengine/src/objects/GameObject.hpp
@@ -2,6 +2,7 @@
 #define _RWENGINE_GAMEOBJECT_HPP_
 
 #include <limits>
+#include <variant>
 
 #include <glm/gtc/quaternion.hpp>
 #include <glm/vec3.hpp>
@@ -28,10 +29,11 @@ class GameObject {
 
     BaseModelInfo* modelinfo_;
 
-    /**
-     * Model used for rendering
-     */
-    ClumpPtr model_ = nullptr;
+    using Model = std::variant<AtomicPtr, ClumpPtr>;
+    Model model_;
+
+    static const AtomicPtr NullAtomic;
+    static const ClumpPtr NullClump;
 
 protected:
     void changeModelInfo(BaseModelInfo* next) {
@@ -92,16 +94,30 @@ public:
         return static_cast<T*>(modelinfo_);
     }
 
-    /**
-     * @return The model used in rendering
-     */
-    ClumpPtr getModel() const {
+    const Model& getModel() const {
         return model_;
     }
 
-    /**
-     * Changes the current model, used for re-dressing chars
-     */
+     const AtomicPtr& getAtomic() const {
+        if (auto atomic = std::get_if<AtomicPtr>(&model_))
+        {
+            return *atomic;
+        }
+        return NullAtomic;
+    }
+
+    const ClumpPtr& getClump() const {
+        if (auto clump = std::get_if<ClumpPtr>(&model_))
+        {
+            return *clump;
+        }
+        return NullClump;
+    }
+
+    void setModel(const AtomicPtr& model) {
+        model_ = model;
+    }
+
     void setModel(const ClumpPtr& model) {
         model_ = model;
     }
@@ -263,20 +279,6 @@ public:
 
 private:
     ObjectLifetime lifetime = GameObject::UnknownLifetime;
-};
-
-class ClumpObject {
-    ClumpPtr clump_;
-
-protected:
-    void setClump(const ClumpPtr& ptr) {
-        clump_ = ptr;
-    }
-
-public:
-    const ClumpPtr& getClump() const {
-        return clump_;
-    }
 };
 
 #endif  // __GAMEOBJECTS_HPP__

--- a/rwengine/src/objects/GameObject.hpp
+++ b/rwengine/src/objects/GameObject.hpp
@@ -23,8 +23,6 @@ class GameWorld;
  * tracking used to make tunnels work.
  */
 class GameObject {
-    glm::vec3 _lastPosition;
-    glm::quat _lastRotation;
     GameObjectID objectID = 0;
 
     BaseModelInfo* modelinfo_;
@@ -62,12 +60,7 @@ public:
 
     GameObject(GameWorld* engine, const glm::vec3& pos, const glm::quat& rot,
                BaseModelInfo* modelinfo)
-        : _lastPosition(pos)
-        , _lastRotation(rot)
-        , modelinfo_(modelinfo)
-        , position(pos)
-        , rotation(rot)
-        , engine(engine) {
+        : modelinfo_(modelinfo), position(pos), rotation(rot), engine(engine) {
         if (modelinfo_) {
             modelinfo_->addReference();
         }
@@ -148,9 +141,6 @@ public:
     const glm::vec3& getPosition() const {
         return position;
     }
-    const glm::vec3& getLastPosition() const {
-        return _lastPosition;
-    }
 
     const glm::quat& getRotation() const {
         return rotation;
@@ -228,17 +218,6 @@ public:
     }
 
     virtual void tick(float dt) = 0;
-
-    /**
-     * @brief Function used to modify the last transform
-     * @param newPos
-     */
-    void _updateLastTransform() {
-        _lastPosition = getPosition();
-        _lastRotation = getRotation();
-    }
-
-    glm::mat4 getTimeAdjustedTransform(float alpha) const;
 
     enum ObjectLifetime {
         /// lifetime has not been set

--- a/rwengine/src/objects/GameObject.hpp
+++ b/rwengine/src/objects/GameObject.hpp
@@ -270,12 +270,7 @@ public:
         }
     }
 
-    virtual void updateTransform(const glm::vec3& pos, const glm::quat& rot) {
-        _lastPosition = position;
-        _lastRotation = rotation;
-        position = pos;
-        rotation = rot;
-    }
+    void updateTransform(const glm::vec3& pos, const glm::quat& rot);
 
 private:
     ObjectLifetime lifetime = GameObject::UnknownLifetime;

--- a/rwengine/src/objects/InstanceObject.cpp
+++ b/rwengine/src/objects/InstanceObject.cpp
@@ -270,11 +270,3 @@ void InstanceObject::setSolid(bool solid) {
     }
     body->getBulletBody()->setCollisionFlags(flags);
 }
-
-void InstanceObject::updateTransform(const glm::vec3& pos,
-                                     const glm::quat& rot) {
-    position = pos;
-    rotation = rot;
-    getAtomic()->getFrame()->setRotation(glm::mat3_cast(rot));
-    getAtomic()->getFrame()->setTranslation(pos);
-}

--- a/rwengine/src/objects/InstanceObject.cpp
+++ b/rwengine/src/objects/InstanceObject.cpp
@@ -165,13 +165,8 @@ void InstanceObject::changeModel(BaseModelInfo* incoming, int atomicNumber) {
                   atomicNumber);
         auto atomic = getModelInfo<SimpleModelInfo>()->getAtomic(atomicNumber);
         if (atomic) {
-            auto previous = atomic_;
-            atomic_ = atomic->clone();
-            if (previous) {
-                atomic_->setFrame(previous->getFrame());
-            } else {
-                atomic_->setFrame(std::make_shared<ModelFrame>());
-            }
+            const auto frame = atomic_ ? atomic_->getFrame() : std::make_shared<ModelFrame>();
+            atomic_ = atomic->clone(frame);
         }
 
         if (collision) {

--- a/rwengine/src/objects/InstanceObject.hpp
+++ b/rwengine/src/objects/InstanceObject.hpp
@@ -86,8 +86,6 @@ public:
     float getHealth() const {
         return health;
     }
-
-    void updateTransform(const glm::vec3& pos, const glm::quat& rot) override;
 };
 
 #endif

--- a/rwengine/src/objects/PickupObject.cpp
+++ b/rwengine/src/objects/PickupObject.cpp
@@ -271,6 +271,11 @@ PickupObject::PickupObject(GameWorld* world, const glm::vec3& position,
 
     setEnabled(true);
     setCollected(false);
+
+    auto modelData = getModelInfo<SimpleModelInfo>();
+    auto atomic = modelData->getAtomic(0)->clone();
+    atomic->setFrame(std::make_shared<ModelFrame>());
+    setModel(std::move(atomic));
 }
 
 PickupObject::~PickupObject() {

--- a/rwengine/src/objects/PickupObject.cpp
+++ b/rwengine/src/objects/PickupObject.cpp
@@ -273,9 +273,7 @@ PickupObject::PickupObject(GameWorld* world, const glm::vec3& position,
     setCollected(false);
 
     auto modelData = getModelInfo<SimpleModelInfo>();
-    auto atomic = modelData->getAtomic(0)->clone();
-    atomic->setFrame(std::make_shared<ModelFrame>());
-    setModel(std::move(atomic));
+    setModel(modelData->getAtomic(0)->clone(std::make_shared<ModelFrame>()));
     updateTransform(getPosition(), getRotation());
 }
 

--- a/rwengine/src/objects/PickupObject.cpp
+++ b/rwengine/src/objects/PickupObject.cpp
@@ -276,6 +276,7 @@ PickupObject::PickupObject(GameWorld* world, const glm::vec3& position,
     auto atomic = modelData->getAtomic(0)->clone();
     atomic->setFrame(std::make_shared<ModelFrame>());
     setModel(std::move(atomic));
+    updateTransform(getPosition(), getRotation());
 }
 
 PickupObject::~PickupObject() {
@@ -318,6 +319,12 @@ void PickupObject::tick(float dt) {
         glm::vec4(red / 255.f, green / 255.f, blue / 255.f, 1.f) * colourValue;
 
     if (m_enabled) {
+        static constexpr float kRotationSpeedCoeff = 3.0f;
+        updateTransform(
+            getPosition(),
+            glm::angleAxis(engine->getGameTime() * kRotationSpeedCoeff,
+                           glm::vec3(0.f, 0.f, 1.f)));
+
         // Sort out interactions with things that may or may not be players.
         btManifoldArray manifoldArray;
         btBroadphasePairArray& pairArray =

--- a/rwengine/src/objects/ProjectileObject.cpp
+++ b/rwengine/src/objects/ProjectileObject.cpp
@@ -158,6 +158,12 @@ ProjectileObject::ProjectileObject(GameWorld* world, const glm::vec3& position,
             _ghostBody.get(), btBroadphaseProxy::SensorTrigger,
             btBroadphaseProxy::AllFilter);
     }
+
+    const auto& modelData = world->data->findModelInfo<SimpleModelInfo>(
+        getProjectileInfo().weapon->modelID);
+    auto atomic = modelData->getAtomic(0)->clone();
+    atomic->setFrame(std::make_shared<ModelFrame>());
+    setModel(std::move(atomic));
 }
 
 ProjectileObject::~ProjectileObject() {

--- a/rwengine/src/objects/ProjectileObject.cpp
+++ b/rwengine/src/objects/ProjectileObject.cpp
@@ -117,8 +117,9 @@ void ProjectileObject::cleanup() {
 
 ProjectileObject::ProjectileObject(GameWorld* world, const glm::vec3& position,
                                    const ProjectileObject::ProjectileInfo& info)
-    : GameObject(world, position, glm::quat{1.0f,0.0f,0.0f,0.0f}, nullptr)
-    , _info(info) {
+    : GameObject(world, position, glm::quat{1.0f, 0.0f, 0.0f, 0.0f}, nullptr)
+    , _info(info)
+    , _motionState(this) {
     _shape = std::make_unique<btSphereShape>(0.45f);
     btVector3 inertia(0.f, 0.f, 0.f);
     _shape->calculateLocalInertia(1.f, inertia);
@@ -130,6 +131,7 @@ ProjectileObject::ProjectileObject(GameWorld* world, const glm::vec3& position,
     ws.setOrigin(btVector3(position.x, position.y, position.z));
     riginfo.m_startWorldTransform = ws;
     riginfo.m_mass = 1.f;
+    riginfo.m_motionState = &_motionState;
 
     _body = std::make_unique<btRigidBody>(riginfo);
     _body->setUserPointer(this);
@@ -172,12 +174,6 @@ ProjectileObject::~ProjectileObject() {
 
 void ProjectileObject::tick(float dt) {
     if (_body == nullptr) return;
-
-    auto& bttr = _body->getWorldTransform();
-    position = {bttr.getOrigin().x(), bttr.getOrigin().y(),
-                bttr.getOrigin().z()};
-    auto r = bttr.getRotation();
-    rotation = {r.x(), r.y(), r.z(), r.w()};
 
     _info.time -= dt;
 

--- a/rwengine/src/objects/ProjectileObject.cpp
+++ b/rwengine/src/objects/ProjectileObject.cpp
@@ -163,9 +163,7 @@ ProjectileObject::ProjectileObject(GameWorld* world, const glm::vec3& position,
 
     const auto& modelData = world->data->findModelInfo<SimpleModelInfo>(
         getProjectileInfo().weapon->modelID);
-    auto atomic = modelData->getAtomic(0)->clone();
-    atomic->setFrame(std::make_shared<ModelFrame>());
-    setModel(std::move(atomic));
+    setModel(modelData->getAtomic(0)->clone(std::make_shared<ModelFrame>()));
 }
 
 ProjectileObject::~ProjectileObject() {

--- a/rwengine/src/objects/ProjectileObject.hpp
+++ b/rwengine/src/objects/ProjectileObject.hpp
@@ -1,13 +1,12 @@
 #ifndef _RWENGINE_PROJECTILEOBJECT_HPP_
 #define _RWENGINE_PROJECTILEOBJECT_HPP_
 
+#include <dynamics/CollisionInstance.hpp>
 #include <objects/GameObject.hpp>
 #include "render/VisualFX.hpp"
 
-
 class GameWorld;
 class btPairCachingGhostObject;
-class btRigidBody;
 class btSphereShape;
 struct WeaponData;
 
@@ -50,6 +49,8 @@ private:
 
     /** Used for RPGs and Molotov collision detection */
     std::unique_ptr<btPairCachingGhostObject> _ghostBody;
+
+    GameObjectMotionState _motionState;
 
     bool _exploded = false;
 

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -173,8 +173,7 @@ VehicleObject::VehicleObject(GameWorld* engine, const glm::vec3& pos,
         wheelsRotation.push_back(0.f);
     }
 
-    setModel(getVehicle()->getModel());
-    setClump(getModelInfo<VehicleModelInfo>()->getModel()->clone());
+    setModel(getVehicle()->getModel()->clone());
     setupModel();
 }
 

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -309,14 +309,6 @@ void VehicleObject::setRotation(const glm::quat& orientation) {
     GameObject::setRotation(orientation);
 }
 
-void VehicleObject::updateTransform(const glm::vec3& pos,
-                                    const glm::quat& rot) {
-    position = pos;
-    rotation = rot;
-    getClump()->getFrame()->setRotation(glm::mat3_cast(rot));
-    getClump()->getFrame()->setTranslation(pos);
-}
-
 void VehicleObject::setExtraEnabled(size_t extra, bool enabled) {
     auto atomic = extras_.at(extra);
     if (!atomic) {

--- a/rwengine/src/objects/VehicleObject.hpp
+++ b/rwengine/src/objects/VehicleObject.hpp
@@ -106,8 +106,6 @@ public:
 
     glm::vec3 getCenterOffset() override;
 
-    void updateTransform(const glm::vec3& pos, const glm::quat& rot) override;
-
     VehicleModelInfo* getVehicle() const {
         return getModelInfo<VehicleModelInfo>();
     }

--- a/rwengine/src/objects/VehicleObject.hpp
+++ b/rwengine/src/objects/VehicleObject.hpp
@@ -39,7 +39,7 @@ struct btVehicleRaycaster;
  * @class VehicleObject
  * Implements Vehicle behaviours.
  */
-class VehicleObject final : public GameObject, public ClumpObject {
+class VehicleObject final : public GameObject {
 private:
     float steerAngle{0.f};
     float throttle{0.f};

--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -349,7 +349,12 @@ RenderList GameRenderer::createObjectRenderList(const GameWorld *world) {
         if (blip.second.target > 0) {
             auto object = world->getBlipTarget(blip.second);
             if (object) {
-                model = object->getTimeAdjustedTransform(_renderAlpha);
+                auto& clump = object->getClump();
+                auto& atomic = object->getAtomic();
+                if (clump)
+                    model = clump->getFrame()->getWorldTransform();
+                else if (atomic)
+                    model = atomic->getFrame()->getWorldTransform();
             }
         } else {
             model = translate(model, blip.second.coord);

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -307,14 +307,8 @@ void ObjectRenderer::renderVehicle(VehicleObject* vehicle,
 
 void ObjectRenderer::renderPickup(PickupObject* pickup, RenderList& outList) {
     if (!pickup->isEnabled()) return;
-    
-    static constexpr float kRotationSpeedCoeff = 3.0f;
-    glm::mat4 modelMatrix =
-        glm::translate(glm::mat4(1.0f), pickup->getPosition());
-    modelMatrix = glm::rotate(modelMatrix, m_world->getGameTime() * kRotationSpeedCoeff,
-                              glm::vec3(0.f, 0.f, 1.f));
     const auto& atomic = pickup->getAtomic();
-    renderAtomic(atomic.get(), modelMatrix, nullptr, outList);
+    renderAtomic(atomic.get(), glm::mat4(1.f), nullptr, outList);
 }
 
 void ObjectRenderer::renderCutsceneObject(CutsceneObject* cutscene,

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -339,9 +339,8 @@ void ObjectRenderer::renderCutsceneObject(CutsceneObject* cutscene,
 
 void ObjectRenderer::renderProjectile(ProjectileObject* projectile,
                                       RenderList& outList) {
-    glm::mat4 modelMatrix = projectile->getTimeAdjustedTransform(m_renderAlpha);
     const auto& atomic = projectile->getAtomic();
-    renderAtomic(atomic.get(), modelMatrix, nullptr, outList);
+    renderAtomic(atomic.get(), glm::mat4(1.0f), nullptr, outList);
 }
 
 void ObjectRenderer::buildRenderList(GameObject* object, RenderList& outList) {

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -313,14 +313,8 @@ void ObjectRenderer::renderPickup(PickupObject* pickup, RenderList& outList) {
         glm::translate(glm::mat4(1.0f), pickup->getPosition());
     modelMatrix = glm::rotate(modelMatrix, m_world->getGameTime() * kRotationSpeedCoeff,
                               glm::vec3(0.f, 0.f, 1.f));
-
-    auto odata = pickup->getModelInfo<SimpleModelInfo>();
-
-    RW_CHECK(odata, "Failed to read modelinfo for Pickup");
-
-    auto atomic = odata->getAtomic(0);
-
-    renderAtomic(atomic, modelMatrix, nullptr, outList);
+    const auto& atomic = pickup->getAtomic();
+    renderAtomic(atomic.get(), modelMatrix, nullptr, outList);
 }
 
 void ObjectRenderer::renderCutsceneObject(CutsceneObject* cutscene,
@@ -346,14 +340,8 @@ void ObjectRenderer::renderCutsceneObject(CutsceneObject* cutscene,
 void ObjectRenderer::renderProjectile(ProjectileObject* projectile,
                                       RenderList& outList) {
     glm::mat4 modelMatrix = projectile->getTimeAdjustedTransform(m_renderAlpha);
-
-    auto odata = m_world->data->findModelInfo<SimpleModelInfo>(
-        projectile->getProjectileInfo().weapon->modelID);
-
-    RW_CHECK(odata, "Failed to read modelinfo");
-
-    auto atomic = odata->getAtomic(0);
-    renderAtomic(atomic, modelMatrix, nullptr, outList);
+    const auto& atomic = projectile->getAtomic();
+    renderAtomic(atomic.get(), modelMatrix, nullptr, outList);
 }
 
 void ObjectRenderer::buildRenderList(GameObject* object, RenderList& outList) {

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -365,11 +365,9 @@ void ObjectRenderer::buildRenderList(GameObject* object, RenderList& outList) {
         case GameObject::Character:
             renderCharacter(static_cast<CharacterObject*>(object), outList);
             break;
-            ;
         case GameObject::Vehicle:
             renderVehicle(static_cast<VehicleObject*>(object), outList);
             break;
-            ;
         case GameObject::Pickup:
             renderPickup(static_cast<PickupObject*>(object), outList);
             break;

--- a/rwengine/src/script/ScriptFunctions.hpp
+++ b/rwengine/src/script/ScriptFunctions.hpp
@@ -219,9 +219,9 @@ ScriptModel getModel(const ScriptArguments& args, ScriptModel model);
 
 inline void clearSpaceForObject(const ScriptArguments& args,
                                 GameObject* object) {
-    RW_ASSERT(object->getModel());
+    RW_ASSERT(object->getClump());
 
-    auto radius = object->getModel()->getBoundingRadius();
+    auto radius = object->getClump()->getBoundingRadius();
 
     const auto& overlapping = args.getWorld()->findOverlappingObjects(
         object->getPosition(), radius);

--- a/rwengine/src/script/modules/GTA3ModuleImpl.inl
+++ b/rwengine/src/script/modules/GTA3ModuleImpl.inl
@@ -10900,7 +10900,7 @@ void opcode_03b6(const ScriptArguments& args, ScriptVec3 coord, const ScriptFloa
 
     for(auto& p : args.getWorld()->instancePool.objects) {
         auto o = p.second.get();
-    	if( !o->getModel() ) continue;
+    	if( !o->getClump() ) continue;
     	if( o->getModelInfo<BaseModelInfo>()->name != oldmodel ) continue;
     	float d = glm::distance(coord, o->getPosition());
     	if( d < radius ) {

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -605,7 +605,6 @@ void RWGame::tickObjects(float dt) const {
         RW_PROFILE_SCOPEC("allObjects", MP_HOTPINK1);
         RW_PROFILE_COUNTER_SET("tickObjects/allObjects", world->allObjects.size());
         for (auto &object : world->allObjects) {
-            object->_updateLastTransform();
             object->tick(dt);
         }
     }

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -448,7 +448,7 @@ const ViewCamera& IngameState::getCamera(float alpha) {
 
     if (target->type() == GameObject::Vehicle) {
         auto vehicle = static_cast<VehicleObject*>(target);
-        auto model = vehicle->getModel();
+        auto model = vehicle->getClump();
         auto maxDist = model->getBoundingRadius() * 2.f;
         viewDistance = viewDistance + maxDist;
         lookTargetPosition.z += (vehicle->info->handling.dimensions.z * 0.5f);

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -439,7 +439,7 @@ const ViewCamera& IngameState::getCamera(float alpha) {
     bool lookright = held(GameInputState::LookRight);
     btCollisionObject* physTarget = player->getCharacter()->physObject.get();
 
-    auto targetTransform = target->getTimeAdjustedTransform(alpha);
+    auto targetTransform = target->getClump()->getFrame()->getWorldTransform();
 
     glm::vec3 targetPosition(targetTransform[3]);
     glm::vec3 lookTargetPosition(targetPosition);

--- a/rwviewer/ViewerWidget.cpp
+++ b/rwviewer/ViewerWidget.cpp
@@ -230,8 +230,8 @@ void ViewerWidget::showObject(quint16 item) {
 
     RW_CHECK(_object != nullptr, "Dummy Object is null");
 
-    if (_object->getModel()) {
-        auto objectRadius = _object->getModel()->getBoundingRadius();
+    if (_object->getClump()) {
+        auto objectRadius = _object->getClump()->getBoundingRadius();
         viewDistance = objectRadius * 2;
         viewAngles.x = glm::radians(-45.f);
         viewAngles.y = glm::radians(22.5f);

--- a/tests/test_Character.cpp
+++ b/tests/test_Character.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(test_activities) {
         VehicleObject* vehicle = Global::get().e->createVehicle(
             90u, glm::vec3(10.f, 0.f, 0.f), glm::quat{1.0f,0.0f,0.0f,0.0f});
         BOOST_REQUIRE(vehicle != nullptr);
-        BOOST_REQUIRE(vehicle->getModel() != nullptr);
+        BOOST_REQUIRE(vehicle->getClump() != nullptr);
 
         auto character = Global::get().e->createPedestrian(1, {0.f, 0.f, 0.f});
         BOOST_REQUIRE(character != nullptr);

--- a/tests/test_Vehicle.cpp
+++ b/tests/test_Vehicle.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(vehicle_parts) {
         Global::get().e->createVehicle(90u, glm::vec3(), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
     BOOST_REQUIRE(vehicle);
-    BOOST_REQUIRE(vehicle->getModel());
+    BOOST_REQUIRE(vehicle->getClump());
 
     VehicleObject::Part* part = vehicle->getPart("bonnet_dummy");
 
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(vehicle_part_vis) {
         Global::get().e->createVehicle(90u, glm::vec3(), glm::quat{1.0f,0.0f,0.0f,0.0f});
 
     BOOST_REQUIRE(vehicle);
-    BOOST_REQUIRE(vehicle->getModel());
+    BOOST_REQUIRE(vehicle->getClump());
 
     VehicleObject::Part* bonnetpart = vehicle->getPart("bonnet_dummy");
 

--- a/tests/test_Weapon.cpp
+++ b/tests/test_Weapon.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(TestDoWeaponScan, DATA_TEST_PREDICATE) {
         // Test RADIUS scan
         auto character = Global::get().e->createPedestrian(1, {0.f, 0.f, 0.f});
         BOOST_REQUIRE(character != nullptr);
-        BOOST_REQUIRE(character->getModel() != nullptr);
+        BOOST_REQUIRE(character->getClump() != nullptr);
         BOOST_REQUIRE(character->physObject != nullptr);
 
         WeaponScan scan(10.f, {0.f, 0.f, 10.f}, {0.f, 0.f, -10.f});


### PR DESCRIPTION
- GameObjects now have either an Atomic or a Clump
- The transform of this object is updated to reflect where the object should be
- Accidentally fixed the player having the wrong model in the intro