### PR TITLE
Improve player vehicle exit logic

### DIFF
--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -505,6 +505,9 @@ bool Activities::EnterVehicle::update(CharacterObject *character,
 
 bool Activities::ExitVehicle::update(CharacterObject *character,
                                      CharacterController *controller) {
+    /// @todo Acitivty must be cancelled if the player lets go of the
+    /// the enter/exit vehicle key and the exit animation has not yet
+    /// started.
     RW_UNUSED(controller);
 
     if (jacked) {

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -726,7 +726,7 @@ void VehicleObject::setOccupant(size_t seat, GameObject* occupant) {
 }
 
 bool VehicleObject::canOccupantExit() const {
-    return getVelocity() <= kVehicleMaxExitVelocity;
+    return abs(getVelocity()) <= kVehicleMaxExitVelocity;
 }
 
 bool VehicleObject::isOccupantDriver(size_t seat) const {

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -259,7 +259,7 @@ void IngameState::tick(float dt) {
         } else if (glm::length2(movement) > 0.001f) {
             if (player->isCurrentActivity(
                     ai::Activities::EnterVehicle::ActivityName)) {
-                // Give up entering a vehicle if we're alreadying doing so
+                // Give up entering a vehicle if we're already doing so
                 player->skipActivity();
             }
         }
@@ -267,6 +267,16 @@ void IngameState::tick(float dt) {
         if (player->getCharacter()->getCurrentVehicle()) {
             auto vehicle = player->getCharacter()->getCurrentVehicle();
             vehicle->setHandbraking(held(GameInputState::Handbrake));
+            if (player->isCurrentActivity(
+                    ai::Activities::ExitVehicle::ActivityName)) {
+                // The player cannot accelerate while exiting.
+                // He can, however, brake in the opposite direction of movement.
+                int velocitySign = vehicle->getVelocity() >= 0 ? 1 : -1;
+	            int movementSign = movement.x >= 0 ? 1 : -1;
+	            if (velocitySign == movementSign) {
+		            movement.x = 0;
+	            }
+            }
             player->setMoveDirection(movement);
         } else {
             if (pressed(GameInputState::Jump)) {

--- a/rwgame/states/IngameState.cpp
+++ b/rwgame/states/IngameState.cpp
@@ -272,10 +272,10 @@ void IngameState::tick(float dt) {
                 // The player cannot accelerate while exiting.
                 // He can, however, brake in the opposite direction of movement.
                 int velocitySign = vehicle->getVelocity() >= 0 ? 1 : -1;
-	            int movementSign = movement.x >= 0 ? 1 : -1;
-	            if (velocitySign == movementSign) {
-		            movement.x = 0;
-	            }
+                int movementSign = movement.x >= 0 ? 1 : -1;
+                if (velocitySign == movementSign) {
+                    movement.x = 0;
+                }
             }
             player->setMoveDirection(movement);
         } else {


### PR DESCRIPTION
The player can now no longer accelerate whilst exiting a vehicle.
This prevents Claude from floating next to the vehicle if the player accelerates during the exit animation.
At the same time, this behaviour is closer to the exit vehicle behaviour in the actual game.