### PR TITLE
audio/SoundSource.hpp: Add missing include

### DIFF
--- a/rwengine/src/audio/SoundSource.hpp
+++ b/rwengine/src/audio/SoundSource.hpp
@@ -11,6 +11,7 @@ extern "C" {
 #include <cstdint>
 #include <future>
 #include <mutex>
+#include <vector>
 
 /// Structure for input data
 struct InputData {


### PR DESCRIPTION
Fix build on Debian testing by adding a missing <vector> include.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>