### PR TITLE
SoundSource.cpp: return AVERROR_EOF when buffer is empty

### DIFF
--- a/rwengine/src/audio/SoundSource.cpp
+++ b/rwengine/src/audio/SoundSource.cpp
@@ -55,7 +55,7 @@ int read_packet(void* opaque, uint8_t* buf, int buf_size) {
     memcpy(buf, input->ptr, buf_size);
     input->ptr += buf_size;
     input->size -= buf_size;
-    return buf_size;
+    return buf_size <= 0 ? AVERROR_EOF : buf_size;
 }
 }  // namespace
 


### PR DESCRIPTION
On latest master (0f83c16f6518c427a4f156497c3edc843610c402) when I click "start new game", nothing happens.

Debugged this a bit it seems the `avformat_find_stream_info` hangs in [SoundSource.cpp](https://github.com/rwengine/openrw/blob/0f83c16f6518c427a4f156497c3edc843610c402/rwengine/src/audio/SoundSource.cpp#L129). Looks like the [read_packet](https://github.com/rwengine/openrw/blob/0f83c16f6518c427a4f156497c3edc843610c402/rwengine/src/audio/SoundSource.cpp#L51) function is called over and over again even the functions returns `0`.

But if `AVERROR_EOF` is returned when the buffer is empty, it fixes the hanging for me. Is this related some API change or something else? Would need to figure it out..