### PR TITLE
Improve player vehicle exit logic

### DIFF
--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -505,6 +505,9 @@ bool Activities::EnterVehicle::update(CharacterObject *character,
 
 bool Activities::ExitVehicle::update(CharacterObject *character,
                                      CharacterController *controller) {
+    /// @todo Acitivty must be cancelled if the player lets go of the
+    /// the enter/exit vehicle key and the exit animation has not yet
+    /// started.
     RW_UNUSED(controller);
 
     if (jacked) {

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -492,14 +492,12 @@ bool CharacterObject::enterVehicle(VehicleObject* vehicle, size_t seat) {
             // enterAction(VehicleSit);
             return true;
         }
-    } else {
-        if (currentVehicle) {
-            currentVehicle->setOccupant(seat, nullptr);
-            // Disabled due to crashing.
-            // setPosition(currentVehicle->getPosition());
-            setCurrentVehicle(nullptr, 0);
-            return true;
-        }
+    } else if (currentVehicle) {
+        currentVehicle->setOccupant(seat, nullptr);
+        // Disabled due to crashing.
+        // setPosition(currentVehicle->getPosition());
+        setCurrentVehicle(nullptr, 0);
+        return true;
     }
     return false;
 }

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -726,7 +726,7 @@ void VehicleObject::setOccupant(size_t seat, GameObject* occupant) {
 }
 
 bool VehicleObject::canOccupantExit() const {
-    return getVelocity() <= kVehicleMaxExitVelocity;
+    return abs(getVelocity()) <= kVehicleMaxExitVelocity;
 }
 
 bool VehicleObject::isOccupantDriver(size_t seat) const {

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -406,6 +406,12 @@ void VehicleObject::tickPhysics(float dt) {
             }
         }
 
+        if (immobilised) {
+            // An immobilised car should not be able to move on it's own.
+            engineForce = 0.f;
+            brakeF = 5.f;
+        }
+
         for (int w = 0; w < physVehicle->getNumWheels(); ++w) {
             btWheelInfo& wi = physVehicle->getWheelInfo(w);
 
@@ -692,6 +698,14 @@ void VehicleObject::setHandbraking(bool hb) {
 
 bool VehicleObject::getHandbraking() const {
     return handbrake;
+}
+
+void VehicleObject::setImmobilised(bool immobile) {
+    immobilised = immobile;
+}
+
+bool VehicleObject::getImmobilised() const {
+    return immobilised;
 }
 
 void VehicleObject::ejectAll() {

--- a/rwengine/src/objects/VehicleObject.hpp
+++ b/rwengine/src/objects/VehicleObject.hpp
@@ -45,6 +45,7 @@ private:
     float throttle{0.f};
     float brake{0.f};
     bool handbrake = true;
+    bool immobilised = false;
     std::vector<btScalar> wheelsRotation;
 
     Atomic* chassishigh_ = nullptr;
@@ -146,6 +147,10 @@ public:
     void setHandbraking(bool);
 
     bool getHandbraking() const;
+
+    void setImmobilised(bool);
+
+    bool getImmobilised() const;
 
     void tick(float dt) override;
 

--- a/rwengine/src/script/ScriptMachine.cpp
+++ b/rwengine/src/script/ScriptMachine.cpp
@@ -133,7 +133,7 @@ void ScriptMachine::executeThread(SCMThread& t, int msPassed) {
                 if (a.type == SCMType::TString) {
                     printf(" %1x:'%s'", a.type, a.string);
                 } else if (a.type == SCMType::TFloat16) {
-                    printf(" %1x:%f", a.type, a.realValue());
+                    printf(" %1x:%f", a.type, static_cast<float>(a.realValue()));
                 } else {
                     printf(" %1x:%d", a.type, a.integerValue());
                 }

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -259,7 +259,7 @@ void IngameState::tick(float dt) {
         } else if (glm::length2(movement) > 0.001f) {
             if (player->isCurrentActivity(
                     ai::Activities::EnterVehicle::ActivityName)) {
-                // Give up entering a vehicle if we're alreadying doing so
+                // Give up entering a vehicle if we're already doing so
                 player->skipActivity();
             }
         }
@@ -267,6 +267,16 @@ void IngameState::tick(float dt) {
         if (player->getCharacter()->getCurrentVehicle()) {
             auto vehicle = player->getCharacter()->getCurrentVehicle();
             vehicle->setHandbraking(held(GameInputState::Handbrake));
+            if (player->isCurrentActivity(
+                    ai::Activities::ExitVehicle::ActivityName)) {
+                // The player cannot accelerate while exiting.
+                // He can, however, brake in the opposite direction of movement.
+                int velocitySign = vehicle->getVelocity() >= 0 ? 1 : -1;
+	            int movementSign = movement.x >= 0 ? 1 : -1;
+	            if (velocitySign == movementSign) {
+		            movement.x = 0;
+	            }
+            }
             player->setMoveDirection(movement);
         } else {
             if (pressed(GameInputState::Jump)) {


### PR DESCRIPTION
The player can now no longer accelerate whilst exiting a vehicle.
This prevents Claude from floating next to the vehicle if the player accelerates during the exit animation.
At the same time, this behaviour is closer to the exit vehicle behaviour in the actual game.