### PR TITLE
cmake: FFmpeg: Fix regex for version detection

### DIFF
--- a/cmake/modules/FindFFmpeg.cmake
+++ b/cmake/modules/FindFFmpeg.cmake
@@ -68,7 +68,7 @@ endif()
 
 if(FFMPEG_INCLUDE_DIR)
     file(READ "${FFMPEG_INCLUDE_DIR}/libavutil/ffversion.h" __FFVERSION_H)
-    string(REGEX MATCH "#define[ ]+FFMPEG_VERSION[ ]+\"([0-9a-zA-Z\\.\\-]+)\"" _FFMPEG_VERSION "${__FFVERSION_H}")
+    string(REGEX MATCH "#define[ ]+FFMPEG_VERSION[ ]+\"([0-9a-zA-Z\\+\\.\\-]+)\"" _FFMPEG_VERSION "${__FFVERSION_H}")
     if(NOT _FFMPEG_VERSION)
         message(AUTHOR_WARNING "Cannot detect ffmpeg version: regex does not match")
     endif()


### PR DESCRIPTION
Fix regex to detect the "4.2.2-1+b1" version currently available on
Debian testing.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>