### PR TITLE
Initial dynamic weather support

### DIFF
--- a/rwengine/src/data/Weather.hpp
+++ b/rwengine/src/data/Weather.hpp
@@ -40,6 +40,14 @@ public:
                       float a, float tod);
 
     std::vector<Entry> entries;
+
+    // Taken from: https://www.gtamodding.com/wiki/Time_cycle#Weather_lists
+    // TODO: This weather list applies only for GTA III
+    const uint16_t WeatherList[64] = {
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 2, 1, 0,
+            0, 0, 1, 3, 3, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2,
+            2, 1, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 0, 0, 0, 2, 1
+    };
 };
 
 #endif

--- a/rwengine/src/engine/GameState.hpp
+++ b/rwengine/src/engine/GameState.hpp
@@ -64,7 +64,7 @@ struct BasicState {
     uint8_t _align3[2]{0};
     uint16_t nextWeather{0};
     uint8_t _align4[2]{0};
-    uint16_t forcedWeather{0};
+    uint16_t forcedWeather{0xFFFF};
     uint8_t _align5[2]{0};
     float weatherInterpolation{1.f};
     uint8_t dateTime[24]{0};  // Unused

--- a/rwengine/src/script/modules/GTA3ModuleImpl.inl
+++ b/rwengine/src/script/modules/GTA3ModuleImpl.inl
@@ -4870,8 +4870,7 @@ void opcode_01b6(const ScriptArguments& args, const ScriptWeather weatherID) {
     opcode 01b7
 */
 void opcode_01b7(const ScriptArguments& args) {
-    RW_UNUSED(args);
-    args.getState()->basic.forcedWeather = -1;
+    args.getState()->basic.forcedWeather = UINT16_MAX;
 }
 
 /**

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -533,6 +533,7 @@ void RWGame::tick(float dt) {
     static float clockAccumulator = 0.f;
     static float scriptTimerAccumulator = 0.f;
     static ScriptInt beepTime = std::numeric_limits<ScriptInt>::max();
+    static uint8_t prevGameHour = state.basic.gameHour;
     if (currState->shouldWorldUpdate()) {
         world->chase.update(dt);
 
@@ -553,6 +554,22 @@ void RWGame::tick(float dt) {
             }
             clockAccumulator -= 1.f;
         }
+
+        if (prevGameHour != state.basic.gameHour) {
+            prevGameHour = state.basic.gameHour;
+            state.basic.lastWeather = state.basic.nextWeather;
+
+            // TODO: VC and SA has more than 4 weather conditions
+            if (state.basic.forcedWeather > 3) {
+                if (state.basic.weatherType < 63) {
+                    ++state.basic.weatherType;
+                } else {
+                    state.basic.weatherType = 0;
+                }
+                state.basic.nextWeather = data.weather.WeatherList[state.basic.weatherType];
+            }
+        }
+        state.basic.weatherInterpolation = state.basic.gameMinute / 60.f;
 
         constexpr float timerClockRate = 1.f / 30.f;
 


### PR DESCRIPTION
This has been work-in-progress (see Lihis/openrw#2) for a while and I will not have time to finish any time soon so I think it might be better to get this merged in its current state so someone can improve it at some point.

I have not tested this against latest `main` but I'll try to do it within few weeks or so.

Copy-paste from PR in my fork of the repo:

------

Tasklist and some details:

- [x] Weather cycles according the [weather list](https://gtamods.com/wiki/Time_cycle#Weather_lists) for GTA III.
- [ ] Verify is the above weather list same for:
  - [ ] v1.1
  - [ ] Steam version
- [ ] Rain droplets in rainy weather
- [ ] Weather can be controlled by opcodes and it behaves according them:
  - [ ] [01B5](https://gtamods.com/wiki/01B5): Force next weather (see https://github.com/rwengine/openrw/issues/379#issuecomment-386902620). Weather does not cycle until released (via 01B7).
  - [x] [01B6](https://gtamods.com/wiki/01B6): Force weather now; weather is immediately set to requested weather. Weather does not cycle until released (via 01B7).
  - [x] [01B7](https://gtamods.com/wiki/01B7): Release weather; continue weather cycle from where it was.
  - [0251](https://gtamods.com/wiki/0251): Store weather; unused.
  - [0251](https://gtamods.com/wiki/0252): Restore weather; unused.
- [ ] New game:
  - [ ] Weather cycle starts from array index 0?
- [ ] Load game:
  - [ ] Clean save without weather cheats; weather cycle continues from the saved state.
  - [ ] "Dirty" save where a weather cheat used; weather does not cycle, weather is kept in the forced state.
- [ ] Write simple SCM for testing opcode 01B5.
- [ ] Did miss something? Yes/No: TBD