### PR TITLE
Improve file loading for .img files.

### DIFF
--- a/rwcore/loaders/LoaderIMG.cpp
+++ b/rwcore/loaders/LoaderIMG.cpp
@@ -1,53 +1,87 @@
-#include "loaders/LoaderIMG.hpp"
+#include <loaders/LoaderIMG.hpp>
 
-#include <boost/algorithm/string/predicate.hpp>
-#include <cstdio>
+#include <cassert>
+#include <cctype>
+#include <cstring>
+#include <algorithm>
 
-#include "rw/debug.hpp"
+#include <rw/debug.hpp>
+
+namespace {
+
+constexpr size_t kAssetRecordSize{2048};
+
+void to_lowercase_inplace(char* name) {
+    size_t len = std::strlen(name);
+
+    std::transform(
+        name, name+len, name,
+        [](char ch) -> char { return std::tolower(ch); }
+    );
+} // namespace
+
+}
 
 bool LoaderIMG::load(const rwfs::path& filepath) {
+    assert(m_archive.empty());
+    m_archive = filepath;
+
     auto dirPath = filepath;
     dirPath.replace_extension(".dir");
 
-    FILE* fp = fopen(dirPath.string().c_str(), "rb");
-    if (fp) {
-        fseek(fp, 0, SEEK_END);
-        unsigned long fileSize = ftell(fp);
-        fseek(fp, 0, SEEK_SET);
-
-        std::size_t expectedCount = fileSize / 32;
-        m_assets.resize(expectedCount);
-        std::size_t actualCount = fread(&m_assets[0], sizeof(LoaderIMGFile),
-                expectedCount, fp);
-
-        if (expectedCount != actualCount) {
-            m_assets.resize(actualCount);
-            RW_ERROR("Error reading records in IMG archive");
-        }
-
-        fclose(fp);
-        auto imgPath = filepath;
-        imgPath.replace_extension(".img");
-        m_archive = imgPath;
-        return true;
-    } else {
+    std::ifstream file(dirPath.string(), std::ios::binary);
+    if (!file.is_open()) {
+        RW_ERROR("Failed to open " + dirPath.string());
         return false;
     }
+
+    file.seekg(0, std::ios::end);
+    auto fileSize = file.tellg();
+    file.seekg(0);
+
+    std::size_t expectedCount = fileSize / sizeof(LoaderIMGFile);
+    m_assets.resize(expectedCount);
+
+    file.read(reinterpret_cast<char*>(m_assets.data()), expectedCount * sizeof(LoaderIMGFile));
+
+    if (file.fail() || file.gcount() != fileSize) {\
+        m_assets.resize(file.gcount() / sizeof(LoaderIMGFile));
+        RW_ERROR("Error reading records in IMG archive");
+    }
+
+    for (auto& asset : m_assets) {
+        to_lowercase_inplace(asset.name);
+    }
+
+    auto imgPath = filepath;
+    imgPath.replace_extension(".img");
+
+    m_archive_stream.open(imgPath.string(), std::ios::binary);
+    if (!m_archive_stream.is_open()) {
+        RW_ERROR("Failed to open " << imgPath.string());
+    }
+
+    return true;
 }
 
 /// Get the information of a asset in the examining archive
 bool LoaderIMG::findAssetInfo(const std::string& assetname,
                               LoaderIMGFile& out) {
-    for (auto &asset : m_assets) {
-        if (boost::iequals(asset.name, assetname)) {
+    for (const auto& asset : m_assets) {
+        if (assetname.compare(asset.name) == 0) {
             out = asset;
             return true;
         }
     }
+
     return false;
 }
 
 std::unique_ptr<char[]> LoaderIMG::loadToMemory(const std::string& assetname) {
+    if (!m_archive_stream.is_open()) {
+        return nullptr;
+    }
+
     LoaderIMGFile assetInfo;
     bool found = findAssetInfo(assetname, assetInfo);
 
@@ -56,50 +90,38 @@ std::unique_ptr<char[]> LoaderIMG::loadToMemory(const std::string& assetname) {
         return nullptr;
     }
 
-    auto imgName = m_archive;
+    std::streamsize asset_size = assetInfo.size * kAssetRecordSize;
+    auto raw_data = std::make_unique<char[]>(asset_size);
+    m_archive_stream.seekg(assetInfo.offset * kAssetRecordSize);
+    m_archive_stream.read(raw_data.get(), asset_size);
 
-    FILE* fp = fopen(imgName.string().c_str(), "rb");
-    if (fp) {
-        auto raw_data = std::make_unique<char[]>(assetInfo.size * 2048);
+    if (m_archive_stream.gcount() != asset_size) {
+        RW_ERROR("Error reading asset " << assetInfo.name);
+    }
 
-        fseek(fp, assetInfo.offset * 2048, SEEK_SET);
-        if (fread(raw_data.get(), 2048, assetInfo.size, fp) != assetInfo.size) {
-            RW_ERROR("Error reading asset " << assetInfo.name);
-        }
-
-        fclose(fp);
-        return raw_data;
-    } else
-        return nullptr;
+    return raw_data;
 }
 
 /// Writes the contents of assetname to filename
 bool LoaderIMG::saveAsset(const std::string& assetname,
                           const std::string& filename) {
     auto raw_data = loadToMemory(assetname);
-    if (!raw_data) return false;
-
-    FILE* dumpFile = fopen(filename.c_str(), "wb");
-    if (dumpFile) {
-        LoaderIMGFile asset;
-        if (findAssetInfo(assetname, asset)) {
-            fwrite(raw_data.get(), 2048, asset.size, dumpFile);
-            printf("=> IMG: Saved %s to disk with filename %s\n",
-                   assetname.c_str(), filename.c_str());
-        }
-        fclose(dumpFile);
-
-        return true;
-    } else {
+    if (!raw_data) {
         return false;
     }
-}
 
-/// Get the information of an asset by its index
-const LoaderIMGFile& LoaderIMG::getAssetInfoByIndex(size_t index) const {
-    return m_assets[index];
-}
+    LoaderIMGFile asset;
+    if (!findAssetInfo(assetname, asset)) {
+        return false;
+    }
 
-std::size_t LoaderIMG::getAssetCount() const {
-    return m_assets.size();
+    std::ofstream dump_file(filename, std::ios::binary);
+    if (!dump_file.is_open()) {
+        return false;
+    }
+
+    dump_file.write(raw_data.get(), kAssetRecordSize * asset.size);
+    RW_MESSAGE("Saved " << assetname << " to disk with filename " << filename);
+
+    return true;
 }

--- a/rwcore/loaders/LoaderIMG.hpp
+++ b/rwcore/loaders/LoaderIMG.hpp
@@ -20,6 +20,7 @@ public:
 /**
     \class LoaderIMG
     \brief Parses the structure of GTA .IMG archives and loads the files in it
+           Warning: loadToMemory() is thread-unsafe, refer to its description.
 */
 class LoaderIMG {
 public:
@@ -43,6 +44,10 @@ public:
 
     /// Load a file from the archive to memory and pass a pointer to it
     /// Warning: Returns nullptr if by any reason it can't load the file
+    //
+    /// Warning: CURRENTLY NOT THREADSAFE!
+    //           This method access/modifies m_archive_stream unconditionally,
+    //           be aware of that.
     std::unique_ptr<char[]> loadToMemory(const std::string& assetname);
 
     /// Writes the contents of assetname to filename

--- a/rwcore/loaders/LoaderIMG.hpp
+++ b/rwcore/loaders/LoaderIMG.hpp
@@ -2,9 +2,10 @@
 #define _LIBRW_LOADERIMG_HPP_
 
 #include <cstddef>
-#include <cstdint>
 #include <string>
 #include <vector>
+#include <memory>
+#include <fstream>
 
 #include <rw/filesystem.hpp>
 
@@ -32,11 +33,13 @@ public:
 
     /// Construct
     LoaderIMG() = default;
+    LoaderIMG(const LoaderIMG&) = delete;
+    LoaderIMG(LoaderIMG&&) noexcept = default;
 
     /// Load the structure of the archive
     /// Omit the extension in filename so both .dir and .img are loaded when
     /// appropriate
-    bool load(const rwfs::path& filename);
+    bool load(const rwfs::path& filepath);
 
     /// Load a file from the archive to memory and pass a pointer to it
     /// Warning: Returns nullptr if by any reason it can't load the file
@@ -49,10 +52,14 @@ public:
     bool findAssetInfo(const std::string& assetname, LoaderIMGFile& out);
 
     /// Get the information of an asset by its index
-    const LoaderIMGFile& getAssetInfoByIndex(size_t index) const;
+    const LoaderIMGFile& getAssetInfoByIndex(size_t index) const {
+        return m_assets[index];
+    }
 
     /// Returns the number of asset files in the archive
-    std::size_t getAssetCount() const;
+    std::size_t getAssetCount() const {
+        return m_assets.size();
+    }
 
     Version getVersion() const {
         return m_version;
@@ -61,8 +68,9 @@ public:
 private:
     Version m_version = GTAIIIVC;  ///< Version of this IMG archive
     rwfs::path m_archive;  ///< Path to the archive being used (no extension)
+    std::ifstream m_archive_stream; ///< File stream for archive
 
-    std::vector<LoaderIMGFile> m_assets;  ///< Asset info of the archive
+    std::vector<LoaderIMGFile> m_assets; ///< Asset info of the archive
 };
 
 #endif  // LoaderIMG_h__

--- a/rwcore/platform/FileIndex.hpp
+++ b/rwcore/platform/FileIndex.hpp
@@ -1,10 +1,13 @@
 #ifndef _LIBRW_FILEINDEX_HPP_
 #define _LIBRW_FILEINDEX_HPP_
 
-#include "rw/filesystem.hpp"
-#include "rw/forward.hpp"
-
 #include <unordered_map>
+#include <memory>
+
+#include <loaders/LoaderIMG.hpp>
+#include <rw/filesystem.hpp>
+#include <rw/forward.hpp>
+
 
 class FileIndex {
 public:
@@ -91,6 +94,11 @@ private:
      * @throws If this FileIndex has not indexed filePath
      */
     const IndexedData *getIndexedDataAt(const std::string &filePath) const;
+
+    /**
+     * @brief loaders_ Maps .img filepaths to its respective loader
+     */
+    std::unordered_map<std::string, LoaderIMG> loaders_;
 };
 
 #endif

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -41,7 +41,11 @@ GameData::GameData(Logger* log, const rwfs::path& path)
         });
 }
 
-void GameData::load() {
+bool GameData::load() {
+    if (!isValidGameDirectory()) {
+        return false;
+    }
+
     index.indexTree(datpath);
 
     loadIMG("models/gta3.img");
@@ -78,6 +82,8 @@ void GameData::load() {
 
     // Load ped groups after IDEs so they can resolve
     loadPedGroups("data/pedgrp.dat");
+
+    return true;
 }
 
 void GameData::loadLevelFile(const std::string& path) {
@@ -759,13 +765,11 @@ float GameData::getWaveHeightAt(const glm::vec3& ws) const {
            WATER_HEIGHT;
 }
 
-bool GameData::isValidGameDirectory(const rwfs::path& path) {
+bool GameData::isValidGameDirectory() const {
     rwfs::error_code ec;
-    if (!rwfs::is_directory(path, ec)) {
-        std::cerr << "first test failed\n";
+    if (!rwfs::is_directory(datpath, ec)) {
         return false;
     }
 
-    LoaderIMG i;
-    return i.load(path / "models/gta3.img");
+    return !ec;
 }

--- a/rwengine/src/engine/GameData.hpp
+++ b/rwengine/src/engine/GameData.hpp
@@ -112,7 +112,7 @@ public:
     void loadWaterpro(const std::string& path);
     void loadWater(const std::string& path);
 
-    void load();
+    bool load();
 
     /**
      * Loads model, placement, models and textures from a level file
@@ -359,10 +359,11 @@ public:
 
     GameTexts texts;
 
+private:
     /**
      * Determines whether the given path is a valid game directory.
      */
-    static bool isValidGameDirectory(const rwfs::path& path);
+    bool isValidGameDirectory() const;
 };
 
 #endif

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -72,16 +72,13 @@ RWGame::RWGame(Logger& log, const std::optional<RWArgConfigLayer> &args)
         benchFile = args->benchmarkPath;
     }
 
-    log.info("Game", "Game directory: " + config.gamedataPath());
+    imgui.init();
 
-    if (!GameData::isValidGameDirectory(config.gamedataPath())) {
+    log.info("Game", "Game directory: " + config.gamedataPath());
+    if (!data.load()) {
         throw std::runtime_error("Invalid game directory path: " +
                                  config.gamedataPath());
     }
-
-    imgui.init();
-
-    data.load();
 
     for (const auto& [specialModel, fileName, name] : kSpecialModels) {
         auto model = data.loadClump(fileName, name);

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -26,6 +26,7 @@
 #include <objects/VehicleObject.hpp>
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <chrono>
 #include <functional>
 #include <iomanip>
 #include <iostream>
@@ -59,6 +60,7 @@ RWGame::RWGame(Logger& log, const std::optional<RWArgConfigLayer> &args)
     RW_PROFILE_THREAD("Main");
     RW_TIMELINE_ENTER("Startup", MP_YELLOW);
 
+    auto loadTimeStart = std::chrono::steady_clock::now();
     bool newgame = false;
     bool test = false;
     std::optional<std::string> startSave;
@@ -126,6 +128,11 @@ RWGame::RWGame(Logger& log, const std::optional<RWArgConfigLayer> &args)
             stateManager.enter<MenuState>(this);
         }
     });
+
+    auto loadTimeEnd = std::chrono::steady_clock::now();
+    auto loadTime =
+        std::chrono::duration_cast<std::chrono::milliseconds>(loadTimeEnd - loadTimeStart);
+    log.info("Game", "Loading took " + std::to_string(loadTime.count()) + " ms");
 
     log.info("Game", "Started");
     RW_TIMELINE_LEAVE("Startup");
@@ -557,7 +564,7 @@ void RWGame::tick(float dt) {
             while (scriptTimerAccumulator >= timerClockRate) {
                 // Original game uses milliseconds
                 (*state.scriptTimerVariable) -= timerClockRate * 1000;
-		    
+
                 //                                11 seconds
                 if (*state.scriptTimerVariable <= 11000 &&
                     beepTime - *state.scriptTimerVariable >= 1000) {
@@ -565,7 +572,7 @@ void RWGame::tick(float dt) {
 
                     // @todo beep
                 }
-		    
+
                 if (*state.scriptTimerVariable <= 0) {
                     (*state.scriptTimerVariable) = 0;
                     state.scriptTimerVariable = nullptr;

--- a/rwviewer/models/IMGArchiveModel.hpp
+++ b/rwviewer/models/IMGArchiveModel.hpp
@@ -6,7 +6,7 @@
 class IMGArchiveModel : public QAbstractListModel {
     Q_OBJECT
 
-    LoaderIMG archive;
+    const LoaderIMG& archive;
 
 public:
     IMGArchiveModel(const LoaderIMG& archive, QObject* parent = 0)


### PR DESCRIPTION
Hi again!

So while working on openrw/debugging an issue, I really started to notice the significant loading time until being in-game.

I did some perf'ing and noticed that `LoaderIMG::load` was a pretty hot path and after digging a bit, I found out that `LoaderIMG::load` was called 3237(!) times with `models/gta3.img`.
That meant opening and reading the file and allocating memory for it each call.

I did some simple optimization, now each file is only loaded once by `LoaderIMG`, which resulted in a pretty nifty speedup. 
Also after these changes, `LoaderIMG::load` completely vanishes from the flamegraph.

On a hot file cache, loading on startup takes ~7600ms on `master` on my machine, after the changes it goes down to ~5100ms.
There might be even more loading time reduction on slower systems and/or spinning rust.

Only tested on Linux, so I’d much appreciate if someone could test this on Windows to check if really nothing breaks.