### PR TITLE
Fix Travis-CI builds and tests/Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,21 @@ matrix:
   - os: osx
     compiler: clang
     env: NAME="Apple macOS" NAME_SUFFIX="mac"
-    osx_image: xcode10.1
+    osx_image: xcode11.4
+    addons:
+      homebrew:
+        packages:
+          - boost
+          - cmake
+          - bullet
+          - ffmpeg
+          - glm
+          - openal-soft
+          - qt5
+          - sdl2
+          - jack
+          - freetype
     install:
-      - brew update
-      - /usr/bin/yes | pip2 uninstall numpy  # see https://github.com/travis-ci/travis-ci/issues/6688
-      - brew upgrade python
-      - brew upgrade
-      - brew install boost cmake bullet ffmpeg glm openal-soft qt5 sdl2 jack freetype
       - export PATH="/usr/local/opt/qt/bin:$PATH"
     script:
       - mkdir -p "$TRAVIS_BUILD_DIR/build"

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,6 +20,15 @@ class OpenrwConan(ConanFile):
         'profiling': True,
         'bullet3:shared': False,
         'sdl2:sdl2main': False,
+        'ffmpeg:bzlib': False,
+        'ffmpeg:lzma': False,
+        'ffmpeg:openjpeg': False,
+        'ffmpeg:openssl': False,
+        'ffmpeg:vorbis': False,
+        'ffmpeg:webp': False,
+        'ffmpeg:x264': False,
+        'ffmpeg:x265': False,
+        'ffmpeg:zlib': False,
     }
 
     generators = 'cmake',
@@ -29,19 +38,21 @@ class OpenrwConan(ConanFile):
 
     _rw_dependencies = {
         'game': (
-            'openal/1.19.0@bincrafters/stable',
+            'openal/1.19.1',
             'bullet3/2.87@bincrafters/stable',
             'glm/0.9.9.1@g-truc/stable',
-            'ffmpeg/4.0.2@bincrafters/stable',
+            'ffmpeg/4.2.1@bincrafters/stable',
             'sdl2/2.0.9@bincrafters/stable',
             'boost/1.68.0@conan/stable',
-            'bzip2/1.0.8@conan/stable',
+            'bzip2/1.0.8',
+            'zlib/1.2.11',
         ),
         'viewer': (
-            'qt/5.12.0@bincrafters/stable',
+            'qt/5.14.0@bincrafters/stable',
+            'glib/2.58.3@bincrafters/stable',
         ),
         'tools': (
-            'freetype/2.9.0@bincrafters/stable',
+            'freetype/2.10.1',
         ),
     }
 

--- a/scripts/docker/conan_base.docker
+++ b/scripts/docker/conan_base.docker
@@ -1,12 +1,13 @@
 FROM ubuntu:rolling
 
 RUN apt-get update \
-    && apt-get install --no-install-recommends --no-upgrade -y \
+    && DEBIAN_FRONTEND=noninteractive \
+       apt-get install --no-install-recommends --no-upgrade -y \
         build-essential \
         cmake \
         ninja-build \
-        gcc-7 \
-        g++-7 \
+        gcc \
+        g++ \
         clang-6.0 \
         llvm \
         lcov \
@@ -65,11 +66,6 @@ RUN apt-get update \
             # conan-sdl2 dependencies https://github.com/bincrafters/conan-sdl2/blob/stable/2.0.8/conanfile.py\
             libxinerama-dev \
             libxkbcommon-dev \
-    && apt-get clean \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 60 \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 \
-    && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-7 60
-
-# RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 50 --slave /usr/bin/g++ g++ /usr/bin/g++-8
+    && apt-get clean
 
 CMD [ /bin/bash ]

--- a/scripts/docker/ubuntu_latest.docker
+++ b/scripts/docker/ubuntu_latest.docker
@@ -1,7 +1,8 @@
 FROM ubuntu:rolling
 
 RUN apt-get update \
-    && apt-get install --no-install-recommends --no-upgrade -y \
+    && DEBIAN_FRONTEND=noninteractive \
+       apt-get install --no-install-recommends --no-upgrade -y \
         build-essential \
         cmake \
         ninja-build \


### PR DESCRIPTION
After sending in my latest PR, I noticed that our travis-ci was failing for three builds.
I did some investigating to fix those issues, pretty much just some regularly maintenance work was done.
One probably noteworthy thing is that I disabled some features of ffmpeg for the conan build - we don't use most of the codecs anyway and since ffmpeg needs to be build from source, this should speed up the CI rebuilds.
Especially RFC for the conan changes, it's my first time working with it.


Additionally, while compile-testing I noticed that `tests/test_Config.cpp` was failing to compile with `FILESYSTEM_LIBRARY` set to `CXX17` due to boost not adhering to the standards specification completely, and `unique_path` not being supported in CXX17's std::filesystem due to security concerns, so I replicated the functionality in some other way.

While working on this, I wondered if it still makes sense to support the `FILESYSTEM_LIBRARY=CXXTS` configuration? This implementation has been pretty much abandoned with recent compilers and even fails to compile on `master`.