### PR TITLE
build: we support recent CMake too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.28)
 
 project(OpenRW)
 
@@ -27,6 +27,9 @@ if(USE_CONAN)
 
     rwdep_wrap_conan_targets()
 else()
+    if(POLICY CMP0167)
+	cmake_policy(SET CMP0167 NEW)
+    endif()
     find_package(Boost REQUIRED)
     find_package(Boost COMPONENTS program_options system REQUIRED)
     if(BUILD_TESTS)

--- a/cmake/ctest/script_ci.ctest
+++ b/cmake/ctest/script_ci.ctest
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.28)
 
 set(MODEL_NAME "continuous")
 

--- a/cmake/ctest/script_experimental.ctest
+++ b/cmake/ctest/script_experimental.ctest
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.28)
 
 set(MODEL_NAME "experimental")
 


### PR DESCRIPTION
Removes CMake warning about deprecation, as we declare we tested up to CMake 3.28.

  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.