### PR TITLE
Use ImGui for debugging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/microprofile/microprofile"]
 	path = external/microprofile/microprofile
 	url = https://github.com/jonasmr/microprofile.git
+[submodule "imgui"]
+	path = external/imgui/imgui
+	url = https://github.com/ocornut/imgui.git

--- a/cmake_options.cmake
+++ b/cmake_options.cmake
@@ -6,7 +6,6 @@ option(BUILD_VIEWER "Build GUI data viewer")
 
 option(ENABLE_SCRIPT_DEBUG "Enable verbose script execution")
 option(ENABLE_PROFILING "Enable detailed profiling metrics")
-option(ENABLE_IMGUI "Enable imgui plugin")
 
 option(TEST_DATA "Enable tests that require game data")
 

--- a/cmake_options.cmake
+++ b/cmake_options.cmake
@@ -6,6 +6,7 @@ option(BUILD_VIEWER "Build GUI data viewer")
 
 option(ENABLE_SCRIPT_DEBUG "Enable verbose script execution")
 option(ENABLE_PROFILING "Enable detailed profiling metrics")
+option(ENABLE_IMGUI "Enable imgui plugin")
 
 option(TEST_DATA "Enable tests that require game data")
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,3 +1,7 @@
 if(ENABLE_PROFILING)
   add_subdirectory(microprofile)
 endif()
+
+if(ENABLE_IMGUI)
+  add_subdirectory(imgui)
+endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -2,6 +2,4 @@ if(ENABLE_PROFILING)
   add_subdirectory(microprofile)
 endif()
 
-if(ENABLE_IMGUI)
-  add_subdirectory(imgui)
-endif()
+add_subdirectory(imgui)

--- a/external/imgui/CMakeLists.txt
+++ b/external/imgui/CMakeLists.txt
@@ -1,0 +1,58 @@
+add_library(imgui EXCLUDE_FROM_ALL
+    rw_imconfig.h
+    imgui/imgui.h
+    imgui/imgui.cpp
+    imgui/imgui_demo.cpp
+    imgui/imgui_draw.cpp
+    imgui/imgui_internal.h
+    imgui/imgui_widgets.cpp
+    imgui/imstb_rectpack.h
+    imgui/imstb_textedit.h
+    imgui/imstb_truetype.h
+)
+
+target_include_directories(imgui SYSTEM
+    PUBLIC
+        "${CMAKE_CURRENT_LIST_DIR}/imgui"
+)
+
+target_compile_definitions(imgui
+    PUBLIC
+        IMGUI_USER_CONFIG="${CMAKE_CURRENT_SOURCE_DIR}/rw_imconfig.h"
+)
+
+add_library(imgui::core ALIAS imgui)
+
+openrw_target_apply_options(
+    TARGET imgui
+)
+
+add_library(imgui_sdl_gl3 EXCLUDE_FROM_ALL
+    imgui/examples/imgui_impl_opengl3.h
+    imgui/examples/imgui_impl_opengl3.cpp
+    imgui/examples/imgui_impl_sdl.h
+    imgui/examples/imgui_impl_sdl.cpp
+)
+
+target_include_directories(imgui_sdl_gl3 SYSTEM
+    PUBLIC
+        "${CMAKE_CURRENT_LIST_DIR}/imgui/examples"
+)
+
+target_link_libraries(imgui_sdl_gl3
+    PUBLIC
+        imgui::core
+        SDL2::SDL2
+)
+
+# FIXME: extract gl loader to target + add property to get header
+target_compile_definitions(imgui_sdl_gl3
+    PRIVATE
+        "IMGUI_IMPL_OPENGL_LOADER_CUSTOM=\"${OpenRW_SOURCE_DIR}/rwcore/gl/gl_core_3_3.h\""
+)
+
+add_library(imgui::sdl_gl3 ALIAS imgui_sdl_gl3)
+
+openrw_target_apply_options(
+    TARGET imgui_sdl_gl3
+)

--- a/external/imgui/CMakeLists.txt
+++ b/external/imgui/CMakeLists.txt
@@ -21,6 +21,11 @@ target_compile_definitions(imgui
         IMGUI_USER_CONFIG="${CMAKE_CURRENT_SOURCE_DIR}/rw_imconfig.h"
 )
 
+target_link_libraries(imgui
+    PUBLIC
+        openrw::checks
+)
+
 add_library(imgui::core ALIAS imgui)
 
 openrw_target_apply_options(

--- a/external/imgui/rw_imconfig.h
+++ b/external/imgui/rw_imconfig.h
@@ -1,0 +1,9 @@
+#ifndef RW_IMCONFIG_H
+#define RW_IMCONFIG_H
+
+// Disable imgui assertions when not in debug mode
+#ifndef RW_DEBUG
+#define IM_ASSERT(MSG) //FIXME(madebr): remove comment
+#endif
+
+#endif // RW_IMCONFIG_H

--- a/rwengine/src/render/ViewCamera.hpp
+++ b/rwengine/src/render/ViewCamera.hpp
@@ -19,7 +19,7 @@ public:
         , rotation(rot) {
     }
 
-    glm::mat4 getView() {
+    glm::mat4 getView() const {
         auto up = rotation * glm::vec3(0.f, 0.f, 1.f);
         return glm::lookAt(position,
                            position + rotation * glm::vec3(1.f, 0.f, 0.f), up);

--- a/rwengine/src/render/ViewFrustum.cpp
+++ b/rwengine/src/render/ViewFrustum.cpp
@@ -3,7 +3,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
-glm::mat4 ViewFrustum::projection() {
+glm::mat4 ViewFrustum::projection() const {
     return glm::perspective(fov / aspectRatio, aspectRatio, near, far);
 }
 

--- a/rwengine/src/render/ViewFrustum.hpp
+++ b/rwengine/src/render/ViewFrustum.hpp
@@ -27,7 +27,7 @@ public:
         : near(near), far(far), fov(fov), aspectRatio(aspect) {
     }
 
-    glm::mat4 projection();
+    glm::mat4 projection() const;
 
     void update(const glm::mat4& proj);
 

--- a/rwgame/CMakeLists.txt
+++ b/rwgame/CMakeLists.txt
@@ -15,6 +15,9 @@ add_library(librwgame STATIC
     GameWindow.hpp
     GameWindow.cpp
 
+    RWImGui.cpp
+    RWImGui.hpp
+
     HUDDrawer.hpp
     HUDDrawer.cpp
     MenuSystem.hpp
@@ -67,6 +70,18 @@ target_link_libraries(librwgame
         Boost::program_options
         SDL2::SDL2
     )
+
+if(ENABLE_IMGUI)
+    target_compile_definitions(librwgame
+        PUBLIC
+            RW_IMGUI
+        )
+
+    target_link_libraries(librwgame
+        PUBLIC
+            imgui::sdl_gl3
+        )
+endif()
 
 add_executable(rwgame
     main.cpp

--- a/rwgame/CMakeLists.txt
+++ b/rwgame/CMakeLists.txt
@@ -71,17 +71,15 @@ target_link_libraries(librwgame
         SDL2::SDL2
     )
 
-if(ENABLE_IMGUI)
-    target_compile_definitions(librwgame
-        PUBLIC
-            RW_IMGUI
-        )
+target_compile_definitions(librwgame
+    PUBLIC
+        RW_IMGUI
+    )
 
-    target_link_libraries(librwgame
-        PUBLIC
-            imgui::sdl_gl3
-        )
-endif()
+target_link_libraries(librwgame
+    PUBLIC
+        imgui::sdl_gl3
+    )
 
 add_executable(rwgame
     main.cpp

--- a/rwgame/GameBase.cpp
+++ b/rwgame/GameBase.cpp
@@ -20,7 +20,7 @@ GameBase::GameBase(Logger &inlog, const std::optional<RWArgConfigLayer> &args) :
     bool fullscreen = config.fullscreen();
     size_t w = config.width(), h = config.height();
 
-    if (SDL_Init(SDL_INIT_VIDEO) < 0)
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) < 0)
         throw std::runtime_error("Failed to initialize SDL2!");
 
     window.create(kWindowTitle + " [" + kBuildStr + "]", w, h, fullscreen);

--- a/rwgame/GameWindow.hpp
+++ b/rwgame/GameWindow.hpp
@@ -5,8 +5,9 @@
 #include <SDL_video.h>
 
 #include <glm/vec2.hpp>
-
 #include <string>
+#include <tuple>
+#include <SDL.h>
 
 class GameWindow {
     SDL_Window* window = nullptr;
@@ -29,6 +30,10 @@ public:
 
     bool isOpen() const {
         return !!window;
+    }
+
+    std::tuple<SDL_Window *, SDL_GLContext> getSDLContext() {
+        return std::make_tuple(window, glcontext);
     }
 };
 

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -22,6 +22,16 @@
 #include <chrono>
 
 class RWGame final : public GameBase {
+public:
+    enum class DebugViewMode {
+        Disabled,
+        General,
+        Physics,
+        Navigation,
+        Objects
+    };
+
+private:
     GameData data;
     GameRenderer renderer;
     RWImGui imgui;
@@ -39,14 +49,6 @@ class RWGame final : public GameBase {
 
     bool inFocus = true;
     ViewCamera currentCam;
-
-    enum class DebugViewMode {
-        Disabled,
-        General,
-        Physics,
-        Navigation,
-        Objects
-    };
 
     DebugViewMode debugview_ = DebugViewMode::Disabled;
     int lastDraws{0};  /// Number of draws issued for the last frame.
@@ -92,6 +94,10 @@ public:
         return hudDrawer;
     }
 
+    DebugViewMode getDebugViewMode() const {
+        return debugview_;
+    }
+
     bool hitWorldRay(glm::vec3& hit, glm::vec3& normal,
                      GameObject** object = nullptr);
 
@@ -112,9 +118,7 @@ private:
     void tick(float dt);
     void render(float alpha, float dt);
 
-    void renderDebugStats(float time);
-    void renderDebugPaths(float time);
-    void renderDebugObjects(float time, ViewCamera& camera);
+    void renderDebugPaths();
 
     void handleCheatInput(char symbol);
 
@@ -124,7 +128,7 @@ private:
 
     float tickWorld(const float deltaTime, float accumulatedTime);
 
-    void renderDebugView(float time, ViewCamera &viewCam);
+    void renderDebugView();
 
     void tickObjects(float dt) const;
 };

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -3,6 +3,8 @@
 
 #include "GameBase.hpp"
 #include "HUDDrawer.hpp"
+#include "RWConfig.hpp"
+#include "RWImGui.hpp"
 #include "StateManager.hpp"
 #include "game.hpp"
 
@@ -22,6 +24,7 @@
 class RWGame final : public GameBase {
     GameData data;
     GameRenderer renderer;
+    RWImGui imgui;
     DebugDraw debug;
     GameState state;
     HUDDrawer hudDrawer{};

--- a/rwgame/RWImGui.cpp
+++ b/rwgame/RWImGui.cpp
@@ -1,5 +1,9 @@
 #include "RWImGui.hpp"
 
+#include <ai/CharacterController.hpp>
+#include <objects/CharacterObject.hpp>
+#include <objects/VehicleObject.hpp>
+
 #ifdef RW_IMGUI
 
 #include "RWGame.hpp"
@@ -8,7 +12,125 @@
 #include <imgui_impl_sdl.h>
 #include <imgui_impl_opengl3.h>
 
+#include <glm/glm.hpp>
+
 #include <gl/gl_core_3_3.h>
+#include <glm/gtx/norm.hpp>
+
+namespace {
+void WindowDebugStats(RWGame& game) {
+    auto& io = ImGui::GetIO();
+
+    auto time_ms = 1000.0f / io.Framerate;
+    constexpr size_t average_every_frame = 240;
+    static float times[average_every_frame];
+    static size_t times_index = 0;
+    static double time_average = 0, time_min = 0, time_max = 0;
+    times[times_index++] = time_ms;
+    if (times_index >= average_every_frame) {
+        times_index = 0;
+        time_average = 0;
+        time_min = std::numeric_limits<double>::max();
+        time_max = std::numeric_limits<double>::lowest();
+
+        for (double time : times) {
+            time_average += time;
+            time_min = std::min(time, time_min);
+            time_max = std::max(time, time_max);
+        }
+        time_average /= average_every_frame;
+    }
+
+    const auto& world = game.getWorld();
+    auto& renderer = game.getRenderer();
+
+    ImGui::SetNextWindowPos({20.f, 20.f});
+    ImGui::Begin("Engine Information", nullptr,
+                 ImGuiWindowFlags_NoDecoration |
+                     ImGuiWindowFlags_NoSavedSettings |
+                     ImGuiWindowFlags_NoInputs);
+    ImGui::Text("%.3f ms/frame (%.1f FPS)\n%.3f / %.3f / %.3f ms",
+                static_cast<double>(1000.0f / io.Framerate),
+                static_cast<double>(io.Framerate), time_average, time_min,
+                time_max);
+    ImGui::Text("Timescale %.2f",
+                static_cast<double>(world->state->basic.timeScale));
+    ImGui::Text("%i Drawn %lu Culled", renderer.getRenderer().getDrawCount(),
+                renderer.getCulledCount());
+    ImGui::Text("%i Textures %i Buffers",
+                renderer.getRenderer().getTextureCount(),
+                renderer.getRenderer().getBufferCount());
+    ImGui::End();
+}
+
+void WindowDebugObjects(RWGame& game, const ViewCamera& camera) {
+    auto& data = game.getGameData();
+    auto world = game.getWorld();
+
+    ImGui::SetNextWindowPos({20.f, 20.f});
+    ImGui::Begin("Object Information", nullptr,
+                 ImGuiWindowFlags_NoDecoration |
+                     ImGuiWindowFlags_NoSavedSettings |
+                     ImGuiWindowFlags_NoInputs);
+    ImGui::Text("%lu Models", data.modelinfo.size());
+    ImGui::Text("Dynamic Objects\n %lu Vehicles\n %lu Peds",
+                world->vehiclePool.objects.size(),
+                world->pedestrianPool.objects.size());
+    ImGui::End();
+
+    // Render worldspace overlay for nearby objects
+    constexpr float kNearbyDistance = 25.f;
+    const auto& view = camera.position;
+    const auto& model = camera.getView();
+    const auto& proj = camera.frustum.projection();
+    const auto& size = game.getWindow().getSize();
+    glm::vec4 viewport(0.f, 0.f, size.x, size.y);
+    auto isnearby = [&](GameObject* o) {
+        return glm::distance2(o->getPosition(), view) <
+               kNearbyDistance * kNearbyDistance;
+    };
+    auto showdata = [&](GameObject* o, std::stringstream& ss) {
+        auto screen = glm::project(o->getPosition(), model, proj, viewport);
+        if (screen.z >= 1.f) {
+            return;
+        }
+        ImGui::SetNextWindowPos({screen.x, viewport.w - screen.y}, 0,
+                                {0.5f, 0.5f});
+        ImGui::Begin(
+            std::to_string(reinterpret_cast<uintptr_t>(o)).c_str(), nullptr,
+            ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings |
+                ImGuiWindowFlags_NoInputs);
+        ImGui::Text("%s", ss.str().c_str());
+        ImGui::End();
+    };
+
+    for (auto& p : world->vehiclePool.objects) {
+        if (!isnearby(p.second.get())) continue;
+        auto v = static_cast<VehicleObject*>(p.second.get());
+
+        std::stringstream ss;
+        ss << v->getVehicle()->vehiclename_ << "\n"
+           << (v->isFlipped() ? "Flipped" : "Upright") << "\n"
+           << (v->isStopped() ? "Stopped" : "Moving") << "\n"
+           << v->getVelocity() << "m/s\n";
+
+        showdata(v, ss);
+    }
+    for (auto& p : world->pedestrianPool.objects) {
+        if (!isnearby(p.second.get())) continue;
+        auto c = static_cast<CharacterObject*>(p.second.get());
+        const auto& state = c->getCurrentState();
+        auto act = c->controller->getCurrentActivity();
+
+        std::stringstream ss;
+        ss << "Health: " << state.health << " (" << state.armour << ")\n"
+           << (c->isAlive() ? "Alive" : "Dead") << "\n"
+           << "Activity: " << (act ? act->name() : "Idle") << "\n";
+
+        showdata(c, ss);
+    }
+}
+}  // namespace
 
 RWImGui::RWImGui(RWGame &game)
     : _game(game) {
@@ -39,7 +161,7 @@ void RWImGui::destroy() {
     _context = nullptr;
 }
 
-bool RWImGui::process_event(SDL_Event &event) {
+bool RWImGui::processEvent(SDL_Event& event) {
     if (!_context) {
         return false;
     }
@@ -49,27 +171,32 @@ bool RWImGui::process_event(SDL_Event &event) {
     return io.WantCaptureMouse || io.WantCaptureKeyboard;
 }
 
-void RWImGui::tick() {
+void RWImGui::startFrame() {
     if (!_context) {
         return;
     }
     ImGui::SetCurrentContext(_context);
-    auto& io = ImGui::GetIO();
 
     auto [window, sdl_glcontext] = _game.getWindow().getSDLContext();
 
     ImGui_ImplOpenGL3_NewFrame();
     ImGui_ImplSDL2_NewFrame(window);
     ImGui::NewFrame();
+}
 
-    static float f = 0.0f;
+void RWImGui::endFrame(const ViewCamera& camera) {
+    switch (_game.getDebugViewMode()) {
+        case RWGame::DebugViewMode::General:
+            WindowDebugStats(_game);
+            break;
+        case RWGame::DebugViewMode::Objects:
+            WindowDebugObjects(_game, camera);
+            break;
+        default:
+            break;
+    }
 
-    ImGui::Begin("Hello, world!");
-    ImGui::Text("Hello, world!");
-    ImGui::SliderFloat("float", &f, 0.0f, 1.0f);
-    ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", static_cast<double>(1000.0f / io.Framerate), static_cast<double>(io.Framerate));   ImGui::End();
-
-    static bool show_demo_window = true;
+    static bool show_demo_window = false;
     if (show_demo_window) {
         ImGui::ShowDemoWindow(&show_demo_window);
     }

--- a/rwgame/RWImGui.cpp
+++ b/rwgame/RWImGui.cpp
@@ -4,8 +4,6 @@
 #include <objects/CharacterObject.hpp>
 #include <objects/VehicleObject.hpp>
 
-#ifdef RW_IMGUI
-
 #include "RWGame.hpp"
 
 #include <imgui.h>
@@ -204,24 +202,3 @@ void RWImGui::endFrame(const ViewCamera& camera) {
     ImGui::Render();
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 }
-
-#else
-
-RWImGui::RWImGui(RWGame &game)
-    : _game(game) {
-}
-
-RWImGui::~RWImGui() {
-    destroy();
-}
-
-RWImGui::init(SDL_Window *window, SDL_GLContext context) {
-}
-
-RWImGui::destroy() {
-}
-
-RWImGui::process_event(SDL_Event &event) {
-}
-
-#endif

--- a/rwgame/RWImGui.cpp
+++ b/rwgame/RWImGui.cpp
@@ -56,8 +56,7 @@ void RWImGui::tick() {
     ImGui::SetCurrentContext(_context);
     auto& io = ImGui::GetIO();
 
-    SDL_Window *window;
-    std::tie(window, std::ignore) = _game.getWindow().getSDLContext();
+    auto [window, sdl_glcontext] = _game.getWindow().getSDLContext();
 
     ImGui_ImplOpenGL3_NewFrame();
     ImGui_ImplSDL2_NewFrame(window);
@@ -77,82 +76,6 @@ void RWImGui::tick() {
 
     ImGui::Render();
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
-}
-
-static ImGuiIO *g_io;
-
-static SDL_Window *g_sdl_window;
-static SDL_GLContext g_sdl_gl_context;
-
-
-void imgui_init(SDL_Window *sdl_window, SDL_GLContext sdl_gl_context) {
-    IMGUI_CHECKVERSION();
-    ImGui::CreateContext();
-    g_io = &ImGui::GetIO();
-
-    g_sdl_window = sdl_window;
-    g_sdl_gl_context = sdl_gl_context;
-
-    ImGui_ImplSDL2_InitForOpenGL(sdl_window, sdl_gl_context);
-    ImGui_ImplOpenGL3_Init("#version 150");
-
-//    ImGui::StyleColorsDark();
-//    ImGui::StyleColorsClassic();
-    ImGui::StyleColorsLight();
-
-
-    // Build atlas
-    unsigned char* tex_pixels = NULL;
-    int tex_w, tex_h;
-    g_io->Fonts->GetTexDataAsRGBA32(&tex_pixels, &tex_w, &tex_h);
-}
-
-void imgui_process_event(SDL_Event *event, bool *mouse, bool *keyboard) {
-    ImGui_ImplSDL2_ProcessEvent(event);
-    *mouse = g_io->WantCaptureMouse;
-    *keyboard = g_io->WantCaptureKeyboard;
-}
-
-static bool show_demo_window = true;
-
-void imgui_tick() {
-    ImGui_ImplOpenGL3_NewFrame();
-    ImGui_ImplSDL2_NewFrame(g_sdl_window);
-    ImGui::NewFrame();
-
-//    g_io->DisplaySize = ImVec2(1920, 1080);
-//    g_io->DeltaTime = 1.0f / 60.0f;
-
-    static float f = 0.0f;
-
-    ImGui::Begin("Hello, world!");
-    ImGui::Text("Hello, world!");
-    ImGui::SliderFloat("float", &f, 0.0f, 1.0f);
-    ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", static_cast<double>(1000.0f / g_io->Framerate), static_cast<double>(g_io->Framerate));
-    ImGui::End();
-
-    if (show_demo_window) {
-        ImGui::ShowDemoWindow(&show_demo_window);
-    }
-
-//    ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
-
-    ImGui::Render();
-//    SDL_GL_MakeCurrent(g_sdl_window, g_sdl_gl_context);
-//    glViewport(0, 0, static_cast<int>(g_io->DisplaySize.x), static_cast<int>(g_io->DisplaySize.y));
-//    glClearColor(clear_color.x, clear_color.y, clear_color.z, clear_color.w);
-//    glClear(GL_COLOR_BUFFER_BIT);
-    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
-//    SDL_GL_SwapWindow(g_sdl_window);
-}
-
-void imgui_destroy() {
-    ImGui_ImplOpenGL3_Shutdown();
-    ImGui_ImplSDL2_Shutdown();
-    ImGui::DestroyContext();
-    g_io = nullptr;
-    g_sdl_gl_context = nullptr;
-    g_sdl_window = nullptr;
 }
 
 #else

--- a/rwgame/RWImGui.cpp
+++ b/rwgame/RWImGui.cpp
@@ -1,0 +1,177 @@
+#include "RWImGui.hpp"
+
+#ifdef RW_IMGUI
+
+#include "RWGame.hpp"
+
+#include <imgui.h>
+#include <imgui_impl_sdl.h>
+#include <imgui_impl_opengl3.h>
+
+#include <gl/gl_core_3_3.h>
+
+RWImGui::RWImGui(RWGame &game)
+    : _game(game) {
+}
+
+RWImGui::~RWImGui() {
+    destroy();
+}
+
+void RWImGui::init() {
+    IMGUI_CHECKVERSION();
+    _context = ImGui::CreateContext();
+
+    auto [window, context] = _game.getWindow().getSDLContext();
+
+    ImGui_ImplSDL2_InitForOpenGL(window, context);
+    ImGui_ImplOpenGL3_Init("#version 150");
+}
+
+void RWImGui::destroy() {
+    if (!_context) {
+        return;
+    }
+    ImGui::SetCurrentContext(_context);
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplSDL2_Shutdown();
+    ImGui::DestroyContext();
+    _context = nullptr;
+}
+
+bool RWImGui::process_event(SDL_Event &event) {
+    if (!_context) {
+        return false;
+    }
+    ImGui::SetCurrentContext(_context);
+    ImGui_ImplSDL2_ProcessEvent(&event);
+    auto& io = ImGui::GetIO();
+    return io.WantCaptureMouse || io.WantCaptureKeyboard;
+}
+
+void RWImGui::tick() {
+    if (!_context) {
+        return;
+    }
+    ImGui::SetCurrentContext(_context);
+    auto& io = ImGui::GetIO();
+
+    SDL_Window *window;
+    std::tie(window, std::ignore) = _game.getWindow().getSDLContext();
+
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplSDL2_NewFrame(window);
+    ImGui::NewFrame();
+
+    static float f = 0.0f;
+
+    ImGui::Begin("Hello, world!");
+    ImGui::Text("Hello, world!");
+    ImGui::SliderFloat("float", &f, 0.0f, 1.0f);
+    ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", static_cast<double>(1000.0f / io.Framerate), static_cast<double>(io.Framerate));   ImGui::End();
+
+    static bool show_demo_window = true;
+    if (show_demo_window) {
+        ImGui::ShowDemoWindow(&show_demo_window);
+    }
+
+    ImGui::Render();
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+}
+
+static ImGuiIO *g_io;
+
+static SDL_Window *g_sdl_window;
+static SDL_GLContext g_sdl_gl_context;
+
+
+void imgui_init(SDL_Window *sdl_window, SDL_GLContext sdl_gl_context) {
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    g_io = &ImGui::GetIO();
+
+    g_sdl_window = sdl_window;
+    g_sdl_gl_context = sdl_gl_context;
+
+    ImGui_ImplSDL2_InitForOpenGL(sdl_window, sdl_gl_context);
+    ImGui_ImplOpenGL3_Init("#version 150");
+
+//    ImGui::StyleColorsDark();
+//    ImGui::StyleColorsClassic();
+    ImGui::StyleColorsLight();
+
+
+    // Build atlas
+    unsigned char* tex_pixels = NULL;
+    int tex_w, tex_h;
+    g_io->Fonts->GetTexDataAsRGBA32(&tex_pixels, &tex_w, &tex_h);
+}
+
+void imgui_process_event(SDL_Event *event, bool *mouse, bool *keyboard) {
+    ImGui_ImplSDL2_ProcessEvent(event);
+    *mouse = g_io->WantCaptureMouse;
+    *keyboard = g_io->WantCaptureKeyboard;
+}
+
+static bool show_demo_window = true;
+
+void imgui_tick() {
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplSDL2_NewFrame(g_sdl_window);
+    ImGui::NewFrame();
+
+//    g_io->DisplaySize = ImVec2(1920, 1080);
+//    g_io->DeltaTime = 1.0f / 60.0f;
+
+    static float f = 0.0f;
+
+    ImGui::Begin("Hello, world!");
+    ImGui::Text("Hello, world!");
+    ImGui::SliderFloat("float", &f, 0.0f, 1.0f);
+    ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", static_cast<double>(1000.0f / g_io->Framerate), static_cast<double>(g_io->Framerate));
+    ImGui::End();
+
+    if (show_demo_window) {
+        ImGui::ShowDemoWindow(&show_demo_window);
+    }
+
+//    ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
+
+    ImGui::Render();
+//    SDL_GL_MakeCurrent(g_sdl_window, g_sdl_gl_context);
+//    glViewport(0, 0, static_cast<int>(g_io->DisplaySize.x), static_cast<int>(g_io->DisplaySize.y));
+//    glClearColor(clear_color.x, clear_color.y, clear_color.z, clear_color.w);
+//    glClear(GL_COLOR_BUFFER_BIT);
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+//    SDL_GL_SwapWindow(g_sdl_window);
+}
+
+void imgui_destroy() {
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplSDL2_Shutdown();
+    ImGui::DestroyContext();
+    g_io = nullptr;
+    g_sdl_gl_context = nullptr;
+    g_sdl_window = nullptr;
+}
+
+#else
+
+RWImGui::RWImGui(RWGame &game)
+    : _game(game) {
+}
+
+RWImGui::~RWImGui() {
+    destroy();
+}
+
+RWImGui::init(SDL_Window *window, SDL_GLContext context) {
+}
+
+RWImGui::destroy() {
+}
+
+RWImGui::process_event(SDL_Event &event) {
+}
+
+#endif

--- a/rwgame/RWImGui.hpp
+++ b/rwgame/RWImGui.hpp
@@ -1,0 +1,21 @@
+#ifndef RWGAME_RWIMGUI_HPP
+#define RWGAME_RWIMGUI_HPP
+
+#include <SDL.h>
+
+class RWGame;
+struct ImGuiContext;
+
+class RWImGui {
+    RWGame &_game;
+    ImGuiContext *_context = nullptr;
+public:
+    RWImGui(RWGame &game);
+    ~RWImGui();
+    void init();
+    void destroy();
+    bool process_event(SDL_Event &event);
+    void tick();
+};
+
+#endif // RWGAME_RWIMGUI_HPP

--- a/rwgame/RWImGui.hpp
+++ b/rwgame/RWImGui.hpp
@@ -5,6 +5,7 @@
 
 class RWGame;
 struct ImGuiContext;
+class ViewCamera;
 
 class RWImGui {
     RWGame &_game;
@@ -14,8 +15,9 @@ public:
     ~RWImGui();
     void init();
     void destroy();
-    bool process_event(SDL_Event &event);
-    void tick();
+    bool processEvent(SDL_Event &event);
+    void startFrame();
+    void endFrame(const ViewCamera &);
 };
 
 #endif // RWGAME_RWIMGUI_HPP

--- a/rwgame/states/DebugState.hpp
+++ b/rwgame/states/DebugState.hpp
@@ -18,13 +18,13 @@ class DebugState final : public State {
     bool _sonicMode = false;
     bool _invertedY;
 
-    Menu createDebugMenu();
-    Menu createMapMenu();
-    Menu createVehicleMenu();
-    Menu createAIMenu();
-    Menu createWeaponMenu();
-    Menu createWeatherMenu();
-    Menu createMissionsMenu();
+    void drawDebugMenu();
+    void drawMapMenu();
+    void drawVehicleMenu();
+    void drawAIMenu();
+    void drawWeaponMenu();
+    void drawWeatherMenu();
+    void drawMissionsMenu();
 
 public:
     DebugState(RWGame* game, const glm::vec3& vp = {},

--- a/rwgame/states/LoadingState.cpp
+++ b/rwgame/states/LoadingState.cpp
@@ -28,15 +28,13 @@ void LoadingState::handleEvent(const SDL_Event& e) {
 }
 
 void LoadingState::draw(GameRenderer& r) {
-    static auto kLoadingString =
-        GameStringUtil::fromString("Loading...", FONT_ARIAL);
     // Display some manner of loading screen.
     TextRenderer::TextInfo ti;
-    ti.text = kLoadingString;
+    ti.text = GameStringUtil::fromString("Loading...", FONT_ARIAL);
     auto size = r.getRenderer().getViewport();
     ti.size = 25.f;
     ti.screenPosition = glm::vec2(50.f, size.y - ti.size - 50.f);
-    ti.font = FONT_PRICEDOWN;
+    ti.font = FONT_ARIAL;
     ti.baseColour = glm::u8vec3(255);
     r.text.renderText(ti);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TESTS
     Text
     TrafficDirector
     Vehicle
+    ViewCamera
     VisualFX
     Weapon
     World

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -3,6 +3,6 @@
 #include "test_Globals.hpp"
 
 std::ostream& operator<<(std::ostream& stream, const glm::vec3& v) {
-    stream << v.x << " " << v.y << " " << v.z;
+    stream << glm::to_string(v);
     return stream;
 }

--- a/tests/test_Globals.hpp
+++ b/tests/test_Globals.hpp
@@ -45,6 +45,12 @@ struct print_log_value<glm::vec3> {
         s << glm::to_string(v);
     }
 };
+template <>
+struct print_log_value<glm::vec4> {
+    void operator()(std::ostream& s, glm::vec4 const& v) {
+        s << glm::to_string(v);
+    }
+};
 BOOST_NS_MAGIC_CLOSING
 }
 }

--- a/tests/test_ViewCamera.cpp
+++ b/tests/test_ViewCamera.cpp
@@ -1,0 +1,26 @@
+#include <boost/test/unit_test.hpp>
+#include "test_Globals.hpp"
+#include <render/ViewCamera.hpp>
+
+namespace {
+
+struct CameraFixture {
+    ViewCamera camera_ {
+        {1.f, 2.f, 3.f}
+    };
+};
+}
+
+BOOST_AUTO_TEST_SUITE(ViewCameraTests)
+
+BOOST_FIXTURE_TEST_CASE(test_creation, CameraFixture) {
+    BOOST_CHECK_EQUAL(camera_.position, glm::vec3(1.f, 2.f, 3.f));
+}
+
+BOOST_FIXTURE_TEST_CASE(test_view_matrix, CameraFixture) {
+    const auto& view = camera_.getView();
+    BOOST_CHECK_EQUAL(view[3], glm::vec4(2.f, -3.f, 1.f, 1.f));
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
To simplify the code (and make it nicer to use)

- cherry-pick some commits from @madebr which adds ImGui
- Replace the debug view modes with ImGui windows
- Replace the debug tools menu with ImGui

Long-term, with imgui we can:-
- Provide a bootstrap phase to input game path, if we can't auto-detect it.
- Replace rwviewer with a lighter-weight in-game version.