### PR TITLE
rwcore: we don't support loading of DXT1, 3, or 5 assets

### DIFF
--- a/rwcore/loaders/LoaderTXD.cpp
+++ b/rwcore/loaders/LoaderTXD.cpp
@@ -73,6 +73,13 @@ static std::unique_ptr<TextureData> createTexture(
         !((texNative.rasterformat & RW::BSTextureNative::FORMAT_888) ==
           RW::BSTextureNative::FORMAT_888);
 
+    if (texNative.dxttype) {
+        RW_ERROR("FIXME: DXT format "
+                 << static_cast<unsigned>(texNative.dxttype)
+                 << " not yet implemented!");
+        return getErrorTexture();
+    }
+
     if (!(isPal8 || isFulc)) {
         RW_ERROR("Unsupported raster format " << std::dec
                   << texNative.rasterformat);


### PR DESCRIPTION
Shouldn't be hard to implement, thou warn, as in GTA 3 assets texNative.rasterformat may be 0x0300, which imply RGBA4444, but also DXT3 with dxttype flag set.