### PR TITLE
Fixes compatibility with newer ffmpeg versions.

### DIFF
--- a/rwengine/src/audio/SoundSource.cpp
+++ b/rwengine/src/audio/SoundSource.cpp
@@ -121,7 +121,7 @@ bool SoundSource::findAudioStream(const std::filesystem::path& filePath) {
     }
 
     audioStream = formatContext->streams[streamIndex];
-    auto codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
+    codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
     return true;
 }
 

--- a/rwengine/src/audio/SoundSource.cpp
+++ b/rwengine/src/audio/SoundSource.cpp
@@ -121,7 +121,7 @@ bool SoundSource::findAudioStream(const std::filesystem::path& filePath) {
     }
 
     audioStream = formatContext->streams[streamIndex];
-    codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
+    auto codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
     return true;
 }
 
@@ -148,7 +148,7 @@ bool SoundSource::findAudioStreamSfx() {
     }
 
     audioStream = formatContext->streams[streamIndex];
-    codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
+    auto codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
 
     return true;
 }

--- a/rwengine/src/audio/SoundSource.cpp
+++ b/rwengine/src/audio/SoundSource.cpp
@@ -148,7 +148,7 @@ bool SoundSource::findAudioStreamSfx() {
     }
 
     audioStream = formatContext->streams[streamIndex];
-    auto codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
+    codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
 
     return true;
 }

--- a/rwengine/src/audio/SoundSource.hpp
+++ b/rwengine/src/audio/SoundSource.hpp
@@ -90,7 +90,7 @@ private:
     AVFrame* frame = nullptr;
     AVFormatContext* formatContext = nullptr;
     AVStream* audioStream = nullptr;
-    AVCodec* codec = nullptr;
+    const AVCodec* codec = nullptr;
     SwrContext* swr = nullptr;
     AVCodecContext* codecContext = nullptr;
     AVPacket readingPacket;


### PR DESCRIPTION
Fixes `Error: assigning to 'AVCodec *' from 'const AVCodec *' discards qualifiers`.

Building on macOS Sonoma 14.1 (23B74), using a M2 Max in an `arch -x86_64 zsh` environment.

Fixes the error by using the auto keyword to infer the correct type.

It should be noted that this *might* not be the best way to handle this. Indeed right after this, the compiler notes that the `codec` variable is never actually used in either location. Perhaps the author of the [original commit for this line](https://github.com/rwengine/openrw/commit/50c6eedf4f48bcbf749f7e0bc50b42be33c0e345), Filip Gawin, could explain what the intention was with this line. Removing this line completely also fixes the error, but I'm unable to tell if it has side effects.