### PR TITLE
cmake: SDL2: Fix SDL2 headers detection

### DIFF
--- a/cmake/modules/FindSDL2.cmake
+++ b/cmake/modules/FindSDL2.cmake
@@ -70,12 +70,10 @@ find_path(SDL2_INCLUDE_DIR SDL.h
     HINTS
         $ENV{SDL2DIR}
     PATH_SUFFIXES
-        include/SDL2 include
+        SDL2
     PATHS
         ~/Library/Frameworks
         /Library/Frameworks
-        /usr/local/include/SDL2
-        /usr/include/SDL2
         /sw # Fink
         /opt/local # DarwinPorts
         /opt/csw # Blastwave


### PR DESCRIPTION
We are looking for the SDL.h file inside a SDL2 folder located in the
standard include paths, so the path suffix should be simply SDL2.

The /usr/local/include/SDL2 and /usr/include/SDL2 are standard paths
with the SDL2 suffix, so they can be dropped.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>