### PR TITLE
core: make findFilePath more robust

### DIFF
--- a/rwcore/platform/FileIndex.cpp
+++ b/rwcore/platform/FileIndex.cpp
@@ -39,12 +39,22 @@ void FileIndex::indexTree(const std::filesystem::path &path) {
 }
 
 const FileIndex::IndexedData *FileIndex::getIndexedDataAt(const std::string &filePath) const {
-    auto normPath = normalizeFilePath(filePath);
-    return &indexedData_.at(normPath);
+    std::string normPath = normalizeFilePath(filePath);
+    try {
+	return &indexedData_.at(normPath);
+    }
+    catch (...) {
+	RW_ERROR("Missing file: " << normPath);
+	return nullptr;
+    }
 }
 
 std::filesystem::path FileIndex::findFilePath(const std::string &filePath) const {
-    return getIndexedDataAt(filePath)->path;
+    auto idxData = getIndexedDataAt(filePath);
+    if (!idxData)
+	return filePath;
+
+    return idxData->path;
 }
 
 FileContentsInfo FileIndex::openFileRaw(const std::string &filePath) const {


### PR DESCRIPTION
Do not crash, when asset is missing, just warn about it. Game can work well without missing wav and mp3 files.

Also, the crash itself looks a bit mysterious, so now the game prints name of the missing asset.

// this caused pretty headache because I didn't copied the audio files from CD2... 